### PR TITLE
Make sample service points available for pickup MODINVSTOR-268

### DIFF
--- a/reference-data/service-points/cd1.json
+++ b/reference-data/service-points/cd1.json
@@ -2,5 +2,10 @@
   "id": "3a40852d-49fd-4df2-a1f9-6e2641a6e91f",
   "name": "Circ Desk 1",
   "code": "cd1",
-  "discoveryDisplayName": "Circulation Desk -- Hallway"
+  "discoveryDisplayName": "Circulation Desk -- Hallway",
+  "pickupLocation": true,
+  "holdShelfExpiryPeriod": {
+    "duration": 3,
+    "intervalId": "Weeks"
+  }
 }

--- a/reference-data/service-points/cd2.json
+++ b/reference-data/service-points/cd2.json
@@ -2,5 +2,10 @@
   "id": "c4c90014-c8c9-4ade-8f24-b5e313319f4b",
   "name": "Circ Desk 2",
   "code": "cd2",
-  "discoveryDisplayName": "Circulation Desk -- Back Entrance"
+  "discoveryDisplayName": "Circulation Desk -- Back Entrance",
+  "pickupLocation": true,
+  "holdShelfExpiryPeriod": {
+    "duration": 5,
+    "intervalId": "Days"
+  }
 }


### PR DESCRIPTION
It is frustrating to need to edit the service points to make them available for pickup each time, as this is required in order to create a fulfillable request.

Hence, let's make the reference service points available for pickup.