### PR TITLE
MODINVSTOR-269: barcode search: drop fulltext index, use item.json schema.

### DIFF
--- a/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
@@ -7,7 +7,6 @@ import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
@@ -23,8 +22,8 @@ import org.folio.rest.persist.Criteria.Limit;
 import org.folio.rest.persist.Criteria.Offset;
 import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.tools.utils.TenantTool;
+import org.folio.util.ResourceUtil;
 import org.z3950.zing.cql.cql2pgjson.CQL2PgJSON;
-import org.z3950.zing.cql.cql2pgjson.FieldException;
 
 /**
  * CRUD for Item.
@@ -32,9 +31,9 @@ import org.z3950.zing.cql.cql2pgjson.FieldException;
 public class ItemStorageAPI implements ItemStorage {
 
   static final String ITEM_TABLE = "item";
-  private static final String ITEM_MATERIALTYPE_VIEW = "items_mt_view";
 
   private static final Logger log = LoggerFactory.getLogger(ItemStorageAPI.class);
+  private static final String ITEM_SCHEMA = ResourceUtil.asString("ramls/item.json");
   private static final String DEFAULT_STATUS_NAME = "Available";
 
   @Validate
@@ -53,7 +52,7 @@ public class ItemStorageAPI implements ItemStorage {
         try {
           PostgresClient postgresClient = StorageHelper.postgresClient(vertxContext, okapiHeaders);
           String[] fieldList = {"*"};
-          CQL2PgJSON cql2pgJson = new CQL2PgJSON("item.jsonb");
+          CQL2PgJSON cql2pgJson = new CQL2PgJSON("item.jsonb", ITEM_SCHEMA);
           CQLWrapper cql = new CQLWrapper(cql2pgJson, query)
             .setLimit(new Limit(limit))
             .setOffset(new Offset(offset));

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -832,12 +832,6 @@
           "removeAccents": true
         }
       ],
-      "fullTextIndex": [
-        {
-          "fieldName": "barcode",
-          "tOps": "ADD"
-        }
-      ],
       "customSnippetPath": "itemHrid.sql"
     }
   ],


### PR DESCRIPTION
For barcode==123 (exact match) and barcode==123* (right truncation) we do
not need the fulltext index, the standard index (b-tree) is sufficient.

Using the item.json schema prevents trying to use a numeric match for barcode.