### PR TITLE
Refactor holdingsRecord note type and add two new reference tables MODINVSTOR-220

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 ## 13.1.0 Unreleased
 
+* Provides `holdings-note-types` interface 1.0 (MODINVSTOR-220)
+* Provides `item-note-types` interface 1.0 (MODINVSTOR-220)
 * Provides `alternative-title-types` interface 1.0 (MODINVSTOR-200)
 * Provides `call-number-types` interface 1.0 (MODINVSTOR-210)
 * Provides `holdings-types` interface 1.0 (MODINVSTOR-210)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -715,6 +715,60 @@
         }
       ]
     },
+    {
+      "id": "holdings-note-types",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": ["GET"],
+          "pathPattern": "/holdings-note-types",
+          "permissionsRequired": ["inventory-storage.holdings-note-types.collection.get"]
+        }, {
+          "methods": ["GET"],
+          "pathPattern": "/holdings-note-types/{id}",
+          "permissionsRequired": ["inventory-storage.holdings-note-types.item.get"]
+        }, {
+          "methods": ["POST"],
+          "pathPattern": "/holdings-note-types",
+          "permissionsRequired": ["inventory-storage.holdings-note-types.item.post"]
+        }, {
+          "methods": ["PUT"],
+          "pathPattern": "/holdings-note-types/{id}",
+          "permissionsRequired": ["inventory-storage.holdings-note-types.item.put"]
+        }, {
+          "methods": ["DELETE"],
+          "pathPattern": "/holdings-note-types/{id}",
+          "permissionsRequired": ["inventory-storage.holdings-note-types.item.delete"]
+        }
+      ]
+    },
+    {
+      "id": "item-note-types",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": ["GET"],
+          "pathPattern": "/item-note-types",
+          "permissionsRequired": ["inventory-storage.item-note-types.collection.get"]
+        }, {
+          "methods": ["GET"],
+          "pathPattern": "/item-note-types/{id}",
+          "permissionsRequired": ["inventory-storage.item-note-types.item.get"]
+        }, {
+          "methods": ["POST"],
+          "pathPattern": "/item-note-types",
+          "permissionsRequired": ["inventory-storage.item-note-types.item.post"]
+        }, {
+          "methods": ["PUT"],
+          "pathPattern": "/item-note-types/{id}",
+          "permissionsRequired": ["inventory-storage.item-note-types.item.put"]
+        }, {
+          "methods": ["DELETE"],
+          "pathPattern": "/item-note-types/{id}",
+          "permissionsRequired": ["inventory-storage.item-note-types.item.delete"]
+        }
+      ]
+    },
 
     {
       "id": "service-points",
@@ -1501,6 +1555,59 @@
       "displayName": "inventory storage - delete individual holdings-type",
       "description": "delete individual holdings-type from storage"
     },
