### PR TITLE
MODINVSTOR-140: Remove InstanceStorage.blankTenantId(String)

### DIFF
--- a/src/main/java/org/folio/rest/impl/InstanceStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceStorageAPI.java
@@ -494,10 +494,6 @@ public class InstanceStorageAPI implements InstanceStorageResource {
         .withPlainBadRequest(message)));
   }
 
-  private boolean blankTenantId(String tenantId) {
-    return tenantId == null || tenantId == "" || tenantId == "folio_shared";
-  }
-
   private boolean isUUID(String id) {
     try {
       UUID.fromString(id);


### PR DESCRIPTION
private boolean blankTenantId(String tenantId) is not used and has a wrong String comparator.