### PR TITLE
Update to RMB 26.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>26.3.0</raml-module-builder-version>
+    <raml-module-builder-version>26.3.1</raml-module-builder-version>
     <argLine />
   </properties>
 


### PR DESCRIPTION
RMB 26.3.1 has a fix that should "restore" to acceptable performance
for full-text queries. RMB-455