+
+    {
+      "permissionName": "inventory-storage.holdings-note-types.collection.get",
+      "displayName": "inventory storage - get holdings-note-type collection",
+      "description": "get holdings-note-type collection from storage"
+    },
+    {
+      "permissionName": "inventory-storage.holdings-note-types.item.get",
+      "displayName": "inventory storage - get individual holdings-note-type",
+      "description": "get individual holdings-note-type from storage"
+    },
+    {
+      "permissionName": "inventory-storage.holdings-note-types.item.post",
+      "displayName": "inventory storage - create individual holdings-note-type",
+      "description": "create individual holdings-note-type in storage"
+    },
+    {
+      "permissionName": "inventory-storage.holdings-note-types.item.put",
+      "displayName": "inventory storage - modify holdings-note-type",
+      "description": "modify holdings-note-type in storage"
+    },
+    {
+      "permissionName": "inventory-storage.holdings-note-types.item.delete",
+      "displayName": "inventory storage - delete individual holdings-note-type",
+      "description": "delete individual holdings-note-type from storage"
+    },
+
+    {
+      "permissionName": "inventory-storage.item-note-types.collection.get",
+      "displayName": "inventory storage - get item-note-type collection",
+      "description": "get item-note-type collection from storage"
+    },
+    {
+      "permissionName": "inventory-storage.item-note-types.item.get",
+      "displayName": "inventory storage - get individual item-note-type",
+      "description": "get individual item-note-type from storage"
+    },
+    {
+      "permissionName": "inventory-storage.item-note-types.item.post",
+      "displayName": "inventory storage - create individual item-note-type",
+      "description": "create individual item-note-type in storage"
+    },
+    {
+      "permissionName": "inventory-storage.item-note-types.item.put",
+      "displayName": "inventory storage - modify item-note-type",
+      "description": "modify item-note-type in storage"
+    },
+    {
+      "permissionName": "inventory-storage.item-note-types.item.delete",
+      "displayName": "inventory storage - delete individual item-note-type",
+      "description": "delete individual item-note-type from storage"
+    },
+
     {
       "permissionName": "inventory-storage.call-number-types.collection.get",
       "displayName": "inventory storage - get call-number-type collection",
@@ -1688,6 +1795,16 @@
         "inventory-storage.call-number-types.item.post",
         "inventory-storage.call-number-types.item.put",
         "inventory-storage.call-number-types.item.delete",
+        "inventory-storage.holdings-note-types.collection.get",
+        "inventory-storage.holdings-note-types.item.get",
+        "inventory-storage.holdings-note-types.item.post",
+        "inventory-storage.holdings-note-types.item.put",
+        "inventory-storage.holdings-note-types.item.delete",
+        "inventory-storage.item-note-types.collection.get",
+        "inventory-storage.item-note-types.item.get",
+        "inventory-storage.item-note-types.item.post",
+        "inventory-storage.item-note-types.item.put",
+        "inventory-storage.item-note-types.item.delete",
         "inventory-storage.service-points.collection.get",
         "inventory-storage.service-points.item.get",
         "inventory-storage.service-points.item.post",

--- a/ramls/examples/holdingsnotetype.json
+++ b/ramls/examples/holdingsnotetype.json
@@ -1,0 +1,6 @@
+{
+  "id": "de14ac4e-f705-404a-8027-4a69d9dc8075",
+  "name": "Note",
+  "source": "folio"
+}
+

--- a/ramls/examples/holdingsnotetypes.json
+++ b/ramls/examples/holdingsnotetypes.json
@@ -1,0 +1,10 @@
+{
+  "id": "de14ac4e-f705-404a-8027-4a69d9dc8075",
+  "name": "Note",
+  "source": "folio"
+},
+{
+  "id": "cb595931-68a6-4179-9422-eaab77c25908",
+  "name": "Action note",
+  "source": "folio"
+}

--- a/ramls/examples/itemnotetype.json
+++ b/ramls/examples/itemnotetype.json
@@ -1,0 +1,5 @@
+{
+  "id": "b989fb41-cf5b-4ae0-8373-297beffa3d77",
+  "name": "Note",
+  "source": "folio"
+}

--- a/ramls/examples/itemnotetypes.json
+++ b/ramls/examples/itemnotetypes.json
@@ -1,0 +1,11 @@
+{
+  "id": "b989fb41-cf5b-4ae0-8373-297beffa3d77",
+  "name": "Note",
+  "source": "folio"
+},
+{
+  "id": "ae67d1e3-0eb1-495b-b461-c2b77b46c650",
+  "name": "Action note",
+  "source": "folio"
+}
+

--- a/ramls/holdings-note-type.raml
+++ b/ramls/holdings-note-type.raml
@@ -1,0 +1,48 @@
+#%RAML 1.0
+title: Holdings note types API
+version: v1.0
+protocols: [ HTTP, HTTPS ]
+baseUri: http://github.com/org/folio/mod-inventory-storage
+
+documentation:
+  - title: Holdings note types API
+    content: This documents the API calls that can be made to query and manage holdings note types of the system
+
+types:
+  holdingsNoteType: !include holdingsnotetype.json
+  holdingsNoteTypes: !include holdingsnotetypes.json
+  errors: !include raml-util/schemas/errors.schema
+
+traits:
+  pageable: !include raml-util/traits/pageable.raml
+  searchable: !include raml-util/traits/searchable.raml
+  language: !include raml-util/traits/language.raml
+  validate: !include raml-util/traits/validation.raml
+
+resourceTypes:
+  collection: !include raml-util/rtypes/collection.raml
+  collection-item: !include raml-util/rtypes/item-collection.raml
+
+/holdings-note-types:
+  type:
+    collection:
+      exampleCollection: !include examples/holdingsnotetypes.json
+      exampleItem: !include examples/holdingsnotetype.json
+      schemaCollection: holdingsNoteTypes
+      schemaItem: holdingsNoteType
+  get:
+    is: [
+      searchable: {description: "with valid searchable fields", example: "name=aaa"},
+      pageable
+    ]
+    description: Return a list of holdings note types
+  post:
+    description: Create a new holdings note type
+    is: [validate]
+  /{id}:
+    description: "Pass in the holdings note type id"
+    type:
+      collection-item:
+        exampleItem: !include examples/holdingsnotetype.json
+        schema: holdingsNoteType
+

--- a/ramls/holdingsnotetype.json
+++ b/ramls/holdingsnotetype.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A holdings note type",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "unique ID of the holdings note type; a UUID"
+    },
+    "name": {
+      "type": "string",
+      "description": "name of the holdings note type"
+    },
+    "source": {
+      "type": "string",
+      "description": "label indicating where the holdings note type entry originates from, i.e. 'folio' or 'local'"
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema",
+      "readonly": true
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "name",
+    "source"
+  ]
+}
+

--- a/ramls/holdingsnotetypes.json
+++ b/ramls/holdingsnotetypes.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A collection of holdings note types",
+  "type": "object",
+  "properties": {
+    "holdingsNoteTypes": {
+      "description": "List of holdings note types",
+      "id": "holdingsNoteType",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "holdingsnotetype.json"
+      }
+    },
+    "totalRecords": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "holdingsNoteTypes",
+    "totalRecords"
+  ]
+}

