### PR TITLE
MODINVSTOR-120: Drop src/main/**/client/ from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 *.class
 *.log
 metrics/
-src/main/**/client/
 #mvn build
 target/
 #vert.x


### PR DESCRIPTION
We changed the directory where we write generated sources. Now there are below target/generated_sources/ .
Therefore we no longer need src/main/**/client/ in .gitignore