### PR TITLE
Remove non-functional uniqueItems constraint. MODINVSTOR-86.

### DIFF
--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -115,8 +115,7 @@
           "dateOfPublication": {
             "type": "string"
           }
-        },
-        "uniqueItems": true
+        }
       }
     },
     "urls": {


### PR DESCRIPTION
It's was in the wrong place, and the unique constraint does not seem to be enforced for arrays of objects anyway. 

This clean-up of obsolete code does not change the API in any way. 