### PR TITLE
Move shared raml back to previous version MODINVSTOR-164

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## 12.7.0 Unreleased
+
+* Uses full text indexing for instance `title` searching (MODINVSTOR-159)
+* Upgrades to RAML Module Builder 19.4.2 (MODINVSTOR-159)
+* Fixes inability to specify page `limit` higher than 100 (MODINVSTOR-164)
+
 ## 12.6.0 2018-09-10
 
 * Adds instance relationship storage (MODINVSTOR-147)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>12.6.1-SNAPSHOT</version>
+  <version>12.7.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/src/test/java/org/folio/rest/api/ContributorTypesTest.java
+++ b/src/test/java/org/folio/rest/api/ContributorTypesTest.java
@@ -1,0 +1,42 @@
+package org.folio.rest.api;
+
+import static org.folio.rest.support.http.InterfaceUrls.contributorTypesUrl;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.rest.support.Response;
+import org.folio.rest.support.ResponseHandler;
+import org.junit.Test;
+
+public class ContributorTypesTest extends TestBase {
+  //See https://issues.folio.org/browse/MODINVSTOR-164 for context
+  @Test
+  public void canSearchForMoreThanOneContributorTypes()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException,
+    UnsupportedEncodingException {
+
+    CompletableFuture<Response> searchCompleted = new CompletableFuture<Response>();
+
+    String url = contributorTypesUrl("").toString() + "?limit=400&query="
+      + URLEncoder.encode("cql.allRecords=1", StandardCharsets.UTF_8.name());
+
+    client.get(url, StorageTestSuite.TENANT_ID, ResponseHandler.json(searchCompleted));
+    Response searchResponse = searchCompleted.get(5, TimeUnit.SECONDS);
+
+    assertThat(
+      String.format("Failed to search for instances: '%s'", searchResponse.getBody()),
+      searchResponse.getStatusCode(), is(200));
+  }
+}

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -1,15 +1,22 @@
 package org.folio.rest.api;
 
-import io.vertx.core.json.Json;
 import static org.folio.rest.support.JsonObjectMatchers.hasSoleMessgeContaining;
 import static org.folio.rest.support.JsonObjectMatchers.identifierMatches;
-import static org.folio.rest.support.http.InterfaceUrls.*;
-import static org.hamcrest.CoreMatchers.*;
+import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.loanTypesStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.locCampusStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.locInstitutionStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.locLibraryStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.locationsStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.materialTypesStorageUrl;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.junit.Assert.assertThat;
-
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
@@ -30,7 +37,11 @@ import java.util.concurrent.TimeoutException;
 import org.apache.commons.io.IOUtils;
 import org.folio.HttpStatus;
 import org.folio.rest.jaxrs.model.MarcJson;
-import org.folio.rest.support.*;
+import org.folio.rest.support.AdditionalHttpStatusCodes;
+import org.folio.rest.support.JsonArrayHelper;
+import org.folio.rest.support.JsonErrorResponse;
+import org.folio.rest.support.Response;
+import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.builders.ItemRequestBuilder;
 import org.folio.rest.support.client.LoanTypesClient;
@@ -38,8 +49,10 @@ import org.folio.rest.support.client.MaterialTypesClient;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 public class InstanceStorageTest extends TestBase {
   private static UUID mainLibraryLocationId;

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -1,9 +1,16 @@
 package org.folio.rest.api;
 
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.sql.ResultSet;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
 import org.folio.rest.RestVerticle;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.HttpClient;
@@ -16,16 +23,10 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Locale;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.ResultSet;
 
 @RunWith(Suite.class)
 
@@ -35,6 +36,7 @@ import static org.junit.Assert.assertThat;
   ItemStorageTest.class,
   LoanTypeTest.class,
   MaterialTypeTest.class,
+  ContributorTypesTest.class,
   ShelfLocationsTest.class,
   LocationUnitTest.class,
   LocationsTest.class,

--- a/src/test/java/org/folio/rest/support/http/InterfaceUrls.java
+++ b/src/test/java/org/folio/rest/support/http/InterfaceUrls.java
@@ -1,9 +1,9 @@
 package org.folio.rest.support.http;
 
-import org.folio.rest.api.StorageTestSuite;
-
 import java.net.MalformedURLException;
 import java.net.URL;
+
+import org.folio.rest.api.StorageTestSuite;
 
 public class InterfaceUrls {
   public static URL materialTypesStorageUrl(String subPath)
@@ -46,6 +46,12 @@ public class InterfaceUrls {
     throws MalformedURLException {
 
     return StorageTestSuite.storageUrl("/instance-storage/instances" + subPath);
+  }
+
+  public static URL contributorTypesUrl(String subPath)
+    throws MalformedURLException {
+
+    return StorageTestSuite.storageUrl("/contributor-types" + subPath);
   }
 
   public static URL locationsStorageUrl(String subPath)


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-164

The shared RAML had been incorrectly moved back to an older version which disallowed page limit parameters higher than 100.

This change reverts to the same shared RAML as version 12.6.0