### PR TITLE
Add simple HRID generators for three record types, MODINVSTOR-170

### DIFF
--- a/sample-data/instances/aba.json
+++ b/sample-data/instances/aba.json
@@ -1,6 +1,5 @@
 {
   "id": "69640328-788e-43fc-9c3c-af39e243f3b7",
-  "hrid": "in000001",
   "source": "MARC",
   "title": "ABA Journal",
   "publication": [

--- a/sample-data/instances/american-journal-of-medicine.json
+++ b/sample-data/instances/american-journal-of-medicine.json
@@ -1,6 +1,5 @@
 {
   "id" : "30fcc8e7-a019-43f4-b642-2edc389f4501",
-  "hrid": "in000002",
   "source" : "MARC",
   "title" : "The American Journal of Medicine",
   "alternativeTitles" : [ 

--- a/sample-data/instances/anglo-saxon-manuscripts.json
+++ b/sample-data/instances/anglo-saxon-manuscripts.json
@@ -1,6 +1,5 @@
 {
   "id": "8be05cf5-fb4f-4752-8094-8e179d08fb99",
-  "hrid": "in000003",
   "source": "MARC",
   "title": "Anglo-Saxon manuscripts in microfiche facsimile Volume 25 Corpus Christi College, Cambridge II, MSS 12, 144, 162, 178, 188, 198, 265, 285, 322, 326, 449 microform A. N. Doane (editor and director), Matthew T. Hussey (associate editor), Phillip Pulsiano (founding editor)",
   "alternativeTitles": [],

--- a/sample-data/instances/biometrics-and-neuroscience.json
+++ b/sample-data/instances/biometrics-and-neuroscience.json
@@ -1,6 +1,5 @@
 {
   "id": "1640f178-f243-4e4a-bf1c-9e1e62b3171d",
-  "hrid": "in000004",
   "source": "MARC",
   "title": "Futures, biometrics and neuroscience research Luiz Moutinho, Mladen Sokele, editors",
   "alternativeTitles": [],

--- a/sample-data/instances/bridget-jones-baby.json
+++ b/sample-data/instances/bridget-jones-baby.json
@@ -1,6 +1,5 @@
 {
   "id": "7fbd5d84-62d1-44c6-9c45-6cb173998bbd",
-  "hrid": "in000005",
   "source": "MARC",
   "title": "Bridget Jones's Baby: the diaries",
   "editions": [

--- a/sample-data/instances/cantatas-for-bass.json
+++ b/sample-data/instances/cantatas-for-bass.json
@@ -1,6 +1,5 @@
 {
   "id": "ce00bca2-9270-4c6b-b096-b83a2e56e8e9",
-  "hrid": "in000006",
   "source": "MARC",
   "title": "Cantatas for bass 4 Ich habe genug : BWV 82 / Johann Sebastian Bach ; Matthias Goerne, baritone ; Freiburger Barockorchester, Gottfried von der Goltz, violin and conductor",
   "alternativeTitles": [

--- a/sample-data/instances/chess-player.json
+++ b/sample-data/instances/chess-player.json
@@ -1,6 +1,5 @@
 {
   "id": "3c4ae3f3-b460-4a89-a2f9-78ce3145e4fc",
-  "hrid": "in000007",
   "source": "MARC",
   "title": "The chess player’s mating guide Computer Datei Robert Ris",
   "alternativeTitles": [],

--- a/sample-data/instances/city-post-modernity.json
+++ b/sample-data/instances/city-post-modernity.json
@@ -1,6 +1,5 @@
 {
   "id": "c1d3be12-ecec-4fab-9237-baf728575185",
-  "hrid": "in000008",
   "source": "MARC",
   "title": "The city post-modernity edited by Alan Latham",
   "alternativeTitles": [],

--- a/sample-data/instances/concepts-of-fashion.json
+++ b/sample-data/instances/concepts-of-fashion.json
@@ -1,6 +1,5 @@
 {
   "id": "5b1eb450-ff9f-412d-a9e7-887f6eaeb5b4",
-  "hrid": "in000009",
   "source": "MARC",
   "title": "Concepts of fashion 1921 - 1987 microform a study of garments worn by selected winners of the Miss America Pageant Marian Ann J. Matwiejczyk-Montgomery",
   "alternativeTitles": [],

--- a/sample-data/instances/dc-motor-control-experiment.json
+++ b/sample-data/instances/dc-motor-control-experiment.json
@@ -1,6 +1,5 @@
 {
   "id": "6eee8eb9-db1a-46e2-a8ad-780f19974efa",
-  "hrid": "in000010",
   "source": "MARC",
   "title": "DC Motor Control Experiment Objekt for introduction to control systems Herbert Werner",
   "alternativeTitles": [],

--- a/sample-data/instances/girl-on-the-train.json
+++ b/sample-data/instances/girl-on-the-train.json
@@ -1,6 +1,5 @@
 {
   "id": "f31a36de-fcf8-44f9-87ef-a55d06ad21ae",
-  "hrid": "in000011",
   "source": "MARC",
   "title": "The Girl on the Train",
   "alternativeTitles": [

--- a/sample-data/instances/global-africa-series.json
+++ b/sample-data/instances/global-africa-series.json
@@ -1,6 +1,5 @@
 {
   "id": "f7e82a1e-fc06-4b82-bb1d-da326cb378ce",
-  "hrid": "in000012",
   "source": "MARC",
   "title": "Global Africa",
   "identifiers": [

--- a/sample-data/instances/global-africa-v1.json
+++ b/sample-data/instances/global-africa-v1.json
@@ -1,6 +1,5 @@
 {
   "id": "81825729-e824-4d52-9d15-1695e9bf1831",
-  "hrid": "in000013",
   "source": "MARC",
   "title": "Dissent, protest and dispute in Africa edited by Emmanuel M. Mbah and Toyin Falola",
   "series": [

--- a/sample-data/instances/global-africa-v2.json
+++ b/sample-data/instances/global-africa-v2.json
@@ -1,6 +1,5 @@
 {
   "id": "04489a01-f3cd-4f9e-9be4-d9c198703f45",
-  "hrid": "in000014",
   "source": "MARC",
   "title": "Environment and identity politics in colonial Africa Fulani migrations and land conflict by Emmanuel M. Mbah",
   "series": [

--- a/sample-data/instances/global-africa-v3.json
+++ b/sample-data/instances/global-africa-v3.json
@@ -1,6 +1,5 @@
 {
   "id": "7ab22f0a-c9cd-449a-9137-c76e5055ca37",
-  "hrid": "in000015",
   "source": "MARC",
   "title": "Poverty reduction strategies in Africa edited by Toyin Falola and Mike Odugbo Odey",
   "series": [

--- a/sample-data/instances/interesting-times.json
+++ b/sample-data/instances/interesting-times.json
@@ -1,6 +1,5 @@
 {
   "id": "a89eccf0-57a6-495e-898d-32b9b2210f2f",
-  "hrid": "in000016",
   "source": "MARC",
   "title": "Interesting Times",
   "contributors": [

--- a/sample-data/instances/journey-through-europe.json
+++ b/sample-data/instances/journey-through-europe.json
@@ -1,6 +1,5 @@
 {
   "id": "1b74ab75-9f41-4837-8662-a1d99118008d",
-  "hrid": "in000017",
   "source": "MARC",
   "title": "A journey through Europe Bildtontraeger high-speed lines European Commission, Directorate-General for Mobility and Transport",
   "alternativeTitles": [],

--- a/sample-data/instances/millimeter-wave-networks.json
+++ b/sample-data/instances/millimeter-wave-networks.json
@@ -1,6 +1,5 @@
 {
   "id": "6b4ae089-e1ee-431f-af83-e1133f8e3da0",
-  "hrid": "in000018",
   "source": "MARC",
   "title": "MobiCom'17 5 mmNets'17, October 16, 2017, Snowbird, UT, USA / general chairs: Haitham Hassanieh (University of Illinois at Urbana Champaign, USA), Xinyu Zhang (University of California San Diego, USA)",
   "alternativeTitles": [

--- a/sample-data/instances/neurotic-heroine.json
+++ b/sample-data/instances/neurotic-heroine.json
@@ -1,6 +1,5 @@
 {
 	"id": "62ca5b43-0f11-40af-a6b4-1a9ee2db33cb",
-        "hrid": "in000019",
         "source": "MARC",
 	"title": "The Neurotic Heroine in Tennessee Williams microform C.N. Stavrou",
 	"alternativeTitles": [],

--- a/sample-data/instances/nod.json
+++ b/sample-data/instances/nod.json
@@ -1,6 +1,5 @@
 {
   "id": "6506b79b-7702-48b2-9774-a1c538fdd34e",
-  "hrid": "in000020",
   "source": "MARC",
   "title": "Nod",
   "contributors": [

--- a/sample-data/instances/signature-of-complex-system.json
+++ b/sample-data/instances/signature-of-complex-system.json
@@ -1,6 +1,5 @@
 {
   "id": "54cc0262-76df-4cac-acca-b10e9bc5c79a",
-  "hrid": "in000021",
   "source": "MARC",
   "title": "On the signature of complex system a decomposed approach Gaofeng Da, Ping Shing Chan, Maochao Xu",
   "alternativeTitles": [],

--- a/sample-data/instances/temeraire.json
+++ b/sample-data/instances/temeraire.json
@@ -1,6 +1,5 @@
 {
   "id": "cf23adf0-61ba-4887-bf82-956c4aae2260",
-  "hrid": "in000022",
   "source": "MARC",
   "title": "Temeraire",
   "contributors": [

--- a/sample-data/instances/transparent-water.json
+++ b/sample-data/instances/transparent-water.json
@@ -1,6 +1,5 @@
 {
   "id": "e54b1f4d-7d05-4b1a-9368-3c36b75d8ac6",
-  "hrid": "in000023",
   "source": "MARC",
   "title": "Transparent water",
   "identifiers": [

--- a/sample-data/instances/umsetzung-multipart.json
+++ b/sample-data/instances/umsetzung-multipart.json
@@ -1,6 +1,5 @@
 {
   "id": "a317b304-528c-424f-961c-39174933b454",
-  "hrid": "in000024",
   "source": "MARC",
   "title": "Umsetzung der DIN EN ISO 9001:2015 Harald Augustin (Hrsg.)",
   "series": [

--- a/sample-data/instances/umsetzung-v1.json
+++ b/sample-data/instances/umsetzung-v1.json
@@ -1,6 +1,5 @@
 {
   "id": "e6bc03c6-c137-4221-b679-a7c5c31f986c",
-  "hrid": "in000025",
   "source": "MARC",
   "title": "Organisations- und Prozessentwicklung Harald Augustin (Hrsg.)",
   "series": [

--- a/sample-data/instances/umsetzung-v2.json
+++ b/sample-data/instances/umsetzung-v2.json
@@ -1,6 +1,5 @@
 {
   "id": "549fad9e-7f8e-4d8e-9a71-00d251817866",
-  "hrid": "in000026",
   "source": "MARC",
   "title": "Agile Organisation, Risiko- und Change Management Harald Augustin (Hrsg.)",
   "series": [

--- a/sample-data/instances/water-resources-of-east-feliciana-parish.json
+++ b/sample-data/instances/water-resources-of-east-feliciana-parish.json
@@ -1,6 +1,5 @@
 {
   "id": "bbd4a5e1-c9f3-44b9-bfdf-d184e04f0ba0",
-  "hrid": "in000027",
   "source": "MARC",
   "title": "Water resources of East Feliciana Parish, Louisiana",
   "contributors": [

--- a/sample-data/items/bridget-jones-baby-item.json
+++ b/sample-data/items/bridget-jones-baby-item.json
@@ -12,6 +12,7 @@
   "numberOfPieces": "1",
   "notes": [
     {
+      "itemNoteTypeId": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
       "note": "Signed by the author"
     }
   ]

--- a/sample-data/items/bridget-jones-baby-item_2.json
+++ b/sample-data/items/bridget-jones-baby-item_2.json
@@ -12,7 +12,24 @@
   "numberOfPieces": "1",
   "notes": [
     {
+      "itemNoteTypeId": "8d0a5eca-25de-4391-81a9-236eeefdd20b",
       "note": "Missing pages; p 10-13"
+    },
+    {
+      "itemNoteTypeId": "0e40884c-3523-4c6d-8187-d578e3d2794e",
+      "note": "My action note"
+    },
+    {
+      "itemNoteTypeId": "1dde7141-ec8a-4dae-9825-49ce14c728e7",
+      "note": "My copy note"
+    },
+    {
+      "itemNoteTypeId": "c3a539b9-9576-4e3a-b6de-d910200b2919",
+      "note": "My provenance"
+    },
+    {
+      "itemNoteTypeId": "acb3a58f-1d72-461d-97c3-0e7119e8d544",
+      "note": "My reproduction"
     }
   ]
 }

--- a/src/main/resources/templates/db_scripts/holdingsRecordHrid.sql
+++ b/src/main/resources/templates/db_scripts/holdingsRecordHrid.sql
@@ -1,0 +1,26 @@
+-- Generates an eight digit HRID prefixed with 'ho' for new holdings_record records, starting with ho00000001.
+-- Ignores the value in 'hrid' -- if any -- in the holdingsRecord POSTed by the client 
+CREATE SEQUENCE IF NOT EXISTS ${myuniversity}_${mymodule}.holdings_record_hrid_seq
+  INCREMENT BY 1
+  START WITH 1
+  OWNED BY holdings_record.jsonb;
+
+GRANT ALL ON SEQUENCE ${myuniversity}_${mymodule}.holdings_record_hrid_seq TO ${myuniversity}_${mymodule};
+
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.set_holdings_record_hrid()
+  RETURNS TRIGGER AS $$
+  DECLARE
+    injectedProp text;
+  BEGIN
+    injectedProp = '"ho' || LPAD(nextval('${myuniversity}_${mymodule}.holdings_record_hrid_seq')::text, 8, '0') ||'"';
+    NEW.jsonb := jsonb_set(NEW.jsonb, '{hrid}', injectedProp::jsonb);
+    RETURN NEW;
+  END;
+  $$ language 'plpgsql';
+
+DROP TRIGGER IF EXISTS set_holdings_record_hrid ON ${myuniversity}_${mymodule}.holdings_record CASCADE;
+CREATE TRIGGER set_holdings_record_hrid
+  BEFORE INSERT ON ${myuniversity}_${mymodule}.holdings_record
+  FOR EACH ROW EXECUTE PROCEDURE ${myuniversity}_${mymodule}.set_holdings_record_hrid();
+
+

--- a/src/main/resources/templates/db_scripts/instanceHrid.sql
+++ b/src/main/resources/templates/db_scripts/instanceHrid.sql
@@ -1,0 +1,25 @@
+-- Generates an eight digit HRID prefixed with 'in' for new instance records, starting with in00000001.
+-- Ignores the value in 'hrid' -- if any -- in the instance POSTed by the client 
+CREATE SEQUENCE IF NOT EXISTS ${myuniversity}_${mymodule}.instance_hrid_seq
+  INCREMENT BY 1
+  START WITH 1
+  OWNED BY instance.jsonb;
+
+GRANT ALL ON SEQUENCE ${myuniversity}_${mymodule}.instance_hrid_seq TO ${myuniversity}_${mymodule};
+
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.set_instance_hrid()
+  RETURNS TRIGGER AS $$
+  DECLARE
+    injectedProp text;
+  BEGIN
+    injectedProp = '"in' || LPAD(nextval('${myuniversity}_${mymodule}.instance_hrid_seq')::text, 8, '0') ||'"';
+    NEW.jsonb := jsonb_set(NEW.jsonb, '{hrid}', injectedProp::jsonb);
+    RETURN NEW;
+  END;
+  $$ language 'plpgsql';
+
+DROP TRIGGER IF EXISTS set_instance_hrid ON ${myuniversity}_${mymodule}.instance CASCADE;
+CREATE TRIGGER set_instance_hrid
+  BEFORE INSERT ON ${myuniversity}_${mymodule}.instance
+  FOR EACH ROW EXECUTE PROCEDURE ${myuniversity}_${mymodule}.set_instance_hrid();
+

--- a/src/main/resources/templates/db_scripts/itemHrid.sql
+++ b/src/main/resources/templates/db_scripts/itemHrid.sql
@@ -1,0 +1,27 @@
+-- Generates an eight digit HRID prefixed with 'it' for new item records, starting with it00000001.
+-- Ignores the value in 'hrid' -- if any -- in the item POSTed by the client 
+CREATE SEQUENCE IF NOT EXISTS ${myuniversity}_${mymodule}.item_hrid_seq
+  INCREMENT BY 1
+  START WITH 1
+  OWNED BY item.jsonb;
+
+GRANT ALL ON SEQUENCE ${myuniversity}_${mymodule}.item_hrid_seq TO ${myuniversity}_${mymodule};
+
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.set_item_hrid()
+  RETURNS TRIGGER AS $$
+  DECLARE
+    injectedProp text;
+  BEGIN
+    injectedProp = '"it' || LPAD(nextval('${myuniversity}_${mymodule}.item_hrid_seq')::text, 8, '0') ||'"';
+    NEW.jsonb := jsonb_set(NEW.jsonb, '{hrid}', injectedProp::jsonb);
+    RETURN NEW;
+  END;
+  $$ language 'plpgsql';
+
+DROP TRIGGER IF EXISTS set_item_hrid ON ${myuniversity}_${mymodule}.item CASCADE;
+CREATE TRIGGER set_item_hrid
+  BEFORE INSERT ON ${myuniversity}_${mymodule}.item
+  FOR EACH ROW EXECUTE PROCEDURE ${myuniversity}_${mymodule}.set_item_hrid();
+
+
+

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -521,7 +521,8 @@
         {
           "fieldName": "instanceTypeId"
         }
-      ]
+      ],
+      "customSnippetPath": "instanceHrid.sql"
     },
     {
       "tableName": "instance_relationship",
@@ -726,7 +727,8 @@
           "caseSensitive": false,
           "removeAccents": true
         }
-      ]
+      ],
+      "customSnippetPath": "holdingsRecordHrid.sql"
     },
     {
       "tableName": "item",
@@ -829,7 +831,8 @@
           "caseSensitive": false,
           "removeAccents": true
         }
-      ]
+      ],
+      "customSnippetPath": "itemHrid.sql"
     }
   ],
   "views": [


### PR DESCRIPTION
  Generates HRIDs as prefixed sequence numbers
  Will ignore any hrid present in the JSON on POST.
  No attempts yet to prevent updates of hrid on subsequent PUTs.
  Numbers starting with 'in00000001' (instances)
                        'ho00000001' (holdingsRecords)
                        'it00000001' (items)