### PR TITLE
Fix searching by barcode and not specific record MODINVSTOR-267 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>23.6.0</raml-module-builder-version>
+    <raml-module-builder-version>23.6.1</raml-module-builder-version>
     <argLine />
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>23.4.0</raml-module-builder-version>
+    <raml-module-builder-version>23.6.0</raml-module-builder-version>
     <argLine />
   </properties>
 

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -807,12 +807,20 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
       "barcode==\"673274826203\" and id<>%s'", UUID.randomUUID()));
 
     client.get(url,
-      StorageTestSuite.TENANT_ID, ResponseHandler.any(searchCompleted));
+      StorageTestSuite.TENANT_ID, ResponseHandler.json(searchCompleted));
 
     Response searchResponse = searchCompleted.get(5, TimeUnit.SECONDS);
 
-    assertThat(searchResponse.getStatusCode(), is(500));
-    assertThat(searchResponse.getBody(), containsString("Unsupported operator '<>'"));
+    assertThat(searchResponse.getStatusCode(), is(200));
+    JsonObject searchBody = searchResponse.getJson();
+
+    JsonArray foundItems = searchBody.getJsonArray("items");
+
+    assertThat(foundItems.size(), is(1));
+    assertThat(searchBody.getInteger("totalRecords"), is(1));
+
+    assertThat(foundItems.getJsonObject(0).getString("barcode"),
+      is("673274826203"));
   }
 
   @Test


### PR DESCRIPTION
When mod-inventory-storage was upgraded to RAML module builder 23.4.0 it lost the ability to search when an item ID does not match a value.

This was [resolved](https://issues.folio.org/browse/CQLPG-86) and released in [cql2pgjson 3.10.0](https://github.com/folio-org/cql2pgjson-java/releases/tag/v3.1.0) [RAML Module Builder 23.6.0](https://github.com/folio-org/raml-module-builder/releases/tag/v23.6.0)

This pull request adds a test to replicate the failing behaviour and the resolution.