### PR TITLE
MODINVSTOR-71: Added metadata to holdings, items, loan types and material types

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 8.2.3 Unreleased
 * Removing SQ warnings and improving test coverage in the new locations and location-units (MODINVSTOR-89)
+* Adds metadata generation (dates and update user) to item, holding, material type and loan type records (MODINVSTOR-71)
 
 ## 8.2.2 Unreleased
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,11 +1,12 @@
-## 8.2.3 Unreleased
-* Removing SQ warnings and improving test coverage in the new locations and location-units (MODINVSTOR-89)
+## 8.3.0 Unreleased
 * Adds metadata generation (dates and update user) to item, holding, material type and loan type records (MODINVSTOR-71)
-
-## 8.2.2 Unreleased
-
+* Removing SQ warnings and improving test coverage in the new locations and location-units (MODINVSTOR-89)
 * Stops hiding database related errors when creating instances or holdings (MODINVSTOR-72)
 * Introduces multi-level (institution, campus, library and location) location model (MODINVSTOR-70, MODINVSTOR-91)
+* Provides `item-storage` 5.1 interface (MODINVSTOR-71)
+* Provides `holdings-storage` 1.1 interface (MODINVSTOR-71)
+* Provides `loan-types` 2.1 interface (MODINVSTOR-71)
+* Provides `material-types` 2.1 interface (MODINVSTOR-71)
 * Provides `locations` 1.0 interface (MODINVSTOR-70)
 * Provides `location-units` 1.0 interface (MODINVSTOR-70)
 * Provides `contributor-name-types` 1.1 interface (MODINVSTOR-66)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "item-storage",
-      "version": "5.0",
+      "version": "5.1",
       "handlers": [
         {
           "methods": ["GET"],
@@ -35,7 +35,7 @@
     },
     {
       "id": "holdings-storage",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": ["GET"],
@@ -97,7 +97,7 @@
     },
     {
       "id": "loan-types",
-      "version": "2.0",
+      "version": "2.1",
       "handlers": [
         {
           "methods": ["GET"],
@@ -124,7 +124,7 @@
     },
     {
       "id": "material-types",
-      "version": "2.0",
+      "version": "2.1",
       "handlers": [
         {
           "methods": ["GET"],

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>8.2.3-SNAPSHOT</version>
+  <version>8.3.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/ramls/holdings-storage.raml
+++ b/ramls/holdings-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 0.8
 title: Holdings Storage
-version: v1.0
+version: v1.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 
@@ -11,6 +11,7 @@ documentation:
 schemas:
   - holdingsrecord.json: !include holdingsrecord.json
   - holdingsRecords: !include holdingsrecords.json
+  - raml-util/schemas/metadata.schema: !include raml-util/schemas/metadata.schema
 
 traits:
   - secured: !include raml-util/traits/auth.raml

--- a/ramls/holdingsrecord.json
+++ b/ramls/holdingsrecord.json
@@ -32,6 +32,11 @@
         "type": "string"
       },
       "uniqueItems": true
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema",
+      "readonly": true
     }
   },
   "required": [

--- a/ramls/item-storage.raml
+++ b/ramls/item-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 0.8
 title: Item Storage
-version: v5.0
+version: v5.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 
@@ -14,6 +14,7 @@ schemas:
   - errors: !include raml-util/schemas/errors.schema
   - error.schema: !include raml-util/schemas/error.schema
   - parameters.schema: !include raml-util/schemas/parameters.schema
+  - raml-util/schemas/metadata.schema: !include raml-util/schemas/metadata.schema
 
 traits:
   - secured: !include raml-util/traits/auth.raml

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -54,6 +54,11 @@
     },
     "temporaryLocationId": {
       "type": "string"
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema",
+      "readonly": true
     }
   },
   "additionalProperties": false,

--- a/ramls/loan-type.raml
+++ b/ramls/loan-type.raml
@@ -16,6 +16,7 @@ schemas:
   - errors: !include raml-util/schemas/errors.schema
   - error.schema: !include raml-util/schemas/error.schema
   - parameters.schema: !include raml-util/schemas/parameters.schema
+  - raml-util/schemas/metadata.schema: !include raml-util/schemas/metadata.schema
 
 traits:
   - secured: !include raml-util/traits/auth.raml

--- a/ramls/loan-type.raml
+++ b/ramls/loan-type.raml
@@ -1,6 +1,6 @@
 #%RAML 0.8
 title: Loan Types API
-version: v2.0
+version: v2.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/loantype.json
+++ b/ramls/loantype.json
@@ -7,6 +7,11 @@
     },
     "name": {
       "type": "string"
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema",
+      "readonly": true
     }
   },
   "additionalProperties": false,

--- a/ramls/material-type.raml
+++ b/ramls/material-type.raml
@@ -1,6 +1,6 @@
 #%RAML 0.8
 title: Material Types API
-version: v2.0
+version: v2.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/material-type.raml
+++ b/ramls/material-type.raml
@@ -16,6 +16,7 @@ schemas:
   - errors: !include raml-util/schemas/errors.schema
   - error.schema: !include raml-util/schemas/error.schema
   - parameters.schema: !include raml-util/schemas/parameters.schema
+  - raml-util/schemas/metadata.schema: !include raml-util/schemas/metadata.schema
 
 traits:
   - secured: !include raml-util/traits/auth.raml

--- a/ramls/materialtype.json
+++ b/ramls/materialtype.json
@@ -7,6 +7,11 @@
     },
     "name": {
       "type": "string"
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema",
+      "readonly": true
     }
   },
   "additionalProperties": false,

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -2,7 +2,7 @@
   "tables": [
     {
       "tableName": "loan_type",
-      "withMetadata": false,
+      "withMetadata": true,
       "pkColumnName": "_id",
       "generateId": false,
       "withAuditing": false,
@@ -15,7 +15,7 @@
     },
     {
       "tableName": "material_type",
-      "withMetadata": false,
+      "withMetadata": true,
       "pkColumnName": "_id",
       "generateId": false,
       "withAuditing": false,
@@ -28,7 +28,7 @@
     },
     {
       "tableName": "shelflocation",
-      "withMetadata": false,
+      "withMetadata": true,
       "pkColumnName": "_id",
       "generateId": false,
       "withAuditing": false,
@@ -247,6 +247,7 @@
     },
     {
       "tableName": "item",
+      "withMetadata": true,
       "generateId": false,
       "pkColumnName": "_id",
       "foreignKeys": [
@@ -403,6 +404,7 @@
     },
     {
       "tableName": "holdings_record",
+      "withMetadata": true,
       "generateId": false,
       "pkColumnName": "_id",
       "foreignKeys": [


### PR DESCRIPTION
[STCOM-228](https://issues.folio.org/browse/STCOM-228), [UIIN-98](https://issues.folio.org/browse/UIIN-98) and [UIIN-99](https://issues.folio.org/browse/UIIN-98) need update `metadata` added to the payloads they fetch. There will need to be one more PR against `mod-inventory` to add metadata to the `/inventory/items` endpoint.

I'm using PR #53 as my guide with this implementation but let me know if there's anything I could be doing better here, please. 

I also bumped minor version numbers on the APIs since we're adding functionality (but mostly bc @marc-johnson did it in that PR 😝).