--- a/ramls/holdingsrecord.json
+++ b/ramls/holdingsrecord.json
@@ -106,17 +106,8 @@
       "items": {
         "type": "object",
         "properties": {
-          "type": {
-            "type": "string",
-            "enum": [
-                      "action note",
-                      "binding",
-                      "copy note",
-                      "electronic bookplate",
-                      "note",
-                      "provenance",
-                      "reproduction"
-                    ]
+          "holdingsNoteTypeId": {
+            "type": "string"
           },
           "note": {
             "type": "string"

--- a/ramls/item-note-type.raml
+++ b/ramls/item-note-type.raml
@@ -1,0 +1,49 @@
+#%RAML 1.0
+title: Item note types API
+version: v1.0
+protocols: [ HTTP, HTTPS ]
+baseUri: http://github.com/org/folio/mod-inventory-storage
+
+documentation:
+  - title: Item note types API
+    content: This documents the API calls that can be made to query and manage item note types of the system
+
+types:
+  itemNoteType: !include itemnotetype.json
+  itemNoteTypes: !include itemnotetypes.json
+  errors: !include raml-util/schemas/errors.schema
+
+traits:
+  pageable: !include raml-util/traits/pageable.raml
+  searchable: !include raml-util/traits/searchable.raml
+  language: !include raml-util/traits/language.raml
+  validate: !include raml-util/traits/validation.raml
+
+resourceTypes:
+  collection: !include raml-util/rtypes/collection.raml
+  collection-item: !include raml-util/rtypes/item-collection.raml
+
+/item-note-types:
+  type:
+    collection:
+      exampleCollection: !include examples/itemnotetypes.json
+      exampleItem: !include examples/itemnotetype.json
+      schemaCollection: itemNoteTypes
+      schemaItem: itemNoteType
+  get:
+    is: [
+      searchable: {description: "with valid searchable fields", example: "name=aaa"},
+      pageable
+    ]
+    description: Return a list of item note types
+  post:
+    description: Create a new item note type
+    is: [validate]
+  /{id}:
+    description: "Pass in the item note type id"
+    type:
+      collection-item:
+        exampleItem: !include examples/itemnotetype.json
+        schema: itemNoteType
+
+

--- a/ramls/itemnotetype.json
+++ b/ramls/itemnotetype.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "An item note type",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "unique ID of the item note type; a UUID"
+    },
+    "name": {
+      "type": "string",
+      "description": "name of the item note type"
+    },
+    "source": {
+      "type": "string",
+      "description": "label indicating where the item note type entry originates from, i.e. 'folio' or 'local'"
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "raml-util/schemas/metadata.schema",
+      "readonly": true
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "name",
+    "source"
+  ]
+}
+

--- a/ramls/itemnotetypes.json
+++ b/ramls/itemnotetypes.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A collection of item note types",
+  "type": "object",
+  "properties": {
+    "itemNoteTypes": {
+      "description": "List of item note types",
+      "id": "itemNoteType",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "itemnotetype.json"
+      }
+    },
+    "totalRecords": {
+      "type": "integer"
+    }
+  },
+  "required": [
+    "itemNoteTypes",
+    "totalRecords"
+  ]
+}
+

--- a/reference-data/holdings-note-types/ActionNote.json
+++ b/reference-data/holdings-note-types/ActionNote.json
@@ -1,0 +1,6 @@
+{
+  "id": "d6510242-5ec3-42ed-b593-3585d2e48fd6",
+  "name": "Action note",
+  "source": "folio"
+}
+

--- a/reference-data/holdings-note-types/Binding.json
+++ b/reference-data/holdings-note-types/Binding.json
@@ -1,0 +1,6 @@
+{
+  "id": "e19eabab-a85c-4aef-a7b2-33bd9acef24e",
+  "name": "Binding",
+  "source": "folio"
+}
+

--- a/reference-data/holdings-note-types/CopyNote.json
+++ b/reference-data/holdings-note-types/CopyNote.json
@@ -1,0 +1,6 @@
+{
+  "id": "c4407cc7-d79f-4609-95bd-1cefb2e2b5c5",
+  "name": "Copy note",
+  "source": "folio"
+}
+

--- a/reference-data/holdings-note-types/ElectronicBookplate.json
+++ b/reference-data/holdings-note-types/ElectronicBookplate.json
@@ -1,0 +1,6 @@
+{
+  "id": "88914775-f677-4759-b57b-1a33b90b24e0",
+  "name": "Electronic bookplate",
+  "source": "folio"
+}
+

--- a/reference-data/holdings-note-types/Note.json
+++ b/reference-data/holdings-note-types/Note.json
@@ -1,0 +1,6 @@
+{
+  "id": "b160f13a-ddba-4053-b9c4-60ec5ea45d56",
+  "name": "Note",
+  "source": "folio"
+}
+

--- a/reference-data/holdings-note-types/Provenance.json
+++ b/reference-data/holdings-note-types/Provenance.json
@@ -1,0 +1,6 @@
+{
+  "id": "db9b4787-95f0-4e78-becf-26748ce6bdeb",
+  "name": "Provenance",
+  "source": "folio"
+}
+

--- a/reference-data/holdings-note-types/Reproduction.json
+++ b/reference-data/holdings-note-types/Reproduction.json
@@ -1,0 +1,6 @@
+{
+  "id": "6a41b714-8574-4084-8d64-a9373c3fbb59",
+  "name": "Reproduction",
+  "source": "folio"
+}
+

--- a/reference-data/import.sh
+++ b/reference-data/import.sh
@@ -59,7 +59,8 @@ modEndpoints_c='locations identifier-types contributor-types service-points inst
 modEndpoints_d='contributor-name-types instance-types instance-formats classification-types platforms'
 modEndpoints_e='instance-statuses statistical-code-types modes-of-issuance alternative-title-types'
 modEndpoints_f='electronic-access-relationships ill-policies holdings-types call-number-types'
