### PR TITLE
MODINVSTOR-324 Inventory App: Assign tags to holdings record

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -35,7 +35,7 @@
     },
     {
       "id": "holdings-storage",
-      "version": "3.0",
+      "version": "3.1",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/examples/holdingsrecord_get.json
+++ b/ramls/examples/holdingsrecord_get.json
@@ -11,5 +11,10 @@
       "statement": "Line 2",
       "note": "Note to line2"
     }
-  ]
+  ],
+  "tags" : {
+    "tagList" : [
+      "important"
+    ]
+  }
 }

--- a/ramls/examples/holdingsrecords_get.json
+++ b/ramls/examples/holdingsrecords_get.json
@@ -13,7 +13,12 @@
           "statement": "Line 2",
           "note": "Note to line2"
         }
-      ]
+      ],
+      "tags" : {
+        "tagList" : [
+          "important"
+        ]
+      }
     },
     {
       "id": "807084d2-1b6c-4448-a566-d3d9ebfd1c08",
@@ -28,7 +33,11 @@
           "statement": "Line 2",
           "note": "Note to line2"
         }
-      ]
+      ],"tags" : {
+      "tagList" : [
+        "important"
+        ]
+      }
     }
   ],
   "totalRecords": 2

--- a/ramls/holdings-storage.raml
+++ b/ramls/holdings-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Holdings Storage
-version: v3.0
+version: v3.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/holdingsrecord.json
+++ b/ramls/holdingsrecord.json
@@ -236,6 +236,12 @@
       "folio:linkToField": "id",
       "folio:includedElement": "instances.0"
     },
+    "tags": {
+      "description": "arbitrary tags associated with this holding",
+      "id": "tags",
+      "type": "object",
+      "$ref": "raml-util/schemas/tags.schema"
+    },
     "metadata": {
       "type": "object",
       "$ref": "raml-util/schemas/metadata.schema",

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -13,6 +13,7 @@ import static org.folio.rest.support.http.InterfaceUrls.materialTypesStorageUrl;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.assertThat;
 
 import java.net.HttpURLConnection;
@@ -44,6 +45,8 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
+  private static final String TAG_VALUE = "test-tag";
+  public static final String NEW_TEST_TAG = "new test tag";
   private static UUID mainLibraryLocationId;
   private static UUID annexLibraryLocationId;
 
@@ -100,7 +103,8 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     JsonObject holding = holdingsClient.create(new HoldingRequestBuilder()
       .withId(holdingId)
       .forInstance(instanceId)
-      .withPermanentLocation(mainLibraryLocationId)).getJson();
+      .withPermanentLocation(mainLibraryLocationId)
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getJson();
 
     assertThat(holding.getString("id"), is(holdingId.toString()));
     assertThat(holding.getString("instanceId"), is(instanceId.toString()));
@@ -115,6 +119,11 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(holdingFromGet.getString("id"), is(holdingId.toString()));
     assertThat(holdingFromGet.getString("instanceId"), is(instanceId.toString()));
     assertThat(holdingFromGet.getString("permanentLocationId"), is(mainLibraryLocationId.toString()));
+
+    List<String> tags = holdingFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
+
+    assertThat(tags.size(), is(1));
+    assertThat(tags, hasItem(TAG_VALUE));
   }
 
   @Test
@@ -131,7 +140,8 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     IndividualResource holdingResponse = holdingsClient.create(new HoldingRequestBuilder()
       .withId(null)
       .forInstance(instanceId)
-      .withPermanentLocation(mainLibraryLocationId));
+      .withPermanentLocation(mainLibraryLocationId)
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE))));
 
     JsonObject holding = holdingResponse.getJson();
 
@@ -150,6 +160,11 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(holdingFromGet.getString("id"), is(holdingId.toString()));
     assertThat(holdingFromGet.getString("instanceId"), is(instanceId.toString()));
     assertThat(holdingFromGet.getString("permanentLocationId"), is(mainLibraryLocationId.toString()));
+
+    List<String> tags = holdingFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
+
+    assertThat(tags.size(), is(1));
+    assertThat(tags, hasItem(TAG_VALUE));
   }
 
   @Test
@@ -199,6 +214,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     holdingsClient.replace(holdingId, new HoldingRequestBuilder()
       .withId(holdingId)
       .forInstance(instanceId)
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))
       .withPermanentLocation(mainLibraryLocationId));
 
     Response getResponse = holdingsClient.getById(holdingId);
