### PR TITLE
FOLIO-2003 initial module metadata

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -126,6 +126,19 @@ at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker/).
 See the built `target/ModuleDescriptor.json` for the interfaces that this module
 requires and provides, the permissions, and the additional module metadata.
 
+### API documentation
+
+This module's [API documentation](https://dev.folio.org/reference/api/#mod-inventory-storage).
+
+### Code analysis
+
+[SonarQube analysis](https://sonarcloud.io/dashboard?id=org.folio%3Amod-inventory-storage).
+
+### Download and configuration
+
+The built artifacts for this module are available.
+See [configuration](https://dev.folio.org/download/artifacts) for repository access,
+and the [Docker image](https://hub.docker.com/r/folioorg/mod-inventory-storage/).
 
 # Appendix 1 - Docker Information
 

--- a/README.MD
+++ b/README.MD
@@ -114,10 +114,18 @@ The guide and other [documentation](doc) for this module.
 
 Other [modules](https://dev.folio.org/source-code/#server-side).
 
+Other FOLIO Developer documentation is at [dev.folio.org](https://dev.folio.org/)
+
+### Issue tracker
+
 See project [MODINVSTOR](https://issues.folio.org/browse/MODINVSTOR)
 at the [FOLIO issue tracker](https://dev.folio.org/guidelines/issue-tracker/).
 
-Other FOLIO Developer documentation is at [dev.folio.org](https://dev.folio.org/)
+### ModuleDescriptor
+
+See the built `target/ModuleDescriptor.json` for the interfaces that this module
+requires and provides, the permissions, and the additional module metadata.
+
 
 # Appendix 1 - Docker Information
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1824,7 +1824,11 @@
       ]
     }
   ],
-    "launchDescriptor": {
+  "metadata": {
+    "containerMemory": "512",
+    "databaseConnection": "true"
+  },
+  "launchDescriptor": {
     "dockerImage": "${artifactId}:${version}",
     "dockerArgs": {
       "HostConfig": { "PortBindings": { "8081/tcp":  [{ "HostPort": "%p" }] } }


### PR DESCRIPTION
Declare additional module metadata in ModuleDescriptor: containerMemory, databaseConnection

[FOLIO-2003](https://issues.folio.org/browse/FOLIO-2003)

Also link README section "Additional information" to dockerhub, sonarqube, apidocs