-modEndpoints="$modEndpoints_a $modEndpoints_b $modEndpoints_c $modEndpoints_d $modEndpoints_e $modEndpoints_f"
+modEndpoints_g='holdings-note-types item-note-types'
+modEndpoints="$modEndpoints_a $modEndpoints_b $modEndpoints_c $modEndpoints_d $modEndpoints_e $modEndpoints_f $modEndpoints_g"
 method=POST
 
 for dir in "${dataDirs[@]}";

--- a/reference-data/item-note-types/ActionNote.json
+++ b/reference-data/item-note-types/ActionNote.json
@@ -1,0 +1,6 @@
+{
+  "id": "0e40884c-3523-4c6d-8187-d578e3d2794e",
+  "name": "Action note",
+  "source": "folio"
+}
+

--- a/reference-data/item-note-types/Binding.json
+++ b/reference-data/item-note-types/Binding.json
@@ -1,0 +1,6 @@
+{
+  "id": "87c450be-2033-41fb-80ba-dd2409883681",
+  "name": "Binding",
+  "source": "folio"
+}
+

--- a/reference-data/item-note-types/CopyNote.json
+++ b/reference-data/item-note-types/CopyNote.json
@@ -1,0 +1,6 @@
+{
+  "id": "1dde7141-ec8a-4dae-9825-49ce14c728e7",
+  "name": "Copy note",
+  "source": "folio"
+}
+

--- a/reference-data/item-note-types/ElectronicBookplate.json
+++ b/reference-data/item-note-types/ElectronicBookplate.json
@@ -1,0 +1,6 @@
+{
+  "id": "f3ae3823-d096-4c65-8734-0c1efd2ffea8",
+  "name": "Electronic bookplate",
+  "source": "folio"
+}
+

--- a/reference-data/item-note-types/Note.json
+++ b/reference-data/item-note-types/Note.json
@@ -1,0 +1,6 @@
+{
+  "id": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
+  "name": "Note",
+  "source": "folio"
+}
+

--- a/reference-data/item-note-types/Provenance.json
+++ b/reference-data/item-note-types/Provenance.json
@@ -1,0 +1,6 @@
+{
+  "id": "c3a539b9-9576-4e3a-b6de-d910200b2919",
+  "name": "Provenance",
+  "source": "folio"
+}
+

--- a/reference-data/item-note-types/Reproduction.json
+++ b/reference-data/item-note-types/Reproduction.json
@@ -1,0 +1,6 @@
+{
+  "id": "acb3a58f-1d72-461d-97c3-0e7119e8d544",
+  "name": "Reproduction",
+  "source": "folio"
+}
+

--- a/src/main/java/org/folio/rest/impl/HoldingsNoteTypeAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsNoteTypeAPI.java
@@ -11,8 +11,8 @@ import java.util.UUID;
 
 import javax.ws.rs.core.Response;
 
-import org.folio.rest.jaxrs.model.HoldingsType;
-import org.folio.rest.jaxrs.model.HoldingsTypes;
+import org.folio.rest.jaxrs.model.HoldingsNoteType;
+import org.folio.rest.jaxrs.model.HoldingsNoteTypes;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.Criteria.Limit;
@@ -39,47 +39,48 @@ import io.vertx.core.logging.LoggerFactory;
  *
  * @author ne
  */
-public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTypes {
+public class HoldingsNoteTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsNoteTypes {
 
-  public static final String REFERENCE_TABLE  = "holdings_type";
+  public static final String REFERENCE_TABLE  = "holdings_note_type";
 
-  private static final String LOCATION_PREFIX = "/holdings-types/";
-  private static final Logger log             = LoggerFactory.getLogger(HoldingsTypeAPI.class);
+  private static final String LOCATION_PREFIX = "/holdings-note-types/";
+  private static final Logger log             = LoggerFactory.getLogger(HoldingsNoteTypeAPI.class);
   private final Messages messages             = Messages.getInstance();
   private String idFieldName                  = "_id";
-
-  public HoldingsTypeAPI(Vertx vertx, String tenantId) {
+  
+  public HoldingsNoteTypeAPI(Vertx vertx, String tenantId) {
     PostgresClient.getInstance(vertx, tenantId).setIdField(idFieldName);
   }
-  
+
+
   @Override
-  public void getHoldingsTypes(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getHoldingsNoteTypes(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     /**
-     * http://host:port/holdings-types
+     * http://host:port/holdings-note-types
      */
     vertxContext.runOnContext(v -> {
       try {
         String tenantId = TenantTool.tenantId(okapiHeaders);
         CQLWrapper cql = getCQL(query, limit, offset);
-        PostgresClient.getInstance(vertxContext.owner(), tenantId).get(REFERENCE_TABLE, HoldingsType.class,
+        PostgresClient.getInstance(vertxContext.owner(), tenantId).get(REFERENCE_TABLE, HoldingsNoteType.class,
             new String[]{"*"}, cql, true, true,
             reply -> {
               try {
                 if (reply.succeeded()) {
-                  HoldingsTypes records = new HoldingsTypes();
-                  List<HoldingsType> record = reply.result().getResults();
-                  records.setHoldingsTypes(record);
+                  HoldingsNoteTypes records = new HoldingsNoteTypes();
+                  List<HoldingsNoteType> record = reply.result().getResults();
+                  records.setHoldingsNoteTypes(record);
                   records.setTotalRecords(reply.result().getResultInfo().getTotalRecords());
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsTypesResponse.respond200WithApplicationJson(records)));
+                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsNoteTypesResponse.respond200WithApplicationJson(records)));
                 }
                 else{
                   log.error(reply.cause().getMessage(), reply.cause());
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsTypesResponse
+                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsNoteTypesResponse
                       .respond400WithTextPlain(reply.cause().getMessage())));
                 }
               } catch (Exception e) {
                 log.error(e.getMessage(), e);
-                asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsTypesResponse
+                asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsNoteTypesResponse
                     .respond500WithTextPlain(messages.getMessage(
                         lang, MessageConsts.InternalServerError))));
               }
@@ -90,14 +91,14 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
         if (e.getCause() instanceof CQLParseException) {
           message = " CQL parse error " + e.getLocalizedMessage();
         }
-        asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsTypesResponse
+        asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsNoteTypesResponse
             .respond500WithTextPlain(message)));
       }
     });
   }
 
   @Override
