### PR TITLE
Make Craig and Piotr Code Owners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @marcjohnson-kint @kostyantyn-kh @mrdpopov @OleksiiKuzminov @nielserik @adamdickmeiss @julianladisch @mtraneis
+*  @marcjohnson-kint @kostyantyn-kh @mrdpopov @craigmcnally @piotr-kalashuk @OleksiiKuzminov @nielserik @Igor-Gorchakov


### PR DESCRIPTION
As the ThunderJet team are conducting some work in inventory, the technical leads of this team should be added to the code owners, in order to facilitate expediting of changes when necessary