### PR TITLE
[MODINVSTOR-318] Respond 422 on post holdings type with duplicate name

### DIFF
--- a/src/main/java/org/folio/rest/impl/HoldingsTypeAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsTypeAPI.java
@@ -212,7 +212,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
 
   private Future<String> saveHoldingsType(PostgresClient pgClient, HoldingsType entity) {
     Future<String> future = Future.future();
-    pgClient.save(REFERENCE_TABLE, entity, future);
+    pgClient.save(REFERENCE_TABLE, entity.getId(), entity, future);
     return future;
   }
 
@@ -228,6 +228,12 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
       return PostHoldingsTypesResponse
         .respond422WithApplicationJson(new Errors().withErrors(singletonList(error)));
     }
+
+    String msg = PgExceptionUtil.badRequestMessage(t);
+    if (msg != null) {
+      return PostHoldingsTypesResponse.respond400WithTextPlain(msg);
+    }
+
     return PostHoldingsTypesResponse.respond500WithTextPlain(
       "Internal Server Error, Please contact System Administrator or try again");
   }

--- a/src/main/java/org/folio/rest/impl/HoldingsTypeAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsTypeAPI.java
@@ -220,7 +220,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
     if (PgExceptionUtil.isUniqueViolation(t)) {
       Error error = new Error()
         .withCode("name.duplicate")
-        .withMessage("Cannot create entity with not unique name")
+        .withMessage("Cannot create entity; name is not unique")
         .withParameters(singletonList(new Parameter()
           .withKey("fieldLabel")
           .withValue("name")));

--- a/src/test/java/org/folio/rest/api/HoldingsTypeTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsTypeTest.java
@@ -1,0 +1,62 @@
+package org.folio.rest.api;
+
+import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
+import static org.folio.rest.support.http.InterfaceUrls.holdingsTypesUrl;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.net.MalformedURLException;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.rest.support.Response;
+import org.folio.rest.support.ResponseHandler;
+import org.folio.rest.support.http.ResourceClient;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class HoldingsTypeTest extends TestBase {
+
+  private static ResourceClient holdingsTypeClient;
+
+  @BeforeClass
+  public static void beforeAll() {
+    holdingsTypeClient = ResourceClient.forHoldingsType(client);
+  }
+
+  @Test
+  public void cannotCreateHoldingsTypeWithDuplicateName()
+    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+
+    JsonObject holdingsType = new JsonObject()
+      .put("name", "Custom")
+      .put("source", "folio");
+
+    holdingsTypeClient.create(holdingsType);
+
+    CompletableFuture<Response> postCompleted = new CompletableFuture<>();
+    client.post(holdingsTypesUrl(""), holdingsType, TENANT_ID, ResponseHandler.json(postCompleted));
+
+    Response response = postCompleted.get(5, TimeUnit.SECONDS);
+    assertThat(response.getStatusCode(), is(422));
+
+    JsonArray errors = response.getJson().getJsonArray("errors");
+    assertThat(errors.size(), is(1));
+
+    JsonObject error = errors.getJsonObject(0);
+    assertThat(error.getString("code"), is("name.duplicate"));
+    assertThat(error.getString("message"), is("Cannot create entity with not unique name"));
+
+    JsonArray errorParameters = error.getJsonArray("parameters");
+    assertThat(errorParameters.size(), is(1));
+
+    JsonObject parameter = errorParameters.getJsonObject(0);
+    assertThat(parameter.getString("key"), is("fieldLabel"));
+    assertThat(parameter.getString("value"), is("name"));
+  }
+}

