### PR TITLE
Remove null from reference and sample data

### DIFF
--- a/reference-data/instance-statuses/notyetassigned.json
+++ b/reference-data/instance-statuses/notyetassigned.json
@@ -1,6 +1,6 @@
 {
   "id": "f5cc2ab6-bb92-4cab-b83f-5a3d09261a41",
-  "code": "null",
+  "code": "none",
   "name": "Not yet assigned",
   "source": "folio"
 }

--- a/sample-data/holdingsrecords/aba-holdingsrecord3.json
+++ b/sample-data/holdingsrecords/aba-holdingsrecord3.json
@@ -26,6 +26,6 @@
  } ],
  "holdingsStatementsForIndexes" : [ ],
  "holdingsStatementsForSupplements" : [ ],
- "statisticalCodeIds" : [ null ],
+ "statisticalCodeIds" : [ ],
  "holdingsItems" : [ ]
 } 

--- a/sample-data/instances/american-journal-of-medicine.json
+++ b/sample-data/instances/american-journal-of-medicine.json
@@ -41,5 +41,5 @@
   "instanceTypeId" : "6312d172-f0cf-40f6-b27d-9fa8feaf332f",
   "physicalDescriptions" : [ "v., ill. 27 cm." ],
   "languages" : [ "eng" ],
-  "notes" : [ "Print subscription cancelled by Dec. 2016.", "May 1988-: \"A Yorke medical. Also known as the Green journal", "Publisher: Excerpta Medica, 2008-; New York, NY : Elsevier Inc. 2013-", "Supplements issued irregularly, 1982.", "Official journal of the Association of Professors of Medicine 2005-", "Indexed quinquennially in: American journal of medicine 5 year cumulative index", null ]
+  "notes" : [ "Print subscription cancelled by Dec. 2016.", "May 1988-: \"A Yorke medical. Also known as the Green journal", "Publisher: Excerpta Medica, 2008-; New York, NY : Elsevier Inc. 2013-", "Supplements issued irregularly, 1982.", "Official journal of the Association of Professors of Medicine 2005-", "Indexed quinquennially in: American journal of medicine 5 year cumulative index" ]
 }


### PR DESCRIPTION
While investigating mod-inventory-storage API test failures, it was noticed that 
- two sample data records use "null" values that break JSON schema validation. 
-- null statisticalCodeId. See https://github.com/folio-org/mod-inventory-storage/blob/v15.5.1/sample-data/holdingsrecords/aba-holdingsrecord3.json#L29
-- null notes. See https://github.com/folio-org/mod-inventory-storage/blob/v15.5.1/sample-data/instances/american-journal-of-medicine.json#L44
- one reference data uses "null" as instance status code.
-- null instance status code. See https://github.com/folio-org/mod-inventory-storage/blob/v15.5.1/reference-data/instance-statuses/notyetassigned.json#L3

This PR **removed** null values from sample data and **changed "null" to "none"** in reference data.