### PR TITLE
MODINVSTOR-269: barcode==123 does not perform

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -810,8 +810,8 @@
         {
           "fieldName": "barcode",
           "tOps": "ADD",
-          "caseSensitive": false,
-          "removeAccents": true
+          "caseSensitive": true,
+          "removeAccents": false
         },
         {
           "fieldName": "status.name",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -790,8 +790,8 @@
         {
           "fieldName": "barcode",
           "tOps": "ADD",
-          "caseSensitive": false,
-          "removeAccents": true
+          "caseSensitive": true,
+          "removeAccents": false
         },
         {
           "fieldName": "status.name",


### PR DESCRIPTION
Adjust barcode index so SQL generated by {{query=(barcode==123)}} can leverage. Remove lower/accent should be fine since we have full text index (and gin index) on barcode field as well. Performance test (50 requests in 50 seconds) shows that the change can improve {{query-by-barcode}} (~8s to ~100ms) and related parent APIs ({{checkin/out-by-barcode}} for example, ~25s to ~1s) significantly.