--- a/src/test/java/org/folio/rest/api/HoldingsTypeTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsTypeTest.java
@@ -50,7 +50,7 @@ public class HoldingsTypeTest extends TestBase {
 
     JsonObject error = errors.getJsonObject(0);
     assertThat(error.getString("code"), is("name.duplicate"));
-    assertThat(error.getString("message"), is("Cannot create entity with not unique name"));
+    assertThat(error.getString("message"), is("Cannot create entity; name is not unique"));
 
     JsonArray errorParameters = error.getJsonArray("parameters");
     assertThat(errorParameters.size(), is(1));

--- a/src/test/java/org/folio/rest/api/ReferenceTablesTest.java
+++ b/src/test/java/org/folio/rest/api/ReferenceTablesTest.java
@@ -5,8 +5,25 @@
  */
 package org.folio.rest.api;
 
-import static org.folio.rest.api.TestBase.client;
-import static org.folio.rest.support.http.InterfaceUrls.*;
+import static org.folio.rest.support.http.InterfaceUrls.alternativeTitleTypesUrl;
+import static org.folio.rest.support.http.InterfaceUrls.callNumberTypesUrl;
+import static org.folio.rest.support.http.InterfaceUrls.classificationTypesUrl;
+import static org.folio.rest.support.http.InterfaceUrls.contributorNameTypesUrl;
+import static org.folio.rest.support.http.InterfaceUrls.contributorTypesUrl;
+import static org.folio.rest.support.http.InterfaceUrls.electronicAccessRelationshipsUrl;
+import static org.folio.rest.support.http.InterfaceUrls.holdingsNoteTypesUrl;
+import static org.folio.rest.support.http.InterfaceUrls.holdingsTypesUrl;
+import static org.folio.rest.support.http.InterfaceUrls.identifierTypesUrl;
+import static org.folio.rest.support.http.InterfaceUrls.illPoliciesUrl;
+import static org.folio.rest.support.http.InterfaceUrls.instanceFormatsUrl;
+import static org.folio.rest.support.http.InterfaceUrls.instanceNoteTypesUrl;
+import static org.folio.rest.support.http.InterfaceUrls.instanceStatusesUrl;
+import static org.folio.rest.support.http.InterfaceUrls.instanceTypesUrl;
+import static org.folio.rest.support.http.InterfaceUrls.itemNoteTypesUrl;
+import static org.folio.rest.support.http.InterfaceUrls.modesOfIssuanceUrl;
+import static org.folio.rest.support.http.InterfaceUrls.natureOfContentTermsUrl;
+import static org.folio.rest.support.http.InterfaceUrls.statisticalCodeTypesUrl;
+import static org.folio.rest.support.http.InterfaceUrls.statisticalCodesUrl;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
@@ -782,7 +799,8 @@ public class ReferenceTablesTest extends TestBase {
 
     entity.put("id", entityId);
     Response postResponse1 = createReferenceRecord(path, entity);
-    if (Arrays.asList("/electronic-access-relationships", "/instance-statuses", "/modes-of-issuance", "/statistical-code-types").contains(path)) {
+    if (Arrays.asList("/electronic-access-relationships", "/instance-statuses",
+      "/modes-of-issuance", "/statistical-code-types", "/holdings-types").contains(path)) {
       assertThat(postResponse1.getStatusCode(), is(422));
     } else {
       assertThat(postResponse1.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));

--- a/src/test/java/org/folio/rest/support/http/ResourceClient.java
+++ b/src/test/java/org/folio/rest/support/http/ResourceClient.java
@@ -35,6 +35,11 @@ public class ResourceClient {
       "holdingsRecords");
   }
 
+  public static ResourceClient forHoldingsType(HttpClient client) {
+    return new ResourceClient(client, InterfaceUrls::holdingsTypesUrl,
+      "holdingsTypeRecords");
+  }
+
   public static ResourceClient forInstances(HttpClient client) {
     return new ResourceClient(client, InterfaceUrls::instancesStorageUrl,
       "instances");


### PR DESCRIPTION
## Purpose
Resolves: MODINVSTOR-318

Controlled Vocab Duplicate Issues (Holdings Type and Call Number type) Change server response for errors during loan type creation.
## Links
https://issues.folio.org/browse/MODINVSTOR-318