-  public void postHoldingsTypes(String lang, HoldingsType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void postHoldingsNoteTypes(String lang, HoldingsNoteType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         String id = entity.getId();
@@ -113,8 +114,8 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
                 if (reply.succeeded()) {
                   String ret = reply.result();
                   entity.setId(ret);
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PostHoldingsTypesResponse
-                    .respond201WithApplicationJson(entity, PostHoldingsTypesResponse.headersFor201().withLocation(LOCATION_PREFIX + ret))));
+                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PostHoldingsNoteTypesResponse
+                    .respond201WithApplicationJson(entity, PostHoldingsNoteTypesResponse.headersFor201().withLocation(LOCATION_PREFIX + ret))));
                 } else {
                   String msg = PgExceptionUtil.badRequestMessage(reply.cause());
                   if (msg == null) {
@@ -122,7 +123,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
                     return;
                   }
                   log.info(msg);
-                  asyncResultHandler.handle(Future.succeededFuture(PostHoldingsTypesResponse
+                  asyncResultHandler.handle(Future.succeededFuture(PostHoldingsNoteTypesResponse
                       .respond400WithTextPlain(msg)));
                 }
               } catch (Exception e) {
@@ -136,7 +137,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
   }
 
   @Override
-  public void getHoldingsTypesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getHoldingsNoteTypesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         String tenantId = TenantTool.tenantId(okapiHeaders);
@@ -144,7 +145,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
         Criterion c = new Criterion(
             new Criteria().addField(idFieldName).setJSONB(false).setOperation("=").setValue("'"+id+"'"));
 
-        PostgresClient.getInstance(vertxContext.owner(), tenantId).get(REFERENCE_TABLE, HoldingsType.class, c, true,
+        PostgresClient.getInstance(vertxContext.owner(), tenantId).get(REFERENCE_TABLE, HoldingsNoteType.class, c, true,
             reply -> {
               try {
                 if (reply.failed()) {
@@ -154,18 +155,18 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
                     return;
                   }
                   log.info(msg);
-                  asyncResultHandler.handle(Future.succeededFuture(GetHoldingsTypesByIdResponse.
+                  asyncResultHandler.handle(Future.succeededFuture(GetHoldingsNoteTypesByIdResponse.
                       respond404WithTextPlain(msg)));
                   return;
                 }
                 @SuppressWarnings("unchecked")
-                List<HoldingsType> records = (List<HoldingsType>) reply.result().getResults();
+                List<HoldingsNoteType> records = (List<HoldingsNoteType>) reply.result().getResults();
                 if (records.isEmpty()) {
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsTypesByIdResponse
+                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsNoteTypesByIdResponse
                       .respond404WithTextPlain(id)));
                 }
                 else{
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsTypesByIdResponse
+                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsNoteTypesByIdResponse
                       .respond200WithApplicationJson(records.get(0))));
                 }
               } catch (Exception e) {
@@ -179,7 +180,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
   }
 
   @Override
-  public void deleteHoldingsTypesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void deleteHoldingsNoteTypesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         String tenantId = TenantTool.tenantId(okapiHeaders);
@@ -194,7 +195,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
                     return;
                   }
                   log.info(msg);
