### PR TITLE
Add links that can be traversed by mod-graphql

### DIFF
--- a/ramls/holdingsrecord.json
+++ b/ramls/holdingsrecord.json
@@ -51,7 +51,7 @@
     },
     "holdingsInstance": {
       "type": "object",
-      "$ref": "instance.json",
+      "folio:$ref": "instance.json",
       "readonly": true,
       "folio:isVirtual": true,
       "folio:linkBase": "inventory/instances",

--- a/ramls/holdingsrecord.json
+++ b/ramls/holdingsrecord.json
@@ -36,6 +36,29 @@
       },
       "uniqueItems": true
     },
+    "holdingsItems": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "item.json"
+      },
+      "readonly": true,
+      "folio:isVirtual": true,
+      "folio:linkBase": "inventory/items",
+      "folio:linkFromField": "id",
+      "folio:linkToField": "holdingsRecordId",
+      "folio:includedElement": "items"
+    },
+    "holdingsInstance": {
+      "type": "object",
+      "$ref": "instance.json",
+      "readonly": true,
+      "folio:isVirtual": true,
+      "folio:linkBase": "inventory/instances",
+      "folio:linkFromField": "instanceId",
+      "folio:linkToField": "id",
+      "folio:includedElement": "instances.0"
+    },
     "metadata": {
       "type": "object",
       "$ref": "raml-util/schemas/metadata.schema",

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -291,8 +291,7 @@
       "$ref": "raml-util/schemas/metadata.schema",
       "readonly": true
     },
-    "holdingsRecords": {
-      "id": "holdingsRecords2",
+    "holdingsRecords2": {
       "type": "array",
       "items": {
         "type": "object",

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -291,7 +291,8 @@
       "$ref": "raml-util/schemas/metadata.schema",
       "readonly": true
     },
-    "holdingsRecords2": {
+    "holdingsRecords": {
+      "id": "holdingsRecords2",
       "type": "array",
       "items": {
         "type": "object",

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -290,6 +290,19 @@
       "type": "object",
       "$ref": "raml-util/schemas/metadata.schema",
       "readonly": true
+    },
+    "holdingsRecords2": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "holdingsrecord.json"
+      },
+      "readonly": true,
+      "folio:isVirtual": true,
+      "folio:linkBase": "holdings-storage/holdings",
+      "folio:linkFromField": "id",
+      "folio:linkToField": "instanceId",
+      "folio:includedElement": "holdingsRecords"
     }
   },
   "additionalProperties": false,

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -62,6 +62,16 @@
       "type": "object",
       "$ref": "raml-util/schemas/metadata.schema",
       "readonly": true
+    },
+    "holdingsRecord": {
+      "type": "object",
+      "$ref": "holdingsrecord.json",
+      "readonly": true,
+      "folio:isVirtual": true,
+      "folio:linkBase": "holdings-storage/holdings",
+      "folio:linkFromField": "holdingsRecordId",
+      "folio:linkToField": "id",
+      "folio:includedElement": "holdingsRecords.0"
     }
   },
   "additionalProperties": false,

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -63,7 +63,7 @@
       "$ref": "raml-util/schemas/metadata.schema",
       "readonly": true
     },
-    "holdingsRecord": {
+    "holdingsRecord2": {
       "type": "object",
       "folio:$ref": "holdingsrecord.json",
       "readonly": true,

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -64,6 +64,7 @@
       "readonly": true
     },
     "holdingsRecord": {
+      "id": "holdingsRecordForItem",
       "type": "object",
       "folio:$ref": "holdingsrecord.json",
       "readonly": true,

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -65,7 +65,7 @@
     },
     "holdingsRecord": {
       "type": "object",
-      "$ref": "holdingsrecord.json",
+      "folio:$ref": "holdingsrecord.json",
       "readonly": true,
       "folio:isVirtual": true,
       "folio:linkBase": "holdings-storage/holdings",

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -64,7 +64,6 @@
       "readonly": true
     },
     "holdingsRecord": {
-      "id": "holdingsRecordForItem",
       "type": "object",
       "folio:$ref": "holdingsrecord.json",
       "readonly": true,


### PR DESCRIPTION
We are using FOLIO extensions to JSON Schema, as described at https://github.com/folio-org/mod-graphql/blob/master/src/autogen/README.md#option-1-json-schema-extensions, to indiciate when one record can link to another -- e.g. an instance record can link to its holdings. These fields are safely ignored by RMB, but interpreted by mod-graphql.

Similarly, we use "weak" references when creating cycles: `folio:$ref` rather than the standard `$ref`. Again, mod-graphql knows to follow these; but RMB does not, which is good, because it can't handle the cycles that they create (e.g. instance -> holdings -> items -> holding -> instance).