### PR TITLE
Modinvstor 168 simple

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 * Provides `cataloging-levels` interface 1.0 (MODINVSTOR-152)
 * Provides `instance-statuses` interface 1.0 (MODINVSTOR-152)
 * Provides `modes-of-issuance` interface 1.0 (MODINVSTOR-152)
+* Uses RMB 19.4.3, which uses the 'simple' dictionary for fulltext,
+  getting around the stopword problem. (MODINVSTOR-168)
 
 ## 12.7.0 2018-09-12
 

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>19.4.3-SNAPSHOT</version>
+      <version>19.4.3</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>domain-models-runtime</artifactId>
-      <version>19.4.2</version>
+      <version>19.4.3-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>


### PR DESCRIPTION
Use the just released RMB 19.4.3, and indirectly cql2pgjson 2.2.2, which use the 'simple' directory for fulltext searches.