-                  asyncResultHandler.handle(Future.succeededFuture(DeleteHoldingsTypesByIdResponse
+                  asyncResultHandler.handle(Future.succeededFuture(DeleteHoldingsNoteTypesByIdResponse
                       .respond400WithTextPlain(msg)));
                   return;
                 }
@@ -202,11 +203,11 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
                 if (updated != 1) {
                   String msg = messages.getMessage(lang, MessageConsts.DeletedCountError, 1, updated);
                   log.error(msg);
-                  asyncResultHandler.handle(Future.succeededFuture(DeleteHoldingsTypesByIdResponse
+                  asyncResultHandler.handle(Future.succeededFuture(DeleteHoldingsNoteTypesByIdResponse
                       .respond404WithTextPlain(msg)));
                   return;
                 }
-                asyncResultHandler.handle(Future.succeededFuture(DeleteHoldingsTypesByIdResponse
+                asyncResultHandler.handle(Future.succeededFuture(DeleteHoldingsNoteTypesByIdResponse
                         .respond204()));
               } catch (Exception e) {
                 internalServerErrorDuringDelete(e, lang, asyncResultHandler);
@@ -219,7 +220,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
   }
 
   @Override
-  public void putHoldingsTypesById(String id, String lang, HoldingsType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void putHoldingsNoteTypesById(String id, String lang, HoldingsNoteType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       String tenantId = TenantTool.tenantId(okapiHeaders);
       try {
@@ -231,10 +232,10 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
               try {
                 if (reply.succeeded()) {
                   if (reply.result().getUpdated() == 0) {
-                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutHoldingsTypesByIdResponse
+                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutHoldingsNoteTypesByIdResponse
                         .respond404WithTextPlain(messages.getMessage(lang, MessageConsts.NoRecordsUpdated))));
                   } else{
-                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutHoldingsTypesByIdResponse
+                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutHoldingsNoteTypesByIdResponse
                         .respond204()));
                   }
                 } else {
@@ -244,7 +245,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
                     return;
                   }
                   log.info(msg);
-                  asyncResultHandler.handle(Future.succeededFuture(PutHoldingsTypesByIdResponse
+                  asyncResultHandler.handle(Future.succeededFuture(PutHoldingsNoteTypesByIdResponse
                       .respond400WithTextPlain(msg)));
                 }
               } catch (Exception e) {
@@ -255,7 +256,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
         internalServerErrorDuringPut(e, lang, asyncResultHandler);      }
     });
   }
-  
+
   private CQLWrapper getCQL(String query, int limit, int offset) throws FieldException {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON(REFERENCE_TABLE+".jsonb");
     return new CQLWrapper(cql2pgJson, query).setLimit(new Limit(limit)).setOffset(new Offset(offset));
@@ -263,27 +264,26 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
 
   private void internalServerErrorDuringPost(Throwable e, String lang, Handler<AsyncResult<Response>> handler) {
     log.error(e.getMessage(), e);
-    handler.handle(Future.succeededFuture(PostHoldingsTypesResponse
+    handler.handle(Future.succeededFuture(PostHoldingsNoteTypesResponse
         .respond500WithTextPlain(messages.getMessage(lang, MessageConsts.InternalServerError))));
   }
   
   private void internalServerErrorDuringDelete(Throwable e, String lang, Handler<AsyncResult<Response>> handler) {
     log.error(e.getMessage(), e);
-    handler.handle(Future.succeededFuture(DeleteHoldingsTypesByIdResponse
+    handler.handle(Future.succeededFuture(DeleteHoldingsNoteTypesByIdResponse
         .respond500WithTextPlain(messages.getMessage(lang, MessageConsts.InternalServerError))));
   }
 
   private void internalServerErrorDuringGetById(Throwable e, String lang, Handler<AsyncResult<Response>> handler) {
     log.error(e.getMessage(), e);
-    handler.handle(Future.succeededFuture(GetHoldingsTypesByIdResponse
+    handler.handle(Future.succeededFuture(GetHoldingsNoteTypesByIdResponse
         .respond500WithTextPlain(messages.getMessage(lang, MessageConsts.InternalServerError))));
   }
 
   private void internalServerErrorDuringPut(Throwable e, String lang, Handler<AsyncResult<Response>> handler) {
     log.error(e.getMessage(), e);
-    handler.handle(Future.succeededFuture(PutHoldingsTypesByIdResponse
+    handler.handle(Future.succeededFuture(PutHoldingsNoteTypesByIdResponse
         .respond500WithTextPlain(messages.getMessage(lang, MessageConsts.InternalServerError))));
   }
 
-  
 }

--- a/src/main/java/org/folio/rest/impl/ItemNoteTypeAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemNoteTypeAPI.java
@@ -11,8 +11,8 @@ import java.util.UUID;
 
 import javax.ws.rs.core.Response;
 
-import org.folio.rest.jaxrs.model.HoldingsType;
-import org.folio.rest.jaxrs.model.HoldingsTypes;
+import org.folio.rest.jaxrs.model.ItemNoteType;
+import org.folio.rest.jaxrs.model.ItemNoteTypes;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.Criteria.Limit;
@@ -39,47 +39,47 @@ import io.vertx.core.logging.LoggerFactory;
  *
  * @author ne
  */
-public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTypes {
+public class ItemNoteTypeAPI implements org.folio.rest.jaxrs.resource.ItemNoteTypes {
 
-  public static final String REFERENCE_TABLE  = "holdings_type";
+  public static final String REFERENCE_TABLE  = "item_note_type";
 
-  private static final String LOCATION_PREFIX = "/holdings-types/";
-  private static final Logger log             = LoggerFactory.getLogger(HoldingsTypeAPI.class);
+  private static final String LOCATION_PREFIX = "/item-note-types/";
+  private static final Logger log             = LoggerFactory.getLogger(ItemNoteTypeAPI.class);
   private final Messages messages             = Messages.getInstance();
   private String idFieldName                  = "_id";
-
-  public HoldingsTypeAPI(Vertx vertx, String tenantId) {
+  
+  public ItemNoteTypeAPI(Vertx vertx, String tenantId) {
     PostgresClient.getInstance(vertx, tenantId).setIdField(idFieldName);
   }
-  
+
   @Override
-  public void getHoldingsTypes(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getItemNoteTypes(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     /**
-     * http://host:port/holdings-types
+     * http://host:port/holdings-note-types
      */
     vertxContext.runOnContext(v -> {
       try {
         String tenantId = TenantTool.tenantId(okapiHeaders);
         CQLWrapper cql = getCQL(query, limit, offset);
-        PostgresClient.getInstance(vertxContext.owner(), tenantId).get(REFERENCE_TABLE, HoldingsType.class,
+        PostgresClient.getInstance(vertxContext.owner(), tenantId).get(REFERENCE_TABLE, ItemNoteType.class,
             new String[]{"*"}, cql, true, true,
             reply -> {
               try {
                 if (reply.succeeded()) {
-                  HoldingsTypes records = new HoldingsTypes();
-                  List<HoldingsType> record = reply.result().getResults();
-                  records.setHoldingsTypes(record);
+                  ItemNoteTypes records = new ItemNoteTypes();
+                  List<ItemNoteType> record = reply.result().getResults();
+                  records.setItemNoteTypes(record);
                   records.setTotalRecords(reply.result().getResultInfo().getTotalRecords());
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsTypesResponse.respond200WithApplicationJson(records)));
+                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetItemNoteTypesResponse.respond200WithApplicationJson(records)));
                 }
                 else{
                   log.error(reply.cause().getMessage(), reply.cause());
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsTypesResponse
+                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetItemNoteTypesResponse
                       .respond400WithTextPlain(reply.cause().getMessage())));
                 }
               } catch (Exception e) {
                 log.error(e.getMessage(), e);
-                asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsTypesResponse
+                asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetItemNoteTypesResponse
                     .respond500WithTextPlain(messages.getMessage(
                         lang, MessageConsts.InternalServerError))));
               }
@@ -90,14 +90,14 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
         if (e.getCause() instanceof CQLParseException) {
           message = " CQL parse error " + e.getLocalizedMessage();
         }
-        asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsTypesResponse
+        asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetItemNoteTypesResponse
             .respond500WithTextPlain(message)));
       }
     });
   }
 
   @Override
-  public void postHoldingsTypes(String lang, HoldingsType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void postItemNoteTypes(String lang, ItemNoteType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         String id = entity.getId();
@@ -113,8 +113,8 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
                 if (reply.succeeded()) {
                   String ret = reply.result();
                   entity.setId(ret);
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PostHoldingsTypesResponse
-                    .respond201WithApplicationJson(entity, PostHoldingsTypesResponse.headersFor201().withLocation(LOCATION_PREFIX + ret))));
+                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PostItemNoteTypesResponse
+                    .respond201WithApplicationJson(entity, PostItemNoteTypesResponse.headersFor201().withLocation(LOCATION_PREFIX + ret))));
                 } else {
                   String msg = PgExceptionUtil.badRequestMessage(reply.cause());
                   if (msg == null) {
@@ -122,7 +122,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
                     return;
                   }
                   log.info(msg);
-                  asyncResultHandler.handle(Future.succeededFuture(PostHoldingsTypesResponse
+                  asyncResultHandler.handle(Future.succeededFuture(PostItemNoteTypesResponse
                       .respond400WithTextPlain(msg)));
                 }
               } catch (Exception e) {
@@ -136,7 +136,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
   }
 
   @Override
-  public void getHoldingsTypesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getItemNoteTypesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         String tenantId = TenantTool.tenantId(okapiHeaders);
@@ -144,7 +144,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
         Criterion c = new Criterion(
             new Criteria().addField(idFieldName).setJSONB(false).setOperation("=").setValue("'"+id+"'"));
 
-        PostgresClient.getInstance(vertxContext.owner(), tenantId).get(REFERENCE_TABLE, HoldingsType.class, c, true,
+        PostgresClient.getInstance(vertxContext.owner(), tenantId).get(REFERENCE_TABLE, ItemNoteType.class, c, true,
             reply -> {
               try {
                 if (reply.failed()) {
@@ -154,18 +154,18 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
                     return;
                   }
                   log.info(msg);
-                  asyncResultHandler.handle(Future.succeededFuture(GetHoldingsTypesByIdResponse.
+                  asyncResultHandler.handle(Future.succeededFuture(GetItemNoteTypesByIdResponse.
                       respond404WithTextPlain(msg)));
                   return;
                 }
                 @SuppressWarnings("unchecked")
-                List<HoldingsType> records = (List<HoldingsType>) reply.result().getResults();
+                List<ItemNoteType> records = (List<ItemNoteType>) reply.result().getResults();
                 if (records.isEmpty()) {
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsTypesByIdResponse
+                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetItemNoteTypesByIdResponse
                       .respond404WithTextPlain(id)));
                 }
                 else{
-                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetHoldingsTypesByIdResponse
+                  asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(GetItemNoteTypesByIdResponse
                       .respond200WithApplicationJson(records.get(0))));
                 }
               } catch (Exception e) {
@@ -179,7 +179,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
   }
 
   @Override
-  public void deleteHoldingsTypesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void deleteItemNoteTypesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       try {
         String tenantId = TenantTool.tenantId(okapiHeaders);
@@ -194,7 +194,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
                     return;
                   }
                   log.info(msg);
-                  asyncResultHandler.handle(Future.succeededFuture(DeleteHoldingsTypesByIdResponse
+                  asyncResultHandler.handle(Future.succeededFuture(DeleteItemNoteTypesByIdResponse
                       .respond400WithTextPlain(msg)));
                   return;
                 }
@@ -202,11 +202,11 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
                 if (updated != 1) {
                   String msg = messages.getMessage(lang, MessageConsts.DeletedCountError, 1, updated);
                   log.error(msg);
-                  asyncResultHandler.handle(Future.succeededFuture(DeleteHoldingsTypesByIdResponse
+                  asyncResultHandler.handle(Future.succeededFuture(DeleteItemNoteTypesByIdResponse
                       .respond404WithTextPlain(msg)));
                   return;
                 }
-                asyncResultHandler.handle(Future.succeededFuture(DeleteHoldingsTypesByIdResponse
+                asyncResultHandler.handle(Future.succeededFuture(DeleteItemNoteTypesByIdResponse
                         .respond204()));
               } catch (Exception e) {
                 internalServerErrorDuringDelete(e, lang, asyncResultHandler);
@@ -219,7 +219,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
   }
 
   @Override
-  public void putHoldingsTypesById(String id, String lang, HoldingsType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void putItemNoteTypesById(String id, String lang, ItemNoteType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
       String tenantId = TenantTool.tenantId(okapiHeaders);
       try {
@@ -231,10 +231,10 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
               try {
                 if (reply.succeeded()) {
                   if (reply.result().getUpdated() == 0) {
-                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutHoldingsTypesByIdResponse
+                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutItemNoteTypesByIdResponse
                         .respond404WithTextPlain(messages.getMessage(lang, MessageConsts.NoRecordsUpdated))));
                   } else{
-                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutHoldingsTypesByIdResponse
+                    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(PutItemNoteTypesByIdResponse
                         .respond204()));
                   }
                 } else {
@@ -244,7 +244,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
                     return;
                   }
                   log.info(msg);
-                  asyncResultHandler.handle(Future.succeededFuture(PutHoldingsTypesByIdResponse
+                  asyncResultHandler.handle(Future.succeededFuture(PutItemNoteTypesByIdResponse
                       .respond400WithTextPlain(msg)));
                 }
               } catch (Exception e) {
@@ -255,6 +255,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
         internalServerErrorDuringPut(e, lang, asyncResultHandler);      }
     });
   }
+
   
   private CQLWrapper getCQL(String query, int limit, int offset) throws FieldException {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON(REFERENCE_TABLE+".jsonb");
@@ -263,27 +264,26 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
 
   private void internalServerErrorDuringPost(Throwable e, String lang, Handler<AsyncResult<Response>> handler) {
     log.error(e.getMessage(), e);
-    handler.handle(Future.succeededFuture(PostHoldingsTypesResponse
+    handler.handle(Future.succeededFuture(PostItemNoteTypesResponse
         .respond500WithTextPlain(messages.getMessage(lang, MessageConsts.InternalServerError))));
   }
   
   private void internalServerErrorDuringDelete(Throwable e, String lang, Handler<AsyncResult<Response>> handler) {
     log.error(e.getMessage(), e);
-    handler.handle(Future.succeededFuture(DeleteHoldingsTypesByIdResponse
+    handler.handle(Future.succeededFuture(DeleteItemNoteTypesByIdResponse
         .respond500WithTextPlain(messages.getMessage(lang, MessageConsts.InternalServerError))));
   }
 
   private void internalServerErrorDuringGetById(Throwable e, String lang, Handler<AsyncResult<Response>> handler) {
     log.error(e.getMessage(), e);
-    handler.handle(Future.succeededFuture(GetHoldingsTypesByIdResponse
+    handler.handle(Future.succeededFuture(GetItemNoteTypesByIdResponse
         .respond500WithTextPlain(messages.getMessage(lang, MessageConsts.InternalServerError))));
   }
 
   private void internalServerErrorDuringPut(Throwable e, String lang, Handler<AsyncResult<Response>> handler) {
     log.error(e.getMessage(), e);
-    handler.handle(Future.succeededFuture(PutHoldingsTypesByIdResponse
+    handler.handle(Future.succeededFuture(PutItemNoteTypesByIdResponse
         .respond500WithTextPlain(messages.getMessage(lang, MessageConsts.InternalServerError))));
   }
-
   
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -612,6 +612,32 @@
       ]
     },
     {
+      "tableName": "holdings_note_type",
+      "withMetadata": true,
+      "generateId": false,
+      "pkColumnName": "_id",
+      "withAuditing": false,
+      "uniqueIndex": [
+        {
+          "fieldName": "name",
+          "tOps": "ADD"
+        }
+      ]
+    },
+    {
+      "tableName": "item_note_type",
+      "withMetadata": true,
+      "generateId": false,
+      "pkColumnName": "_id",
+      "withAuditing": false,
+      "uniqueIndex": [
+        {
+          "fieldName": "name",
+          "tOps": "ADD"
+        }
+      ]
+    },
+    {
       "tableName": "holdings_record",
       "withMetadata": true,
       "generateId": false,


### PR DESCRIPTION
  Change holdings note type from enum based string to reference
  table based UUID, rename property to `holdingsNoteTypeId`

  Add holdings-note-types and item-note-types end-points