### PR TITLE
Implement MODINVSTOR-235: add print by default property to service point

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 ## 14.1.0 Unreleased
 
+* Provides `service-points` interface version 3.1 (MODINVSTOR-235)
+* Adds `staffSlips` to `servicepoint` schema (MODINVSTOR-235)
 * Provides `item-storage` interface version 7.1 (MODINVSTOR-249)
 * Adds `circulationNotes` to `item` schema (MODINVSTOR-249)
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -799,7 +799,7 @@
 
     {
       "id": "service-points",
-      "version": "3.0",
+      "version": "3.1",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/servicepoint.json
+++ b/ramls/servicepoint.json
@@ -30,7 +30,7 @@
       "items": {
         "type": "object",
         "properties": {
-          "staffSlipId": {
+          "id": {
             "type": "string",
             "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
             "description": "The ID of the staff slip"
@@ -42,7 +42,7 @@
         },
         "additionalProperties": false,
         "required": [
-          "staffSlipId",
+          "id",
           "printByDefault"
         ]
       }

--- a/ramls/servicepoint.json
+++ b/ramls/servicepoint.json
@@ -24,6 +24,29 @@
     "pickupLocation": {
       "type": "boolean"
     },
+    "staffSlips": {
+      "type": "array",
+      "description": "List of staff slips for this service point",
+      "items": {
+        "type": "object",
+        "properties": {
+          "staffSlipId": {
+            "type": "string",
+            "pattern": "^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[1-5][0-9a-fA-F]{3}-[89abAB][0-9a-fA-F]{3}-[0-9a-fA-F]{12}$",
+            "description": "The ID of the staff slip"
+          },
+          "printByDefault": {
+            "type": "boolean",
+            "description": "Whether or not to print the staff slip by default"
+          }
+        },
+        "additionalProperties": false,
+        "required": [
+          "staffSlipId",
+          "printByDefault"
+        ]
+      }
+    },
     "metadata": {
       "type": "object",
       "$ref": "raml-util/schemas/metadata.schema",

--- a/src/test/java/org/folio/rest/api/ServicePointTest.java
+++ b/src/test/java/org/folio/rest/api/ServicePointTest.java
@@ -230,8 +230,8 @@ public class ServicePointTest {
     String uuidTrue = UUID.randomUUID().toString();
     String uuidFalse = UUID.randomUUID().toString();
     List<StaffSlip> staffSlips = new ArrayList<>(2);
-    staffSlips.add(new StaffSlip().withStaffSlipId(uuidTrue).withPrintByDefault(Boolean.TRUE));
-    staffSlips.add(new StaffSlip().withStaffSlipId(uuidFalse).withPrintByDefault(Boolean.FALSE));
+    staffSlips.add(new StaffSlip().withId(uuidTrue).withPrintByDefault(Boolean.TRUE));
+    staffSlips.add(new StaffSlip().withId(uuidFalse).withPrintByDefault(Boolean.FALSE));
 
     Response response = createServicePoint(null, "Circ Desk 1", "cd1",
         "Circulation Desk -- Hallway", null, 20, true, staffSlips);
@@ -239,9 +239,9 @@ public class ServicePointTest {
     assertThat(response.getJson().getString("id"), notNullValue());
     assertThat(response.getJson().getString("code"), is("cd1"));
     assertThat(response.getJson().getString("name"), is("Circ Desk 1"));
-    assertThat(response.getJson().getJsonArray("staffSlips").getJsonObject(0).getString("staffSlipId"), is(uuidTrue));
+    assertThat(response.getJson().getJsonArray("staffSlips").getJsonObject(0).getString("id"), is(uuidTrue));
     assertThat(response.getJson().getJsonArray("staffSlips").getJsonObject(0).getBoolean("printByDefault"), is(Boolean.TRUE));
-    assertThat(response.getJson().getJsonArray("staffSlips").getJsonObject(1).getString("staffSlipId"), is(uuidFalse));
+    assertThat(response.getJson().getJsonArray("staffSlips").getJsonObject(1).getString("id"), is(uuidFalse));
     assertThat(response.getJson().getJsonArray("staffSlips").getJsonObject(1).getBoolean("printByDefault"), is(Boolean.FALSE));
   }
 
@@ -254,7 +254,7 @@ public class ServicePointTest {
   
     String uuid = UUID.randomUUID().toString();
     List<StaffSlip> staffSlips = new ArrayList<>(1);
-    staffSlips.add(new StaffSlip().withStaffSlipId(uuid));
+    staffSlips.add(new StaffSlip().withId(uuid));
 
     Response response = createServicePoint(null, "Circ Desk 1", "cd1",
         "Circulation Desk -- Hallway", null, 20, true, staffSlips);
@@ -270,7 +270,7 @@ public class ServicePointTest {
     UUID id = UUID.randomUUID();
     String staffSlipId = UUID.randomUUID().toString();
     List<StaffSlip> staffSlips = new ArrayList<>(2);
-    staffSlips.add(new StaffSlip().withStaffSlipId(staffSlipId).withPrintByDefault(Boolean.TRUE));
+    staffSlips.add(new StaffSlip().withId(staffSlipId).withPrintByDefault(Boolean.TRUE));
     createServicePoint(id, "Circ Desk 1", "cd1",
         "Circulation Desk -- Hallway", null, 20, true, staffSlips);
     JsonObject request = new JsonObject()
@@ -281,7 +281,7 @@ public class ServicePointTest {
             .put("pickupLocation", false)
             .put("staffSlips", new JsonArray()
                 .add(new JsonObject()
-                    .put("staffSlipId", staffSlipId)
+                    .put("id", staffSlipId)
                     .put("printByDefault", Boolean.FALSE)));
     CompletableFuture<Response> updated = new CompletableFuture<>();
     send(servicePointsUrl("/" + id.toString()), HttpMethod.PUT, request.encode(),
@@ -293,7 +293,7 @@ public class ServicePointTest {
     assertThat(getResponse.getJson().getString("code"), is("cd2"));
     assertThat(getResponse.getJson().getString("name"), is("Circ Desk 2")); //should fail
     assertThat(getResponse.getJson().getBoolean("pickupLocation"), is(false));
-    assertThat(getResponse.getJson().getJsonArray("staffSlips").getJsonObject(0).getString("staffSlipId"), is(staffSlipId));
+    assertThat(getResponse.getJson().getJsonArray("staffSlips").getJsonObject(0).getString("id"), is(staffSlipId));
     assertThat(getResponse.getJson().getJsonArray("staffSlips").getJsonObject(0).getBoolean("printByDefault"), is(Boolean.FALSE));
   }
   // --- END TESTS --- //
@@ -328,7 +328,7 @@ public class ServicePointTest {
       JsonArray staffSlips = new JsonArray();
       for (StaffSlip ss : slips) {
         JsonObject staffSlip = new JsonObject();
-        staffSlip.put("staffSlipId", ss.getStaffSlipId());
+        staffSlip.put("id", ss.getId());
         staffSlip.put("printByDefault", ss.getPrintByDefault());
         staffSlips.add(staffSlip);
       }

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -233,7 +233,7 @@ public class StorageTestSuite {
     client.post(storageUrl("/_/tenant"), jo, tenantId,
       ResponseHandler.any(tenantPrepared));
 
-    Response response = tenantPrepared.get(20, TimeUnit.SECONDS);
+    Response response = tenantPrepared.get(30, TimeUnit.SECONDS);
 
     String failureMessage = String.format("Tenant preparation failed: %s: %s",
       response.getStatusCode(), response.getBody());


### PR DESCRIPTION
Added an array `staffSlips` to the service point schema. This array accepts 2 properties, the `id` of the staff slip and `printByDefault` boolean property which will be used to determine the default print behavior for the slip.

Also, increased the reference data timeout to 30 seconds, since this timeout was too low for my dev machine and the builds failed consistently at 20 seconds.