### PR TITLE
MODINVSTOR-254: Performance: PUT /instance-storage/instances/{instId}

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>23.1.0</raml-module-builder-version>
+    <raml-module-builder-version>23.4.0</raml-module-builder-version>
     <argLine />
   </properties>
 

--- a/ramls/instance-storage.raml
+++ b/ramls/instance-storage.raml
@@ -100,6 +100,9 @@ resourceTypes:
               description: "Source record deleted"
             404:
               description: "There is no source record for that instanceId"
+              body:
+                text/plain:
+                  example: "There is no source record for that instanceId"
             500:
               description: "Internal server error, e.g. due to misconfiguration"
               body:

--- a/src/main/java/org/folio/rest/impl/InstanceStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceStorageAPI.java
@@ -20,6 +20,7 @@ import org.folio.rest.jaxrs.model.Instances;
 import org.folio.rest.jaxrs.model.MarcJson;
 import org.folio.rest.jaxrs.resource.InstanceStorage;
 import org.folio.rest.persist.PgExceptionUtil;
+import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.Criteria.Limit;
 import org.folio.rest.persist.Criteria.Offset;
@@ -410,116 +411,8 @@ public class InstanceStorageAPI implements InstanceStorage {
     Handler<AsyncResult<Response>> asyncResultHandler,
     Context vertxContext) {
 
-    String tenantId = okapiHeaders.get(TENANT_HEADER);
-
-    try {
-      PostgresClient postgresClient =
-        PostgresClient.getInstance(
-          vertxContext.owner(), TenantTool.calculateTenantId(tenantId));
-
-      vertxContext.runOnContext(v -> {
-        try {
-          String[] fieldList = {"*"};
-
-          PreparedCQL preparedCql = handleCQL(String.format("id==%s", instanceId), 1, 0);
-          CQLWrapper cql = preparedCql.getCqlWrapper();
-
-          postgresClient.get(preparedCql.getTableName(), Instance.class, fieldList, cql, true, false,
-            reply -> {
-              if(reply.succeeded()) {
-                List<Instance> instancesList = reply.result().getResults();
-
-                if (instancesList.size() == 1) {
-                  try {
-                      postgresClient.update(preparedCql.getTableName(), entity, entity.getId(),
-                      update -> {
-                        try {
-                          if(update.succeeded()) {
-                            OutStream stream = new OutStream();
-                            stream.setData(entity);
-
-                            asyncResultHandler.handle(
-                              Future.succeededFuture(
-                                PutInstanceStorageInstancesByInstanceIdResponse
-                                  .respond204()));
-                          }
-                          else {
-                            asyncResultHandler.handle(
-                              Future.succeededFuture(
-                                PutInstanceStorageInstancesByInstanceIdResponse
-                                  .respond500WithTextPlain(
-                                    update.cause().getMessage())));
-                          }
-                        } catch (Exception e) {
-                          asyncResultHandler.handle(
-                            Future.succeededFuture(
-                              PutInstanceStorageInstancesByInstanceIdResponse
-                                .respond500WithTextPlain(e.getMessage())));
-                        }
-                      });
-                  } catch (Exception e) {
-                    asyncResultHandler.handle(Future.succeededFuture(
-                      PutInstanceStorageInstancesByInstanceIdResponse
-                        .respond500WithTextPlain(e.getMessage())));
-                  }
-              }
-              else {
-                try {
-                      postgresClient.save(preparedCql.getTableName(), entity.getId(), entity,
-                    save -> {
-                      try {
-                        if(save.succeeded()) {
-                          OutStream stream = new OutStream();
-                          stream.setData(entity);
-
-                          asyncResultHandler.handle(
-                            Future.succeededFuture(
-                              PutInstanceStorageInstancesByInstanceIdResponse
-                                .respond204()));
-                        }
-                        else {
-                          asyncResultHandler.handle(
-                            Future.succeededFuture(
-                              PutInstanceStorageInstancesByInstanceIdResponse
-                                .respond500WithTextPlain(
-                                  save.cause().getMessage())));
-                        }
-                      } catch (Exception e) {
-                        asyncResultHandler.handle(
-                          Future.succeededFuture(
-                            PutInstanceStorageInstancesByInstanceIdResponse
-                              .respond500WithTextPlain(e.getMessage())));
-                      }
-                    });
-                } catch (Exception e) {
-                  asyncResultHandler.handle(Future.succeededFuture(
-                    PutInstanceStorageInstancesByInstanceIdResponse
-                      .respond500WithTextPlain(e.getMessage())));
-                }
-              }
-            } else {
-                asyncResultHandler.handle(Future.succeededFuture(
-                  PutInstanceStorageInstancesByInstanceIdResponse
-                    .respond500WithTextPlain(reply.cause().getMessage())));
-            }
-          });
-        } catch (Exception e) {
-          asyncResultHandler.handle(Future.succeededFuture(
-            PutInstanceStorageInstancesByInstanceIdResponse
-              .respond500WithTextPlain(e.getMessage())));
-        }
-      });
-    } catch (Exception e) {
-      asyncResultHandler.handle(Future.succeededFuture(
-        PutInstanceStorageInstancesByInstanceIdResponse
-          .respond500WithTextPlain(e.getMessage())));
-    }
-  }
-
-  private void badRequestResult(
-    Handler<AsyncResult<Response>> asyncResultHandler, String message) {
-    asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
-      GetInstanceStorageInstancesResponse.respond400WithTextPlain(message)));
+    PgUtil.put(INSTANCE_TABLE, entity, instanceId, okapiHeaders, vertxContext,
+        PutInstanceStorageInstancesByInstanceIdResponse.class, asyncResultHandler);
   }
 
   private boolean isUUID(String id) {
@@ -541,19 +434,8 @@ public class InstanceStorageAPI implements InstanceStorage {
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
 
-    PostgresClient postgresClient =
-        PostgresClient.getInstance(vertxContext.owner(), TenantTool.tenantId(okapiHeaders));
-    postgresClient.delete(INSTANCE_SOURCE_MARC_TABLE, instanceId, reply -> {
-      if (! reply.succeeded()) {
-        asyncResultHandler.handle(Future.succeededFuture(
-          DeleteInstanceStorageInstancesSourceRecordByInstanceIdResponse
-            .respond500WithTextPlain(reply.cause().getMessage())));
-        return;
-      }
-
-      asyncResultHandler.handle(Future.succeededFuture(
-          DeleteInstanceStorageInstancesSourceRecordByInstanceIdResponse.respond204()));
-    });
+    PgUtil.deleteById(INSTANCE_SOURCE_MARC_TABLE, instanceId, okapiHeaders, vertxContext,
+        DeleteInstanceStorageInstancesSourceRecordByInstanceIdResponse.class, asyncResultHandler);
   }
 
   @Override
@@ -600,19 +482,8 @@ public class InstanceStorageAPI implements InstanceStorage {
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
 
-    PostgresClient postgresClient =
-        PostgresClient.getInstance(vertxContext.owner(), TenantTool.tenantId(okapiHeaders));
-
-    postgresClient.delete(INSTANCE_SOURCE_MARC_TABLE, instanceId, reply -> {
-      if (! reply.succeeded()) {
-        asyncResultHandler.handle(Future.succeededFuture(
-          DeleteInstanceStorageInstancesSourceRecordMarcJsonByInstanceIdResponse
-            .respond500WithTextPlain(reply.cause().getMessage())));
-        return;
-      }
-      asyncResultHandler.handle(Future.succeededFuture(
-          DeleteInstanceStorageInstancesSourceRecordMarcJsonByInstanceIdResponse.respond204()));
-    });
+    PgUtil.deleteById(INSTANCE_SOURCE_MARC_TABLE, instanceId, okapiHeaders, vertxContext,
+        DeleteInstanceStorageInstancesSourceRecordMarcJsonByInstanceIdResponse.class, asyncResultHandler);
   }
 
   @Override

--- a/src/main/java/org/folio/rest/impl/StorageHelper.java
+++ b/src/main/java/org/folio/rest/impl/StorageHelper.java
@@ -20,6 +20,7 @@ import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.Criteria.Limit;
 import org.folio.rest.persist.Criteria.Offset;
 import org.folio.rest.persist.PgExceptionUtil;
+import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.tools.utils.OutStream;
@@ -58,7 +59,7 @@ public final class StorageHelper {
    * Create a Response using okMethod(entity, headersMethod().withLocationMethod(location)).
    * On exception create a Response using failResponseMethod.
    *
-   * <p>All exceptions are catched and reported via the returned Future.
+   * <p>All exceptions are caught and reported via the returned Future.
    */
   static <T> Future<Response> response(T entity, String location,
       Method headersMethod, Method withLocationMethod,
@@ -87,7 +88,7 @@ public final class StorageHelper {
    * On exception create a Response using failResponseMethod(String exceptionMessage).
    * If that also throws an exception create a failed future.
    *
-   * <p>All exceptions are catched and reported via the returned Future.
+   * <p>All exceptions are caught and reported via the returned Future.
    */
   static <T> Future<Response> response(T value, Method valueMethod, Method failResponseMethod) {
     try {
@@ -121,7 +122,7 @@ public final class StorageHelper {
    * wrapped in a succeeded future.
    * If that also throws an exception create a failed future.
    *
-   * <p>All exceptions are catched and reported via the returned Future.
+   * <p>All exceptions are caught and reported via the returned Future.
    */
   static Future<Response> response(Method responseMethod, Method failResponseMethod) {
     try {
@@ -152,8 +153,9 @@ public final class StorageHelper {
   /**
    * Delete a record from a table.
    *
-   * <p>All exceptions are catched and reported via the asyncResultHandler.
+   * <p>All exceptions are caught and reported via the asyncResultHandler.
    *
+   * @deprecated use {@link PgUtil#deleteById(String, String, Map, Context, Class, Handler)} instead.
    * @param table  where to delete
    * @param id  the primary key of the record to delete
    * @param okapiHeaders  http headers provided by okapi
@@ -164,6 +166,7 @@ public final class StorageHelper {
    * @param deleted
    * @param internalError
    */
+  @Deprecated
   protected static void deleteById(String table, String id,
       Map<String, String> okapiHeaders, Context vertxContext,
       Class<? extends ResponseDelegate> clazz,
@@ -201,8 +204,9 @@ public final class StorageHelper {
   /**
    * Get a record by id.
    *
-   * <p>All exceptions are catched and reported via the asyncResultHandler.
+   * <p>All exceptions are caught and reported via the asyncResultHandler.
    *
+   * @deprecated use {@link PgUtil#getById(String, Class, String, Map, Context, Class, Handler)} instead.
    * @param table  the table that contains the record
    * @param id  the primary key of the record to get
    * @param okapiHeaders  http headers provided by okapi
@@ -211,6 +215,7 @@ public final class StorageHelper {
    *               respond200(T), respond500WithTextPlain(Object).
    * @param asyncResultHandler  where to return the result created using clazz
    */
+  @Deprecated
   protected static <T> void getById(String table, Class<T> clazz, String id,
       Map<String, String> okapiHeaders, Context vertxContext,
       Class<? extends ResponseDelegate> responseDelegateClass,
@@ -288,8 +293,9 @@ public final class StorageHelper {
   /**
    * Post entity to table.
    *
-   * <p>All exceptions are catched and reported via the asyncResultHandler.
+   * <p>All exceptions are caught and reported via the asyncResultHandler.
    *
+   * @deprecated use {@link PgUtil#post(String, Object, Map, Context, Class, Handler)} instead.
    * @param table  table name
    * @param entity  the entity to post. If the id field is missing or null it is set to a random UUID.
    * @param clazz  the ResponseDelegate class created from the RAML file with these methods: headersFor201(),
@@ -297,6 +303,7 @@ public final class StorageHelper {
    *               respond500WithTextPlain(Object).
    * @param asyncResultHandler  where to return the result created using clazz
    */
+  @Deprecated
   protected static <T> void post(String table, T entity,
       Map<String, String> okapiHeaders, Context vertxContext,
       Class<? extends ResponseDelegate> clazz,
@@ -352,8 +359,9 @@ public final class StorageHelper {
   /**
    * Put entity to table.
    *
-   * <p>All exceptions are catched and reported via the asyncResultHandler.
+   * <p>All exceptions are caught and reported via the asyncResultHandler.
    *
+   * @deprecated use {@link PgUtil#put(String, Object, String, Map, Context, Class, Handler)} instead.
    * @param table  table name
    * @param entity  the new entity to store. The id field is set to the id value.
    * @param id  the id value to use for entity
@@ -361,6 +369,7 @@ public final class StorageHelper {
    *               respond204(), respond400WithTextPlain(Object), respond500WithTextPlain(Object).
    * @param asyncResultHandler  where to return the result created using clazz
    */
+  @Deprecated
   protected static <T> void put(String table, T entity, String id,
       Map<String, String> okapiHeaders, Context vertxContext,
       Class<? extends ResponseDelegate> clazz,

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -621,13 +621,13 @@ public class InstanceStorageTest extends TestBase {
   }
 
   @Test
-  public void canDeleteInstanceSourceRecord() throws Exception {
+  public void canDeleteInstanceMarcSourceRecord() throws Exception {
     UUID id = UUID.randomUUID();
     JsonObject instance = smallAngryPlanet(id);
     createInstance(instance);
     assertThat(getSourceRecordFormat(id), is(nullValue()));
 
-    Response putResponse = put(id, marcJson);
+    put(id, marcJson);
     assertThat(getSourceRecordFormat(id), is("MARC-JSON"));
 
     // delete MARC source record
@@ -637,7 +637,26 @@ public class InstanceStorageTest extends TestBase {
     Response deleteResponse = deleteCompleted.get(5, TimeUnit.SECONDS);
     assertThat(deleteResponse.getStatusCode(), is(HttpStatus.HTTP_NO_CONTENT.toInt()));
     assertThat(getSourceRecordFormat(id), is(nullValue()));
+    getMarcJsonNotFound(id);
+  }
 
+  @Test
+  public void canDeleteInstanceSourceRecord() throws Exception {
+    UUID id = UUID.randomUUID();
+    JsonObject instance = smallAngryPlanet(id);
+    createInstance(instance);
+    assertThat(getSourceRecordFormat(id), is(nullValue()));
+
+    put(id, marcJson);
+    assertThat(getSourceRecordFormat(id), is("MARC-JSON"));
+
+    // delete source record
+    CompletableFuture<Response> deleteCompleted = new CompletableFuture<>();
+    client.delete(instancesStorageUrl("/" + id + "/source-record"),
+        StorageTestSuite.TENANT_ID, ResponseHandler.empty(deleteCompleted));
+    Response deleteResponse = deleteCompleted.get(5, TimeUnit.SECONDS);
+    assertThat(deleteResponse.getStatusCode(), is(HttpStatus.HTTP_NO_CONTENT.toInt()));
+    assertThat(getSourceRecordFormat(id), is(nullValue()));
     getMarcJsonNotFound(id);
   }
 


### PR DESCRIPTION
* Speed up PUT /instance-storage/instances/{instanceId} by using PgUtil.put.
* Fix 404 for PUT /instance-storage/instances/{instanceId}.
* Remove duplicated code for deleting source record by using PgUtil.deleteById.
* Update RMB to v23.4.0, needed for PgUtil.put.
* Deprecate StorageHelper methods that have been moved to RMB PgUtil.