### PR TITLE
MODINVSTOR-153 Fix broken JSON schema

### DIFF
--- a/ramls/holdingsrecord.json
+++ b/ramls/holdingsrecord.json
@@ -95,7 +95,7 @@
     "notes": {
       "type": "array",
       "items": {
-        "type": "objects",
+        "type": "object",
         "properties": {
           "type": {
             "type": "string",


### PR DESCRIPTION
In pull/#185 the lint-raml CI job said the following in response to a typo (objects should be object) in a JSON schema:

```
INFO: lint-raml-cop: Processing RAML v1.0 file: holdings-storage.raml
ERROR: lint-raml-cop:   raml-cop detected errors with holdings-storage.raml:
[ramls/holdingsrecord.json:96:6] WARNING Invalid JSON schema: Keyword 'type' is expected to be of type 'array,boolean,integer,number,null,object,string'
[ramls/holdingsrecords.json:0:0] WARNING Invalid JSON schema: Remote reference didn't compile successfully: https://__/APPENDED_PROTOCOL/__/home/jenkins/workspace/folio-org/mod-inventory-storage/PR-185/ramls/holdingsrecord.json#
...
```