@@ -210,6 +226,11 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(holdingFromGet.getString("id"), is(holdingId.toString()));
     assertThat(holdingFromGet.getString("instanceId"), is(instanceId.toString()));
     assertThat(holdingFromGet.getString("permanentLocationId"), is(mainLibraryLocationId.toString()));
+
+    List<String> tags = holdingFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
+
+    assertThat(tags.size(), is(1));
+    assertThat(tags, hasItem(TAG_VALUE));
   }
 
   @Test
@@ -254,12 +275,14 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     IndividualResource holdingResource = holdingsClient.create(new HoldingRequestBuilder()
       .forInstance(instanceId)
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))
       .withPermanentLocation(mainLibraryLocationId));
 
     UUID holdingId = holdingResource.getId();
 
     JsonObject replacement = holdingResource.copyJson()
-      .put("permanentLocationId", annexLibraryLocationId.toString());
+      .put("permanentLocationId", annexLibraryLocationId.toString())
+      .put("tags", new JsonObject().put("tagList", new JsonArray().add(NEW_TEST_TAG)));
 
     holdingsClient.replace(holdingId, replacement);
 
@@ -272,6 +295,11 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(holdingFromGet.getString("id"), is(holdingId.toString()));
     assertThat(holdingFromGet.getString("instanceId"), is(instanceId.toString()));
     assertThat(holdingFromGet.getString("permanentLocationId"), is(annexLibraryLocationId.toString()));
+
+    List<String> tags = holdingFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
+
+    assertThat(tags.size(), is(1));
+    assertThat(tags, hasItem(NEW_TEST_TAG));
   }
 
   @Test
@@ -323,7 +351,8 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     UUID thirdHoldingId = holdingsClient.create(new HoldingRequestBuilder()
       .forInstance(thirdInstanceId)
-      .withPermanentLocation(mainLibraryLocationId)).getId();
+      .withPermanentLocation(mainLibraryLocationId)
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getId();
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 

--- a/src/test/java/org/folio/rest/support/builders/HoldingRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/HoldingRequestBuilder.java
@@ -1,30 +1,34 @@
 package org.folio.rest.support.builders;
 
-import io.vertx.core.json.JsonObject;
-
 import java.util.UUID;
+
+import io.vertx.core.json.JsonObject;
 
 public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder {
 
   private final UUID id;
   private final UUID instanceId;
   private final UUID permanentLocationId;
+  private JsonObject tags;
 
   public HoldingRequestBuilder() {
     this(
       null,
       null,
-      UUID.randomUUID());
+      UUID.randomUUID(),
+      null);
   }
 
   private HoldingRequestBuilder(
     UUID id,
     UUID instanceId,
-    UUID permanentLocationId) {
+    UUID permanentLocationId,
+    JsonObject tags) {
 
     this.id = id;
     this.instanceId = instanceId;
     this.permanentLocationId = permanentLocationId;
+    this.tags = tags;
   }
 
   @Override
@@ -34,6 +38,7 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     put(request, "id", id);
     put(request, "instanceId", instanceId);
     put(request, "permanentLocationId", permanentLocationId);
+    put(request, "tags", tags);
 
     return request;
   }
@@ -42,20 +47,31 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     return new HoldingRequestBuilder(
       this.id,
       this.instanceId,
-      permanentLocationId);
+      permanentLocationId,
+      this.tags);
   }
 
   public HoldingRequestBuilder forInstance(UUID instanceId) {
     return new HoldingRequestBuilder(
       this.id,
       instanceId,
-      this.permanentLocationId);
+      this.permanentLocationId,
+      this.tags);
   }
 
   public HoldingRequestBuilder withId(UUID id) {
     return new HoldingRequestBuilder(
       id,
       this.instanceId,
-      this.permanentLocationId);
+      this.permanentLocationId,
+      this.tags);
+  }
+
+  public HoldingRequestBuilder withTags(JsonObject tags) {
+    return new HoldingRequestBuilder(
+      this.id,
+      this.instanceId,
+      this.permanentLocationId,
+      tags);
   }
 }

--- a/src/test/java/org/folio/rest/support/builders/JsonRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/JsonRequestBuilder.java
@@ -16,4 +16,10 @@ public class JsonRequestBuilder {
       request.put(property, value.toString());
     }
   }
+
+  protected void put(JsonObject request, String property, JsonObject value) {
+    if(value != null) {
+      request.put(property, value);
+    }
+  }
 }


### PR DESCRIPTION
## Purpose
Due to https://issues.folio.org/browse/MODINVSTOR-324 we would like to introduce tags for holdingentities.

## Approach
* update holding model with tags
* update holding interfaces versions
* update tests