### PR TITLE
MODINVSTOR-348: Calculate and persist effective location for item.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "item-storage",
-      "version": "7.5",
+      "version": "7.6",
       "handlers": [
         {
           "methods": ["GET"],

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,12 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>pl.pragmatists</groupId>
+      <artifactId>JUnitParams</artifactId>
+      <version>1.1.1</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
       <version>3.5.4</version>

--- a/ramls/holdingsrecord.json
+++ b/ramls/holdingsrecord.json
@@ -179,7 +179,7 @@
     },
     "copyNumber": {
       "type": "string",
-      "description": "Item/Piece ID (usually barcode) for systems that do not use item records. Ability to designate the copy number if institution chooses to use copy numbers."
+      "description": "Item/Piece ID (usually barcode) for systems that do not use item records. Ability to designate the copy number if institution chooses to use copy numbers."
     },
     "numberOfItems": {
       "type": "string",

--- a/ramls/item-storage.raml
+++ b/ramls/item-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Item Storage
-version: v7.5
+version: v7.6
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -202,7 +202,7 @@
     },
     "effectiveLocationId": {
       "type": "string",
-      "description": "The current home location for the item. Read only, it is automatically updated to be the first defined value from item.temporaryLocationId, item.permanentLocationId, holdingsRecord.temporaryLocationId, holdingsRecord.permanentLocationId.",
+      "description": "Read only current home location for the item.",
       "$ref": "uuid.json",
       "readonly": true
     },

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -200,6 +200,11 @@
     "temporaryLocationId": {
       "type": "string"
     },
+    "effectiveLocationId": {
+      "type": "string",
+      "description": "The effective location is used by FOLIO and other integrated systems to know the current home location for the item (read only, derived from locations on HoldingsRecord and Item)",
+      "readonly": true
+    },
     "electronicAccess": {
       "type": "array",
       "items": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -202,7 +202,7 @@
     },
     "effectiveLocationId": {
       "type": "string",
-      "description": "The effective location is used by FOLIO and other integrated systems to know the current home location for the item (read only, derived from locations on HoldingsRecord and Item)",
+      "description": "The current home location for the item. Read only, it is automatically updated to be the first defined value from item.temporaryLocationId, item.permanentLocationId, holdingsRecord.temporaryLocationId, holdingsRecord.permanentLocationId.",
       "$ref": "uuid.json",
       "readonly": true
     },

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -203,6 +203,7 @@
     "effectiveLocationId": {
       "type": "string",
       "description": "The effective location is used by FOLIO and other integrated systems to know the current home location for the item (read only, derived from locations on HoldingsRecord and Item)",
+      "$ref": "uuid.json",
       "readonly": true
     },
     "electronicAccess": {

--- a/src/main/java/org/folio/rest/support/ResponseUtil.java
+++ b/src/main/java/org/folio/rest/support/ResponseUtil.java
@@ -15,4 +15,14 @@ public final class ResponseUtil {
     return response != null
       && response.getStatus() == Response.Status.CREATED.getStatusCode();
   }
+
+  public static <T> Response copyResponseWithNewEntity(Response originalResponse, T newEntity) {
+    if (originalResponse == null) {
+      return null;
+    }
+
+    return Response.fromResponse(originalResponse)
+      .entity(newEntity)
+      .build();
+  }
 }

--- a/src/main/java/org/folio/rest/support/ResponseUtil.java
+++ b/src/main/java/org/folio/rest/support/ResponseUtil.java
@@ -1,0 +1,18 @@
+package org.folio.rest.support;
+
+import javax.ws.rs.core.Response;
+
+/**
+ * Utility methods for Response object.
+ */
+public final class ResponseUtil {
+
+  private ResponseUtil() {
+    throw new UnsupportedOperationException("Do not instantiate");
+  }
+
+  public static boolean hasCreatedStatus(Response response) {
+    return response != null
+      && response.getStatus() == Response.Status.CREATED.getStatusCode();
+  }
+}

--- a/src/main/resources/templates/db_scripts/itemEffectiveLocation.sql
+++ b/src/main/resources/templates/db_scripts/itemEffectiveLocation.sql
@@ -26,7 +26,7 @@ AS $$
   END;
   $$ LANGUAGE 'plpgsql';
 
--- Set Item effective location in case insert or update of temporary/permanentLocationId or holdingsRecordId properties
+-- Set Item effective location when inserting or updating an Item.
 CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.update_effective_location_on_item_update() RETURNS trigger
 AS $$
   declare

--- a/src/main/resources/templates/db_scripts/itemEffectiveLocation.sql
+++ b/src/main/resources/templates/db_scripts/itemEffectiveLocation.sql
@@ -1,0 +1,85 @@
+-- Returns item effectiveLocationId.
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.calculate_item_effective_location(hr_perm_location text,
+           hr_temp_location text, itm_perm_location text, itm_temp_location text) RETURNS jsonb
+AS $$
+  begin
+   RETURN ('"' || coalesce(itm_temp_location, itm_perm_location, hr_temp_location, hr_perm_location) || '"')::jsonb;
+  END;
+  $$ LANGUAGE 'plpgsql';
+
+-- Updates item effective location property in case holding record permanent or temp location has changed.
+-- only items that do not have permanent or temp location set will be updated.
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.update_effective_location_on_holding_update() RETURNS trigger
+AS $$
+  begin
+	  -- null-safe comparison of OLD vs NEW location
+	  -- have to update effectiveLocation only if related fields have been changed
+	  if (OLD.jsonb->>'permanentLocationId' is distinct from NEW.jsonb->>'permanentLocationId'
+	  	  OR OLD.jsonb->>'temporaryLocationId' is distinct from NEW.jsonb->>'temporaryLocationId') THEN
+	  	  UPDATE ${myuniversity}_${mymodule}.item
+	  	  SET jsonb = jsonb_set(jsonb,
+		  					  '{effectiveLocationId}',
+		  					   ${myuniversity}_${mymodule}.calculate_item_effective_location(
+	  							   new.jsonb->>'permanentLocationId',
+	  							   new.jsonb->>'temporaryLocationId',
+	  							   jsonb->>'permanentLocationId',
+	  							   jsonb->>'temporaryLocationId')
+	  			      )
+	  	  WHERE holdingsrecordid = new.id
+	  	  -- if item's either temp or perm location is not null then we don't need to update it's effective location
+	  	  -- as item's location has more priority than holding's one.
+	  	  AND jsonb->>'permanentLocationId' is null AND jsonb->>'temporaryLocationId' is null;
+	  end if;
+   RETURN NEW;
+  END;
+  $$ LANGUAGE 'plpgsql';
+
+-- Set Item effective location in case insert or update of temporary/permanentLocationId or holdingsRecordId properties
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.update_effective_location_on_item_update() RETURNS trigger
+AS $$
+	declare
+		hr_perm_location text;
+		hr_temp_location text;
+		effective_location jsonb;
+	begin
+
+	  -- skip the trigger in case item's sensitive fields were not updated.
+	  if (TG_OP = 'UPDATE' and OLD.jsonb->>'holdingsRecordId' IS NOT DISTINCT FROM NEW.jsonb->>'holdingsRecordId'
+	      AND OLD.jsonb->>'temporaryLocationId' IS NOT DISTINCT FROM NEW.jsonb->>'temporaryLocationId'
+	      AND OLD.jsonb->>'permanentLocationId' IS NOT DISTINCT FROM NEW.jsonb->>'permanentLocationId') then
+	     return new;
+	  end if;
+
+		-- we need to retrieve holding_record temp and perm location only if item location fields are empty
+		-- otherwise it does not make any affect as item location takes precedence over holding location
+		if(NEW.jsonb ->> 'temporaryLocationId' is null and NEW.jsonb ->> 'permanentLocationId' is null) then
+			select jsonb->>'temporaryLocationId', jsonb->>'permanentLocationId'
+			 into hr_temp_location, hr_perm_location
+			from ${myuniversity}_${mymodule}.holdings_record
+			 where id::text = new.jsonb->>'holdingsRecordId' limit 1;
+		else
+		  -- initialize to nulls as they won't change final result
+			hr_perm_location = null;
+			hr_temp_location = null;
+		end if;
+		new.jsonb = jsonb_set(new.jsonb,
+		                      '{effectiveLocationId}',
+		                      ${myuniversity}_${mymodule}.calculate_item_effective_location(
+									            hr_perm_location,
+									            hr_temp_location,
+									            new.jsonb->>'permanentLocationId',
+									            new.jsonb->>'temporaryLocationId')
+									        );
+	  return new;
+	END;
+$$ LANGUAGE 'plpgsql';
+
+DROP TRIGGER IF EXISTS update_effective_location_for_items ON ${myuniversity}_${mymodule}.holdings_record;
+-- should be after update trigger, will allow item trigger to fetch up-to-date locations from holding
+create trigger update_effective_location_for_items after update
+on ${myuniversity}_${mymodule}.holdings_record for each row execute procedure ${myuniversity}_${mymodule}.update_effective_location_on_holding_update();
+
+
+DROP TRIGGER IF EXISTS update_effective_location ON ${myuniversity}_${mymodule}.item;
+create trigger update_effective_location before insert or update
+on ${myuniversity}_${mymodule}.item for each row execute procedure ${myuniversity}_${mymodule}.update_effective_location_on_item_update();

--- a/src/main/resources/templates/db_scripts/populateEffectiveLocationForExistingItems.sql
+++ b/src/main/resources/templates/db_scripts/populateEffectiveLocationForExistingItems.sql
@@ -1,0 +1,15 @@
+UPDATE ${myuniversity}_${mymodule}.item AS it
+SET jsonb = jsonb_set(jsonb, '{effectiveLocationId}',
+	CASE
+	  -- Check item's locations first
+		WHEN jsonb->'temporaryLocationId' IS NOT NULL THEN jsonb->'temporaryLocationId'
+		WHEN jsonb->'permanentLocationId' IS NOT NULL THEN jsonb->'permanentLocationId'
+		-- If no item's locations present - check holding's locations, and return an empty string by default
+		ELSE (
+			SELECT COALESCE(hr.jsonb->'temporaryLocationId', hr.jsonb->'permanentLocationId', to_jsonb(''::text))
+		    FROM ${myuniversity}_${mymodule}.holdings_record AS hr
+			WHERE hr.id = it.holdingsrecordid LIMIT 1
+		)
+	END
+)
+WHERE jsonb->'effectiveLocationId' IS NULL;

--- a/src/main/resources/templates/db_scripts/populateEffectiveLocationForExistingItems.sql
+++ b/src/main/resources/templates/db_scripts/populateEffectiveLocationForExistingItems.sql
@@ -6,4 +6,4 @@ SET	jsonb = JSONB_SET(it.jsonb,
 			hr.jsonb->'temporaryLocationId', hr.jsonb->'permanentLocationId')
 )
 FROM ${myuniversity}_${mymodule}.holdings_record AS hr
-WHERE it.jsonb->'effectiveLocationId' IS NULL AND hr.id = it.holdingsrecordid;
+WHERE hr.id = it.holdingsrecordid;

--- a/src/main/resources/templates/db_scripts/populateEffectiveLocationForExistingItems.sql
+++ b/src/main/resources/templates/db_scripts/populateEffectiveLocationForExistingItems.sql
@@ -1,30 +1,9 @@
--- 1st step - update items with holding records linked.
-UPDATE  ${myuniversity}_${mymodule}.item AS it
-SET jsonb =
-	CASE
-		WHEN it.jsonb->'temporaryLocationId' IS NOT NULL
-			THEN jsonb_set(it.jsonb, '{effectiveLocationId}', it.jsonb->'temporaryLocationId')
-		WHEN it.jsonb->'permanentLocationId' IS NOT NULL
-			THEN jsonb_set(it.jsonb, '{effectiveLocationId}', it.jsonb->'permanentLocationId')
-		WHEN hr.jsonb->'temporaryLocationId' IS NOT NULL
-			THEN jsonb_set(it.jsonb, '{effectiveLocationId}', hr.jsonb->'temporaryLocationId')
-		WHEN hr.jsonb->'permanentLocationId' IS NOT NULL
-			THEN jsonb_set(it.jsonb, '{effectiveLocationId}', hr.jsonb->'permanentLocationId')
-		-- do nothing if all locations are nulls
-		ELSE it.jsonb
-	END
-FROM  ${myuniversity}_${mymodule}.holdings_record AS hr
+UPDATE ${myuniversity}_${mymodule}.item AS it
+-- Since holdings_record.permanentLocationId and item.holdingsRecordId are required there can not be a NULL value
+SET	jsonb = JSONB_SET(it.jsonb,
+			'{effectiveLocationId}',
+			COALESCE(it.jsonb->'temporaryLocationId', it.jsonb->'permanentLocationId',
+			hr.jsonb->'temporaryLocationId', hr.jsonb->'permanentLocationId')
+)
+FROM ${myuniversity}_${mymodule}.holdings_record AS hr
 WHERE it.jsonb->'effectiveLocationId' IS NULL AND hr.id = it.holdingsrecordid;
-
--- 2nd step - update 'orphaned' items.
-UPDATE  ${myuniversity}_${mymodule}.item it
-SET jsonb =
-	CASE
-		WHEN it.jsonb->'temporaryLocationId' IS NOT NULL
-			THEN jsonb_set(it.jsonb, '{effectiveLocationId}', it.jsonb->'temporaryLocationId')
-		WHEN it.jsonb->'permanentLocationId' IS NOT NULL
-			THEN jsonb_set(it.jsonb, '{effectiveLocationId}', it.jsonb->'permanentLocationId')
-		-- do nothing if all locations are nulls
-		ELSE it.jsonb
-	END
-WHERE it.jsonb->'effectiveLocationId' IS NULL AND it.holdingsrecordid IS NULL;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -734,6 +734,7 @@
     {
       "tableName": "item",
       "withMetadata": true,
+      "fromModuleVersion": "17.1.0",
       "foreignKeys": [
         {
           "fieldName": "holdingsRecordId",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -810,6 +810,12 @@
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": true
+        },
+        {
+          "fieldName": "effectiveLocationId",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
         }
       ],
       "ginIndex": [

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -859,6 +859,11 @@
       "run": "after",
       "snippetPath": "itemEffectiveLocation.sql",
       "fromModuleVersion": "17.1.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "populateEffectiveLocationForExistingItems.sql",
+      "fromModuleVersion": "17.1.0"
     }
   ]
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -846,5 +846,12 @@
       ],
       "customSnippetPath": "itemHrid.sql"
     }
+  ],
+  "scripts": [
+    {
+      "run": "after",
+      "snippetPath": "itemEffectiveLocation.sql",
+      "fromModuleVersion": "17.1.0"
+    }
   ]
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -815,7 +815,7 @@
           "fieldName": "effectiveLocationId",
           "tOps": "ADD",
           "caseSensitive": false,
-          "removeAccents": true
+          "removeAccents": false
         }
       ],
       "ginIndex": [

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -4,12 +4,6 @@ import static org.folio.rest.support.JsonObjectMatchers.hasSoleMessgeContaining;
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.loanTypesStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locCampusStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locInstitutionStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locLibraryStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locationsStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.materialTypesStorageUrl;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -37,7 +31,6 @@ import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -47,28 +40,8 @@ import io.vertx.core.json.JsonObject;
 public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   private static final String TAG_VALUE = "test-tag";
   public static final String NEW_TEST_TAG = "new test tag";
-  private static UUID mainLibraryLocationId;
-  private static UUID annexLibraryLocationId;
 
-  @BeforeClass
-  public static void beforeAny() {
-    StorageTestSuite.deleteAll(itemsStorageUrl(""));
-    StorageTestSuite.deleteAll(holdingsStorageUrl(""));
-    StorageTestSuite.deleteAll(instancesStorageUrl(""));
-
-    StorageTestSuite.deleteAll(locationsStorageUrl(""));
-    StorageTestSuite.deleteAll(locLibraryStorageUrl(""));
-    StorageTestSuite.deleteAll(locCampusStorageUrl(""));
-    StorageTestSuite.deleteAll(locInstitutionStorageUrl(""));
-
-    StorageTestSuite.deleteAll(materialTypesStorageUrl(""));
-    StorageTestSuite.deleteAll(loanTypesStorageUrl(""));
-
-    LocationsTest.createLocUnits(true);
-    mainLibraryLocationId = LocationsTest.createLocation(null, "Main Library (H)", "H/M");
-    annexLibraryLocationId = LocationsTest.createLocation(null, "Annex Library (H)", "H/A");
-
-  }
+  // see also @BeforeClass TestBaseWithInventoryUtil.beforeAny()
 
   @Before
   public void beforeEach() {

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -11,8 +11,6 @@ import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageBatchInstancesUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.loanTypesStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.materialTypesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.natureOfContentTermsUrl;
 import static org.folio.util.StringUtil.urlEncode;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -55,11 +53,8 @@ import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.builders.ItemRequestBuilder;
-import org.folio.rest.support.client.LoanTypesClient;
-import org.folio.rest.support.client.MaterialTypesClient;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -74,31 +69,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   private static final String INSTANCES_KEY = "instances";
   private static final String TOTAL_RECORDS_KEY = "totalRecords";
   private static final String TAG_VALUE = "test-tag";
-  private static UUID mainLibraryLocationId;
-  private static UUID annexLocationId;
-  private static UUID bookMaterialTypeId;
-  private static UUID canCirculateLoanTypeId;
   private Set<String> natureOfContentIdsToRemoveAfterTest = new HashSet<>();
 
-  @BeforeClass
-  public static void beforeAny() throws Exception {
-
-    StorageTestSuite.deleteAll(itemsStorageUrl(""));
-    StorageTestSuite.deleteAll(holdingsStorageUrl(""));
-    StorageTestSuite.deleteAll(instancesStorageUrl(""));
-
-    StorageTestSuite.deleteAll(materialTypesStorageUrl(""));
-    StorageTestSuite.deleteAll(loanTypesStorageUrl(""));
-
-    MaterialTypesClient materialTypesClient = new MaterialTypesClient(client, materialTypesStorageUrl(""));
-    bookMaterialTypeId = UUID.fromString(materialTypesClient.create("book"));
-
-    mainLibraryLocationId = LocationsTest.createLocation(null, "Main Library (Inst)", "I/M");
-    annexLocationId = LocationsTest.createLocation(null, "Annex Library (Inst)", "I/A");
-
-    LoanTypesClient loanTypesClient = new LoanTypesClient(client, loanTypesStorageUrl(""));
-    canCirculateLoanTypeId = UUID.fromString(loanTypesClient.create("Can Circulate"));
-  }
+  // see also @BeforeClass TestBaseWithInventoryUtil.beforeAny()
 
   @Before
   public void beforeEach() {
@@ -1098,7 +1071,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     createHoldings(new HoldingRequestBuilder()
       .withId(annexSmallAngryHoldingId)
-      .withPermanentLocation(annexLocationId)
+      .withPermanentLocation(annexLibraryLocationId)
       .forInstance(smallAngryPlanetInstanceId)
       .create());
 
@@ -1676,22 +1649,6 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     tags.add("test-tag");
     return createInstanceRequest(id, "TEST", "Interesting Times",
       identifiers, contributors, UUID_INSTANCE_TYPE, tags);
-  }
-
-  private void createItem(JsonObject itemToCreate)
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException {
-
-    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
-
-    client.post(itemsStorageUrl(""), itemToCreate, TENANT_ID,
-      json(createCompleted));
-
-    Response response = createCompleted.get(2, SECONDS);
-
-    assertThat(String.format("Create item failed: %s", response.getBody()),
-      response.getStatusCode(), is(201));
   }
 
   private NatureOfContentTerm createNatureOfContentTerm(final String name)

--- a/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
@@ -86,6 +86,7 @@ public class ItemEffectiveLocationTest extends TestBaseWithInventoryUtil {
   @After
   public void checkIdsAfterEach() {
     StorageTestSuite.checkForMismatchedIDs("item");
+    StorageTestSuite.checkForMismatchedIDs("holdings_record");
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
@@ -1,0 +1,355 @@
+package org.folio.rest.api;
+
+import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.loanTypesStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.locCampusStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.locInstitutionStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.locLibraryStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.locationsStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.materialTypesStorageUrl;
+import static org.folio.util.StringUtil.urlEncode;
+import static org.hamcrest.CoreMatchers.hasItems;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.jaxrs.model.Items;
+import org.folio.rest.support.IndividualResource;
+import org.folio.rest.support.Response;
+import org.folio.rest.support.ResponseHandler;
+import org.folio.rest.support.client.LoanTypesClient;
+import org.folio.rest.support.client.MaterialTypesClient;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import io.vertx.core.json.JsonObject;
+
+/**
+ * Test cases to verify effectiveLocationId property calculation that implemented
+ * as two triggers for holdings_record and item tables (see itemEffectiveLocation.sql)
+ */
+public class ItemEffectiveLocationTest extends TestBaseWithInventoryUtil {
+  private static String journalMaterialTypeID;
+  private static String canCirculateLoanTypeID;
+  private static UUID mainLibraryLocationId;
+  private static UUID annexLibraryLocationId;
+  private static UUID onlineLocationId;
+  private static UUID secondFloorLocationId;
+
+  @BeforeClass
+  public static void beforeAny() throws Exception {
+    StorageTestSuite.deleteAll(itemsStorageUrl(""));
+    StorageTestSuite.deleteAll(holdingsStorageUrl(""));
+    StorageTestSuite.deleteAll(instancesStorageUrl(""));
+
+    StorageTestSuite.deleteAll(materialTypesStorageUrl(""));
+    StorageTestSuite.deleteAll(locationsStorageUrl(""));
+    StorageTestSuite.deleteAll(locLibraryStorageUrl(""));
+    StorageTestSuite.deleteAll(locCampusStorageUrl(""));
+    StorageTestSuite.deleteAll(locInstitutionStorageUrl(""));
+    StorageTestSuite.deleteAll(loanTypesStorageUrl(""));
+
+    MaterialTypesClient materialTypesClient = new MaterialTypesClient(client, materialTypesStorageUrl(""));
+    journalMaterialTypeID = materialTypesClient.create("journal");
+    canCirculateLoanTypeID = new LoanTypesClient(client, loanTypesStorageUrl("")).create("Can Circulate");
+
+    LocationsTest.createLocUnits(true);
+    mainLibraryLocationId = LocationsTest.createLocation(null, "Main Library (Item)", "It/M");
+    annexLibraryLocationId = LocationsTest.createLocation(null, "Annex Library (item)", "It/A");
+    onlineLocationId = LocationsTest.createLocation(null, "Online (item)", "It/O");
+    secondFloorLocationId = LocationsTest.createLocation(null, "Second Floor (item)", "It/SF");
+  }
+
+  @Before
+  public void beforeEach() {
+    StorageTestSuite.deleteAll(itemsStorageUrl(""));
+    StorageTestSuite.deleteAll(holdingsStorageUrl(""));
+    StorageTestSuite.deleteAll(instancesStorageUrl(""));
+  }
+
+  @After
+  public void checkIdsAfterEach() {
+    StorageTestSuite.checkForMismatchedIDs("item");
+  }
+
+  @Test
+  public void canCalculateEffectiveLocationOnItemInsertWithPermLocationOnHolding() throws Exception {
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
+    Item itemToCreate = buildItem(holdingsRecordId, null, null);
+
+    IndividualResource createdItem = createItem(itemToCreate);
+    assertTrue(createdItem.getJson().containsKey("effectiveLocationId"));
+
+    Item fetchedItem = getItem(itemToCreate.getId());
+    assertEquals(fetchedItem.getEffectiveLocationId(), mainLibraryLocationId.toString());
+  }
+
+  @Test
+  public void canCalculateEffectiveLocationOnItemInsertWithTempLocationOnHolding() throws Exception {
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId,
+      annexLibraryLocationId);
+    Item itemToCreate = buildItem(holdingsRecordId, null, null);
+
+    IndividualResource createdItem = createItem(itemToCreate);
+    assertTrue(createdItem.getJson().containsKey("effectiveLocationId"));
+
+    Item fetchedItem = getItem(itemToCreate.getId());
+    assertEquals(fetchedItem.getEffectiveLocationId(), annexLibraryLocationId.toString());
+  }
+
+  @Test
+  public void canCalculateEffectiveLocationOnItemInsertWithPermLocationOnItem() throws Exception {
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId,
+      annexLibraryLocationId);
+    Item itemToCreate = buildItem(holdingsRecordId, null, onlineLocationId);
+
+    IndividualResource createdItem = createItem(itemToCreate);
+    assertTrue(createdItem.getJson().containsKey("effectiveLocationId"));
+
+    Item fetchedItem = getItem(itemToCreate.getId());
+    assertEquals(fetchedItem.getEffectiveLocationId(), onlineLocationId.toString());
+  }
+
+  @Test
+  public void canCalculateEffectiveLocationOnItemInsertWithTempLocationOnItem() throws Exception {
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId,
+      annexLibraryLocationId);
+    Item itemToCreate = buildItem(holdingsRecordId, secondFloorLocationId,
+      onlineLocationId);
+
+    IndividualResource createdItem = createItem(itemToCreate);
+    assertTrue(createdItem.getJson().containsKey("effectiveLocationId"));
+
+    Item fetchedItem = getItem(itemToCreate.getId());
+    assertEquals(fetchedItem.getEffectiveLocationId(), secondFloorLocationId.toString());
+  }
+
+  @Test
+  public void canCalculateEffectiveLocationOnHoldingUpdate() throws Exception {
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
+
+    final Item[] itemsToCreate = {
+      buildItem(holdingsRecordId, null, null),
+      buildItem(holdingsRecordId, null, null),
+      buildItem(holdingsRecordId, null, null)
+    };
+
+    for (Item item : itemsToCreate) {
+      IndividualResource createdItem = createItem(item);
+      assertTrue(createdItem.getJson().containsKey("effectiveLocationId"));
+    }
+
+    JsonObject holding = holdingsClient.getById(holdingsRecordId).getJson();
+    holding.put("temporaryLocationId", secondFloorLocationId.toString());
+    holdingsClient.replace(holdingsRecordId, holding);
+
+    for (Item item : itemsToCreate) {
+      Item fetchedItem = getItem(item.getId());
+      assertEquals(fetchedItem.getEffectiveLocationId(), secondFloorLocationId.toString());
+    }
+  }
+
+  @Test
+  public void canCalculateEffectiveLocationOnHoldingRemoveTempLocation() throws Exception {
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId, annexLibraryLocationId);
+
+    final Item[] itemsToCreate = {
+      buildItem(holdingsRecordId, null, null),
+      buildItem(holdingsRecordId, null, null),
+      buildItem(holdingsRecordId, null, null)
+    };
+
+    for (Item item : itemsToCreate) {
+      IndividualResource createdItem = createItem(item);
+      assertTrue(createdItem.getJson().containsKey("effectiveLocationId"));
+    }
+
+    JsonObject holding = holdingsClient.getById(holdingsRecordId).getJson();
+    holding.remove("temporaryLocationId");
+    holdingsClient.replace(holdingsRecordId, holding);
+
+    for (Item item : itemsToCreate) {
+      Item fetchedItem = getItem(item.getId());
+      assertEquals(fetchedItem.getEffectiveLocationId(), mainLibraryLocationId.toString());
+    }
+  }
+
+  @Test
+  public void canCalculateEffectiveLocationOnHoldingUpdateWhenSomeItemsHasLocation() throws Exception {
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
+
+    Item itemWithPermLocation = buildItem(holdingsRecordId, null, onlineLocationId);
+    Item itemNoLocation = buildItem(holdingsRecordId, null, null);
+    Item itemWithTempLocation = buildItem(holdingsRecordId, annexLibraryLocationId, null);
+
+    createItem(itemWithPermLocation);
+    createItem(itemNoLocation);
+    createItem(itemWithTempLocation);
+
+    JsonObject holding = holdingsClient.getById(holdingsRecordId).getJson();
+    holding.put("temporaryLocationId", secondFloorLocationId.toString());
+    holdingsClient.replace(holdingsRecordId, holding);
+
+    // fetch items
+    Item itemWithPermLocationFetched = getItem(itemWithPermLocation.getId());
+    Item itemNoLocationFetched = getItem(itemNoLocation.getId());
+    Item itemWithTempLocationFetched = getItem(itemWithTempLocation.getId());
+
+    // Assert that itemWithPermLocationFetched was not updated
+    assertEquals(itemWithPermLocationFetched.getEffectiveLocationId(), onlineLocationId.toString());
+
+    // Assert that itemNoLocationFetched was updated
+    assertEquals(itemNoLocationFetched.getEffectiveLocationId(), secondFloorLocationId.toString());
+
+    // Assert that itemWithPermLocationFetched was not updated
+    assertEquals(itemWithTempLocationFetched.getEffectiveLocationId(), annexLibraryLocationId.toString());
+
+  }
+
+  @Test
+  public void canCalculateEffectiveLocationOnItemPermLocationUpdate() throws Exception {
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId, annexLibraryLocationId);
+
+    Item item = buildItem(holdingsRecordId, null, null);
+    createItem(item);
+
+    Item itemFetched = getItem(item.getId());
+    assertEquals(itemFetched.getEffectiveLocationId(), annexLibraryLocationId.toString());
+
+    itemsClient.replace(UUID.fromString(itemFetched.getId()),
+      JsonObject.mapFrom(itemFetched).copy()
+        .put("permanentLocationId", onlineLocationId.toString())
+    );
+
+    assertEquals(getItem(item.getId()).getEffectiveLocationId(), onlineLocationId.toString());
+  }
+
+  @Test
+  public void canCalculateEffectiveLocationOnItemTempLocationUpdate() throws Exception {
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId, annexLibraryLocationId);
+
+    Item item = buildItem(holdingsRecordId, null, null);
+    createItem(item);
+
+    Item itemFetched = getItem(item.getId());
+    assertEquals(itemFetched.getEffectiveLocationId(), annexLibraryLocationId.toString());
+
+    itemsClient.replace(UUID.fromString(itemFetched.getId()),
+      JsonObject.mapFrom(itemFetched).copy()
+        .put("temporaryLocationId", onlineLocationId.toString())
+    );
+
+    assertEquals(getItem(item.getId()).getEffectiveLocationId(), onlineLocationId.toString());
+  }
+
+  @Test
+  public void canCalculateEffectiveLocationOnItemAllLocationUpdate() throws Exception {
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId, annexLibraryLocationId);
+
+    Item item = buildItem(holdingsRecordId, null, null);
+    createItem(item);
+
+    Item itemFetched = getItem(item.getId());
+    assertEquals(itemFetched.getEffectiveLocationId(), annexLibraryLocationId.toString());
+
+    itemsClient.replace(UUID.fromString(itemFetched.getId()),
+      JsonObject.mapFrom(itemFetched).copy()
+        .put("temporaryLocationId", onlineLocationId.toString())
+        .put("permanentLocationId", secondFloorLocationId.toString())
+    );
+
+    assertEquals(getItem(item.getId()).getEffectiveLocationId(), onlineLocationId.toString());
+  }
+
+  @Test
+  public void canSearchItemByEffectiveLocation() throws Exception {
+    UUID holdingsWithPermLocation = createInstanceAndHolding(mainLibraryLocationId);
+    UUID holdingsWithTempLocation = createInstanceAndHolding(mainLibraryLocationId, annexLibraryLocationId);
+
+    Item itemWithHoldingPermLocation = buildItem(holdingsWithPermLocation, null, null);
+    Item itemWithHoldingTempLocation = buildItem(holdingsWithTempLocation, null, null);
+    Item itemWithTempLocation = buildItem(holdingsWithPermLocation, onlineLocationId, null);
+    Item itemWithPermLocation = buildItem(holdingsWithTempLocation, null, secondFloorLocationId);
+    Item itemWithAllLocation = buildItem(holdingsWithTempLocation, onlineLocationId, secondFloorLocationId);
+
+    Item[] itemsToCreate = {itemWithHoldingPermLocation, itemWithHoldingTempLocation,
+      itemWithTempLocation, itemWithPermLocation, itemWithAllLocation};
+
+    for (Item item : itemsToCreate) {
+      IndividualResource createdItem = createItem(item);
+      assertTrue(createdItem.getJson().containsKey("effectiveLocationId"));
+    }
+
+    Items mainLibraryItems = findItems("effectiveLocationId=" + mainLibraryLocationId);
+    Items annexLibraryItems = findItems("effectiveLocationId=" + annexLibraryLocationId);
+    Items onlineLibraryItems = findItems("effectiveLocationId=" + onlineLocationId);
+    Items secondFloorLibraryItems = findItems("effectiveLocationId=" + secondFloorLocationId);
+
+    assertEquals(1, mainLibraryItems.getTotalRecords().intValue());
+    assertThat(mainLibraryItems.getItems().get(0).getId(), is(itemWithHoldingPermLocation.getId()));
+
+    assertEquals(1, annexLibraryItems.getTotalRecords().intValue());
+    assertThat(annexLibraryItems.getItems().get(0).getId(), is(itemWithHoldingTempLocation.getId()));
+
+    assertEquals(2, onlineLibraryItems.getTotalRecords().intValue());
+
+    assertThat(onlineLibraryItems.getItems()
+        .stream()
+        .map(Item::getId)
+        .collect(Collectors.toList()),
+      hasItems(itemWithTempLocation.getId(), itemWithAllLocation.getId()));
+
+    assertEquals(1, secondFloorLibraryItems.getTotalRecords().intValue());
+    assertThat(secondFloorLibraryItems.getItems().get(0).getId(), is(itemWithPermLocation.getId()));
+  }
+
+  private Item buildItem(UUID holdingsRecordId,
+                         UUID tempLocation, UUID permLocation) {
+    JsonObject itemToCreate = new JsonObject();
+
+    itemToCreate.put("id", UUID.randomUUID().toString());
+    itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
+    itemToCreate.put("barcode", Long.toString(new Random().nextLong()));
+    itemToCreate.put("status", new JsonObject().put("name", "Available"));
+    itemToCreate.put("materialTypeId", journalMaterialTypeID);
+    itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
+    if (tempLocation != null) {
+      itemToCreate.put("temporaryLocationId", tempLocation.toString());
+    }
+    if (permLocation != null) {
+      itemToCreate.put("permanentLocationId", permLocation.toString());
+    }
+
+    return itemToCreate.mapTo(Item.class);
+  }
+
+  private Item getItem(String id) throws Exception {
+    return itemsClient.getById(UUID.fromString(id)).getJson().mapTo(Item.class);
+  }
+
+  private Items findItems(String searchQuery) throws Exception {
+    CompletableFuture<Response> searchCompleted = new CompletableFuture<>();
+
+    client.get(itemsStorageUrl("?query=") + urlEncode(searchQuery),
+      StorageTestSuite.TENANT_ID, ResponseHandler.json(searchCompleted));
+
+    return searchCompleted.get(5, TimeUnit.SECONDS).getJson()
+      .mapTo(Items.class);
+  }
+
+  private IndividualResource createItem(Item item) throws Exception {
+    return itemsClient.create(JsonObject.mapFrom(item));
+  }
+}

--- a/src/test/java/org/folio/rest/api/ItemEffectiveLocationTestDataProvider.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveLocationTestDataProvider.java
@@ -1,0 +1,134 @@
+package org.folio.rest.api;
+
+import static org.folio.rest.api.TestBaseWithInventoryUtil.ANNEX_LIBRARY_LOCATION;
+import static org.folio.rest.api.TestBaseWithInventoryUtil.FOURTH_FLOOR_LOCATION;
+import static org.folio.rest.api.TestBaseWithInventoryUtil.MAIN_LIBRARY_LOCATION;
+import static org.folio.rest.api.TestBaseWithInventoryUtil.ONLINE_LOCATION;
+import static org.folio.rest.api.TestBaseWithInventoryUtil.SECOND_FLOOR_LOCATION;
+import static org.folio.rest.api.TestBaseWithInventoryUtil.THIRD_FLOOR_LOCATION;
+import static org.folio.rest.api.TestBaseWithInventoryUtil.annexLibraryLocationId;
+import static org.folio.rest.api.TestBaseWithInventoryUtil.fourthFloorLocationId;
+import static org.folio.rest.api.TestBaseWithInventoryUtil.mainLibraryLocationId;
+import static org.folio.rest.api.TestBaseWithInventoryUtil.onlineLocationId;
+import static org.folio.rest.api.TestBaseWithInventoryUtil.secondFloorLocationId;
+import static org.folio.rest.api.TestBaseWithInventoryUtil.thirdFloorLocationId;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+/**
+ * Parameter provider for ItemEffectiveLocationTest.class.
+ */
+public class ItemEffectiveLocationTestDataProvider {
+  private static Map<UUID, String> locationIdToNameMap = buildLocationIdToNameMap();
+
+  @SuppressWarnings("unused")
+  public static List<PermTemp[]> canCalculateEffectiveLocationOnHoldingUpdateParams() {
+    List<PermTemp[]> params = new ArrayList<>();
+
+    PermTemp[] itemLocationsList = {
+      new PermTemp(null, null),
+      new PermTemp(null, mainLibraryLocationId),
+      new PermTemp(mainLibraryLocationId, null),
+      new PermTemp(mainLibraryLocationId, annexLibraryLocationId),
+    };
+
+    PermTemp[] holdingsStartLocationsList = {
+      new PermTemp(onlineLocationId, null),
+      new PermTemp(onlineLocationId, secondFloorLocationId),
+    };
+    PermTemp[] holdingsEndLocationsList = {
+      new PermTemp(onlineLocationId, null),
+      new PermTemp(onlineLocationId, secondFloorLocationId),
+      new PermTemp(thirdFloorLocationId, null),
+      new PermTemp(thirdFloorLocationId, fourthFloorLocationId),
+    };
+
+    for (PermTemp itemLocations : itemLocationsList) {
+      for (PermTemp holdingStartLocations : holdingsStartLocationsList) {
+        for (PermTemp holdingEndLocations : holdingsEndLocationsList) {
+          params.add(new PermTemp[]{itemLocations, holdingStartLocations, holdingEndLocations});
+        }
+      }
+    }
+    return params;
+  }
+
+  @SuppressWarnings("unused")
+  public static List<PermTemp[]> canCalculateEffectiveLocationOnItemUpdateParams() {
+    List<PermTemp[]> parameters = new ArrayList<>();
+    PermTemp[] holdingsLocationsList = {
+      new PermTemp(mainLibraryLocationId, null),
+      new PermTemp(mainLibraryLocationId, annexLibraryLocationId),
+    };
+    PermTemp[] itemStartLocationsList = {
+      new PermTemp(null, null),
+      new PermTemp(null, onlineLocationId),
+      new PermTemp(onlineLocationId, null),
+      new PermTemp(onlineLocationId, secondFloorLocationId),
+    };
+    PermTemp[] itemEndLocationsList = {
+      new PermTemp(null, null),
+      new PermTemp(null, onlineLocationId),
+      new PermTemp(onlineLocationId, null),
+      new PermTemp(onlineLocationId, secondFloorLocationId),
+      new PermTemp(null, thirdFloorLocationId),
+      new PermTemp(thirdFloorLocationId, null),
+      new PermTemp(thirdFloorLocationId, fourthFloorLocationId),
+    };
+
+    for (PermTemp holdingLocations : holdingsLocationsList) {
+      for (PermTemp itemStartLocations : itemStartLocationsList) {
+        for (PermTemp itemEndLocations : itemEndLocationsList) {
+          parameters.add(new PermTemp[]{holdingLocations, itemStartLocations, itemEndLocations});
+        }
+      }
+    }
+    return parameters;
+  }
+
+  private static Map<UUID, String> buildLocationIdToNameMap() {
+    HashMap<UUID, String> idToNameMap = new HashMap<>();
+
+    idToNameMap.put(mainLibraryLocationId, MAIN_LIBRARY_LOCATION);
+    idToNameMap.put(annexLibraryLocationId, ANNEX_LIBRARY_LOCATION);
+    idToNameMap.put(onlineLocationId, ONLINE_LOCATION);
+    idToNameMap.put(secondFloorLocationId, SECOND_FLOOR_LOCATION);
+    idToNameMap.put(thirdFloorLocationId, THIRD_FLOOR_LOCATION);
+    idToNameMap.put(fourthFloorLocationId, FOURTH_FLOOR_LOCATION);
+
+    return idToNameMap;
+  }
+
+  /**
+   * Store a permanent location UUID and a temporary location UUID.
+   */
+  public static class PermTemp {
+    /**
+     * permanent location UUID
+     */
+    UUID perm;
+    /**
+     * temporary location UUID
+     */
+    UUID temp;
+
+    /**
+     * @param perm permanent location UUID
+     * @param temp temporary location UUID
+     */
+    PermTemp(UUID perm, UUID temp) {
+      this.perm = perm;
+      this.temp = temp;
+    }
+
+    @Override
+    public String toString() {
+      return locationIdToNameMap.get(perm) + ", " + locationIdToNameMap.get(temp);
+    }
+  }
+
+}

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -5,17 +5,13 @@ import static org.folio.rest.support.JsonObjectMatchers.validationErrorMatches;
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.loanTypesStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locCampusStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locInstitutionStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locLibraryStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locationsStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.materialTypesStorageUrl;
 import static org.folio.util.StringUtil.urlEncode;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -31,17 +27,18 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.jaxrs.model.Items;
 import org.folio.rest.support.AdditionalHttpStatusCodes;
+import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.JsonArrayHelper;
 import org.folio.rest.support.JsonErrorResponse;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
-import org.folio.rest.support.client.LoanTypesClient;
-import org.folio.rest.support.client.MaterialTypesClient;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import io.vertx.core.json.JsonArray;
@@ -51,39 +48,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
   private static final String TAG_VALUE = "test-tag";
 
-  private static String journalMaterialTypeID;
-  private static String bookMaterialTypeID;
-  private static String canCirculateLoanTypeID;
-  private static UUID mainLibraryLocationId;
-  private static UUID annexLibraryLocationId;
-
-  @BeforeClass
-  public static void beforeAny()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
-
-    StorageTestSuite.deleteAll(itemsStorageUrl(""));
-    StorageTestSuite.deleteAll(holdingsStorageUrl(""));
-    StorageTestSuite.deleteAll(instancesStorageUrl(""));
-
-    StorageTestSuite.deleteAll(materialTypesStorageUrl(""));
-    StorageTestSuite.deleteAll(locationsStorageUrl(""));
-    StorageTestSuite.deleteAll(locLibraryStorageUrl(""));
-    StorageTestSuite.deleteAll(locCampusStorageUrl(""));
-    StorageTestSuite.deleteAll(locInstitutionStorageUrl(""));
-    StorageTestSuite.deleteAll(loanTypesStorageUrl(""));
-
-    MaterialTypesClient materialTypesClient = new MaterialTypesClient(client, materialTypesStorageUrl(""));
-    journalMaterialTypeID = materialTypesClient.create("journal");
-    bookMaterialTypeID = materialTypesClient.create("book");
-    canCirculateLoanTypeID = new LoanTypesClient(client, loanTypesStorageUrl("")).create("Can Circulate");
-
-    LocationsTest.createLocUnits(true);
-    mainLibraryLocationId = LocationsTest.createLocation(null, "Main Library (Item)", "It/M");
-    annexLibraryLocationId = LocationsTest.createLocation(null, "Annex Library (item)", "It/A");
-  }
+  // see also @BeforeClass TestBaseWithInventoryUtil.beforeAny()
 
   @Before
   public void beforeEach() {
@@ -960,6 +925,48 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  public void canSearchItemByEffectiveLocation() throws Exception {
+    UUID holdingsWithPermLocation = createInstanceAndHolding(mainLibraryLocationId);
+    UUID holdingsWithTempLocation = createInstanceAndHolding(mainLibraryLocationId, annexLibraryLocationId);
+
+    Item itemWithHoldingPermLocation = buildItem(holdingsWithPermLocation, null, null);
+    Item itemWithHoldingTempLocation = buildItem(holdingsWithTempLocation, null, null);
+    Item itemWithTempLocation = buildItem(holdingsWithPermLocation, onlineLocationId, null);
+    Item itemWithPermLocation = buildItem(holdingsWithTempLocation, null, secondFloorLocationId);
+    Item itemWithAllLocation = buildItem(holdingsWithTempLocation, secondFloorLocationId, onlineLocationId);
+
+    Item[] itemsToCreate = {itemWithHoldingPermLocation, itemWithHoldingTempLocation,
+      itemWithTempLocation, itemWithPermLocation, itemWithAllLocation};
+
+    for (Item item : itemsToCreate) {
+      IndividualResource createdItem = createItem(item);
+      assertTrue(createdItem.getJson().containsKey("effectiveLocationId"));
+    }
+
+    Items mainLibraryItems = findItems("effectiveLocationId=" + mainLibraryLocationId);
+    Items annexLibraryItems = findItems("effectiveLocationId=" + annexLibraryLocationId);
+    Items onlineLibraryItems = findItems("effectiveLocationId=" + onlineLocationId);
+    Items secondFloorLibraryItems = findItems("effectiveLocationId=" + secondFloorLocationId);
+
+    assertEquals(1, mainLibraryItems.getTotalRecords().intValue());
+    assertThat(mainLibraryItems.getItems().get(0).getId(), is(itemWithHoldingPermLocation.getId()));
+
+    assertEquals(1, annexLibraryItems.getTotalRecords().intValue());
+    assertThat(annexLibraryItems.getItems().get(0).getId(), is(itemWithHoldingTempLocation.getId()));
+
+    assertEquals(2, onlineLibraryItems.getTotalRecords().intValue());
+
+    assertThat(onlineLibraryItems.getItems()
+        .stream()
+        .map(Item::getId)
+        .collect(Collectors.toList()),
+      hasItems(itemWithTempLocation.getId(), itemWithAllLocation.getId()));
+
+    assertEquals(1, secondFloorLibraryItems.getTotalRecords().intValue());
+    assertThat(secondFloorLibraryItems.getItems().get(0).getId(), is(itemWithPermLocation.getId()));
+  }
+
+  @Test
   public void cannotSearchForItemsUsingADefaultField()
     throws MalformedURLException,
     InterruptedException,
@@ -1094,22 +1101,6 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     return getCompleted.get(5, TimeUnit.SECONDS);
   }
 
-  private void createItem(JsonObject itemToCreate)
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
-
-    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
-
-    client.post(itemsStorageUrl(""), itemToCreate, StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(createCompleted));
-
-    Response response = createCompleted.get(2, TimeUnit.SECONDS);
-
-    assertThat(response.getStatusCode(), is(201));
-  }
-
   private JsonObject createItemRequest(
       UUID id,
       UUID holdingsRecordId,
@@ -1166,6 +1157,16 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
   private JsonObject interestingTimes(UUID itemId, UUID holdingsRecordId) {
     return createItemRequest(itemId, holdingsRecordId, "56454543534");
+  }
+
+  private Items findItems(String searchQuery) throws Exception {
+    CompletableFuture<Response> searchCompleted = new CompletableFuture<>();
+
+    client.get(itemsStorageUrl("?query=") + urlEncode(searchQuery),
+      StorageTestSuite.TENANT_ID, ResponseHandler.json(searchCompleted));
+
+    return searchCompleted.get(5, TimeUnit.SECONDS).getJson()
+      .mapTo(Items.class);
   }
 
   private JsonObject addTags(String tagValue, UUID holdingsRecordId) {

--- a/src/test/java/org/folio/rest/api/LoanTypeTest.java
+++ b/src/test/java/org/folio/rest/api/LoanTypeTest.java
@@ -5,14 +5,8 @@ import static java.net.HttpURLConnection.HTTP_CREATED;
 import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
 import static java.net.HttpURLConnection.HTTP_NO_CONTENT;
 import static java.net.HttpURLConnection.HTTP_OK;
-import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.loanTypesStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locCampusStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locInstitutionStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locLibraryStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locationsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.materialTypesStorageUrl;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -32,7 +26,6 @@ import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.http.ResourceClient;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import io.vertx.core.Handler;
@@ -53,22 +46,8 @@ public class LoanTypeTest extends TestBaseWithInventoryUtil {
   private static String postRequestCirculate = "{\"name\": \"Can circulate\"}";
   private static String postRequestCourse    = "{\"name\": \"Course reserve\"}";
   private static String putRequest  = "{\"name\": \"Reading room\"}";
-  private static UUID mainLibraryLocationId;
 
-  @BeforeClass
-  public static void beforeAny() {
-    StorageTestSuite.deleteAll(itemsStorageUrl(""));
-    StorageTestSuite.deleteAll(holdingsStorageUrl(""));
-    StorageTestSuite.deleteAll(instancesStorageUrl(""));
-
-    StorageTestSuite.deleteAll(locationsStorageUrl(""));
-    StorageTestSuite.deleteAll(locLibraryStorageUrl(""));
-    StorageTestSuite.deleteAll(locCampusStorageUrl(""));
-    StorageTestSuite.deleteAll(locInstitutionStorageUrl(""));
-
-    LocationsTest.createLocUnits(true);
-    mainLibraryLocationId = LocationsTest.createLocation(null, "Main Library (Loan)", "Lo/M");
-  }
+  // see also @BeforeClass TestBaseWithInventoryUtil.beforeAny()
 
   @Before
   public void beforeEach()

--- a/src/test/java/org/folio/rest/api/LocationsTest.java
+++ b/src/test/java/org/folio/rest/api/LocationsTest.java
@@ -31,7 +31,6 @@ import org.folio.rest.support.client.LoanTypesClient;
 import org.folio.rest.support.client.MaterialTypesClient;
 import org.junit.Assert;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
 import io.vertx.core.Handler;
@@ -53,8 +52,6 @@ import io.vertx.core.logging.LoggerFactory;
 public class LocationsTest extends TestBaseWithInventoryUtil {
   private static Logger logger = LoggerFactory.getLogger(LocationUnitTest.class);
   private static final String SUPPORTED_CONTENT_TYPE_JSON_DEF = "application/json";
-  private String canCirculateLoanTypeID;
-  private String journalMaterialTypeID;
   private static UUID instID;
   private static UUID campID;
   private static UUID libID;
@@ -79,17 +76,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
     }
   }
 
-  @BeforeClass
-  public static void beforeAny()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
-
-    StorageTestSuite.deleteAll(itemsStorageUrl(""));
-    StorageTestSuite.deleteAll(holdingsStorageUrl(""));
-    StorageTestSuite.deleteAll(instancesStorageUrl(""));
-  }
+  // see also @BeforeClass TestBaseWithInventoryUtil.beforeAny()
 
   @Before
   public void beforeEach()

--- a/src/test/java/org/folio/rest/api/MaterialTypeTest.java
+++ b/src/test/java/org/folio/rest/api/MaterialTypeTest.java
@@ -28,33 +28,12 @@ import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
-import org.junit.BeforeClass;
 
 public class MaterialTypeTest extends TestBaseWithInventoryUtil {
 
   private static final String SUPPORTED_CONTENT_TYPE_JSON_DEF = "application/json";
-  private static UUID mainLibraryLocationId;
 
-  private String canCirculateLoanTypeID;
-  
-  @BeforeClass
-  public static void beforeAny()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
-    StorageTestSuite.deleteAll(itemsStorageUrl(""));
-    StorageTestSuite.deleteAll(holdingsStorageUrl(""));
-    StorageTestSuite.deleteAll(instancesStorageUrl(""));
-
-    StorageTestSuite.deleteAll(locationsStorageUrl(""));
-    StorageTestSuite.deleteAll(locLibraryStorageUrl(""));
-    StorageTestSuite.deleteAll(locCampusStorageUrl(""));
-    StorageTestSuite.deleteAll(locInstitutionStorageUrl(""));
-
-    LocationsTest.createLocUnits(true);
-    mainLibraryLocationId = LocationsTest.createLocation(null, "Main Library (Loan)", "Lo/M");
-  }
+  // see also @BeforeClass TestBaseWithInventoryUtil.beforeAny()
 
   @Before
   public void beforeEach()

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -53,6 +53,7 @@ import io.vertx.ext.sql.UpdateResult;
   ReferenceTablesTest.class,
   ItemDamagedStatusAPITest.class,
   ItemDamagedStatusAPIUnitTest.class,
+  ItemEffectiveLocationTest.class,
 
   // these run with loadReference=true, loadSample=true
   SampleDataTest.class,

--- a/src/test/java/org/folio/rest/api/TestBase.java
+++ b/src/test/java/org/folio/rest/api/TestBase.java
@@ -21,6 +21,8 @@ public abstract class TestBase {
   static HttpClient client;
   static ResourceClient instancesClient;
   static ResourceClient holdingsClient;
+  static ResourceClient itemsClient;
+  static ResourceClient locationsClient;
 
   @BeforeClass
   public static void testBaseBeforeClass() throws Exception {
@@ -34,6 +36,8 @@ public abstract class TestBase {
     client = new HttpClient(vertx);
     instancesClient = ResourceClient.forInstances(client);
     holdingsClient = ResourceClient.forHoldings(client);
+    itemsClient = ResourceClient.forItems(client);
+    locationsClient = ResourceClient.forLocations(client);
   }
 
   @AfterClass

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -1,11 +1,33 @@
 package org.folio.rest.api;
 
+import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.loanTypesStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.locCampusStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.locInstitutionStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.locLibraryStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.locationsStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.materialTypesStorageUrl;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+
 import java.net.MalformedURLException;
+import java.util.Random;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.support.IndividualResource;
+import org.folio.rest.support.Response;
+import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
+import org.folio.rest.support.client.LoanTypesClient;
+import org.folio.rest.support.client.MaterialTypesClient;
+import org.junit.BeforeClass;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -15,6 +37,32 @@ import io.vertx.core.json.JsonObject;
  * @author ne
  */
 public abstract class TestBaseWithInventoryUtil extends TestBase {
+  protected static final String PERMANENT_LOCATION_ID_KEY = "permanentLocationId";
+  protected static final String TEMPORARY_LOCATION_ID_KEY = "temporaryLocationId";
+  protected static final String EFFECTIVE_LOCATION_ID_KEY = "effectiveLocationId";
+
+  protected static final String MAIN_LIBRARY_LOCATION = "Main Library";
+  protected static final String SECOND_FLOOR_LOCATION = "Second Floor";
+  protected static final String ANNEX_LIBRARY_LOCATION = "Annex Library";
+  protected static final String ONLINE_LOCATION = "Online";
+  protected static final String THIRD_FLOOR_LOCATION = "Third Floor";
+  protected static final String FOURTH_FLOOR_LOCATION = "Fourth Floor";
+
+  protected static UUID   journalMaterialTypeId;
+  protected static String journalMaterialTypeID;
+  protected static UUID   bookMaterialTypeId;
+  protected static String bookMaterialTypeID;
+  protected static UUID   canCirculateLoanTypeId;
+  protected static String canCirculateLoanTypeID;
+
+  // Creating the UUIDs here because they are used in ItemEffectiveLocationTest.parameters()
+  // that JUnit calls *before* the @BeforeClass beforeAny() method.
+  protected static UUID mainLibraryLocationId = UUID.randomUUID();
+  protected static UUID annexLibraryLocationId = UUID.randomUUID();
+  protected static UUID onlineLocationId = UUID.randomUUID();
+  protected static UUID secondFloorLocationId = UUID.randomUUID();
+  protected static UUID thirdFloorLocationId = UUID.randomUUID();
+  protected static UUID fourthFloorLocationId = UUID.randomUUID();
 
   // These UUIDs were taken from reference-data folder.
   // When the vertical gets started the data from the reference-data folder are loaded to the DB.
@@ -25,6 +73,41 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   protected static final UUID UUID_TEXT = UUID.fromString("6312d172-f0cf-40f6-b27d-9fa8feaf332f");
   protected static final UUID UUID_INSTANCE_TYPE = UUID.fromString("535e3160-763a-42f9-b0c0-d8ed7df6e2a2");
 
+  @BeforeClass
+  public static void beforeAny()
+    throws MalformedURLException,
+    InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    StorageTestSuite.deleteAll(itemsStorageUrl(""));
+    StorageTestSuite.deleteAll(holdingsStorageUrl(""));
+    StorageTestSuite.deleteAll(instancesStorageUrl(""));
+
+    StorageTestSuite.deleteAll(materialTypesStorageUrl(""));
+    StorageTestSuite.deleteAll(locationsStorageUrl(""));
+    StorageTestSuite.deleteAll(locLibraryStorageUrl(""));
+    StorageTestSuite.deleteAll(locCampusStorageUrl(""));
+    StorageTestSuite.deleteAll(locInstitutionStorageUrl(""));
+    StorageTestSuite.deleteAll(loanTypesStorageUrl(""));
+
+    MaterialTypesClient materialTypesClient = new MaterialTypesClient(client, materialTypesStorageUrl(""));
+    journalMaterialTypeID = materialTypesClient.create("journal");
+    journalMaterialTypeId = UUID.fromString(journalMaterialTypeID);
+    bookMaterialTypeID = materialTypesClient.create("book");
+    bookMaterialTypeId = UUID.fromString(bookMaterialTypeID);
+    LoanTypesClient loanTypesClient = new LoanTypesClient(client, loanTypesStorageUrl(""));
+    canCirculateLoanTypeID = loanTypesClient.create("Can Circulate");
+    canCirculateLoanTypeId = UUID.fromString(canCirculateLoanTypeID);
+
+    LocationsTest.createLocUnits(true);
+    LocationsTest.createLocation(mainLibraryLocationId,  MAIN_LIBRARY_LOCATION,  "TestBaseWI/M");
+    LocationsTest.createLocation(annexLibraryLocationId, ANNEX_LIBRARY_LOCATION, "TestBaseWI/A");
+    LocationsTest.createLocation(onlineLocationId,       ONLINE_LOCATION,        "TestBaseWI/O");
+    LocationsTest.createLocation(secondFloorLocationId,  SECOND_FLOOR_LOCATION,  "TestBaseWI/SF");
+    LocationsTest.createLocation(thirdFloorLocationId,   THIRD_FLOOR_LOCATION,   "TestBaseWI/TF");
+    LocationsTest.createLocation(fourthFloorLocationId,  FOURTH_FLOOR_LOCATION,  "TestBaseWI/FF");
+  }
 
   protected static UUID createInstanceAndHolding(UUID holdingsPermanentLocationId)
     throws ExecutionException, InterruptedException, MalformedURLException, TimeoutException {
@@ -71,6 +154,46 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     );
   }
 
+  protected static Item buildItem(UUID holdingsRecordId,
+                                   UUID permLocation,
+                                   UUID tempLocation) {
+    JsonObject itemToCreate = new JsonObject();
+
+    itemToCreate.put("id", UUID.randomUUID().toString());
+    itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
+    itemToCreate.put("barcode", Long.toString(new Random().nextLong()));
+    itemToCreate.put("status", new JsonObject().put("name", "Available"));
+    itemToCreate.put("materialTypeId", journalMaterialTypeID);
+    itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
+    if (tempLocation != null) {
+      itemToCreate.put(TEMPORARY_LOCATION_ID_KEY, tempLocation.toString());
+    }
+    if (permLocation != null) {
+      itemToCreate.put(PERMANENT_LOCATION_ID_KEY, permLocation.toString());
+    }
+
+    return itemToCreate.mapTo(Item.class);
+  }
+
+  protected void createItem(JsonObject itemToCreate)
+      throws MalformedURLException,
+      InterruptedException,
+      ExecutionException,
+      TimeoutException {
+
+    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
+
+    client.post(itemsStorageUrl(""), itemToCreate, StorageTestSuite.TENANT_ID,
+        ResponseHandler.json(createCompleted));
+
+    Response response = createCompleted.get(2, TimeUnit.SECONDS);
+
+    assertThat(response.getStatusCode(), is(201));
+  }
+
+  protected IndividualResource createItem(Item item) throws Exception {
+    return itemsClient.create(JsonObject.mapFrom(item));
+  }
 
   protected static JsonObject identifier(UUID identifierTypeId, String value) {
     return new JsonObject()

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -40,17 +40,26 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
 
     UUID instanceId = UUID.randomUUID();
     instancesClient.create(instance(instanceId));
-
-    return holdingsClient.create(
-      new HoldingRequestBuilder()
-        .withId(UUID.randomUUID())
-        .forInstance(instanceId)
-        .withPermanentLocation(holdingsPermanentLocationId)
-        .withTemporaryLocation(holdingsTemporaryLocationId)
-    ).getId();
+    return createHolding(instanceId, holdingsPermanentLocationId, holdingsTemporaryLocationId);
   }
 
-  private static JsonObject instance(UUID id) {
+  protected static UUID createHolding(UUID instanceId,
+                                      UUID holdingsPermanentLocationId,
+                                      UUID holdingsTemporaryLocationId)
+                                          throws ExecutionException,
+                                          InterruptedException,
+                                          MalformedURLException,
+                                          TimeoutException {
+    return holdingsClient.create(
+        new HoldingRequestBuilder()
+          .withId(UUID.randomUUID())
+          .forInstance(instanceId)
+          .withPermanentLocation(holdingsPermanentLocationId)
+          .withTemporaryLocation(holdingsTemporaryLocationId)
+      ).getId();
+  }
+
+  protected static JsonObject instance(UUID id) {
     return createInstanceRequest(
       id,
       "TEST",

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -27,6 +27,11 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
 
 
   protected static UUID createInstanceAndHolding(UUID holdingsPermanentLocationId)
+    throws ExecutionException, InterruptedException, MalformedURLException, TimeoutException {
+    return createInstanceAndHolding(holdingsPermanentLocationId, null);
+  }
+
+  protected static UUID createInstanceAndHolding(UUID holdingsPermanentLocationId, UUID holdingTempLocation)
     throws ExecutionException,
     InterruptedException,
     MalformedURLException,
@@ -40,6 +45,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
         .withId(UUID.randomUUID())
         .forInstance(instanceId)
         .withPermanentLocation(holdingsPermanentLocationId)
+        .withTemporaryLocation(holdingTempLocation)
     ).getId();
   }
 

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -31,7 +31,8 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     return createInstanceAndHolding(holdingsPermanentLocationId, null);
   }
 
-  protected static UUID createInstanceAndHolding(UUID holdingsPermanentLocationId, UUID holdingTempLocation)
+  protected static UUID createInstanceAndHolding(UUID holdingsPermanentLocationId,
+                                                 UUID holdingsTemporaryLocationId)
     throws ExecutionException,
     InterruptedException,
     MalformedURLException,
@@ -45,7 +46,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
         .withId(UUID.randomUUID())
         .forInstance(instanceId)
         .withPermanentLocation(holdingsPermanentLocationId)
-        .withTemporaryLocation(holdingTempLocation)
+        .withTemporaryLocation(holdingsTemporaryLocationId)
     ).getId();
   }
 

--- a/src/test/java/org/folio/rest/support/ResponseUtilTest.java
+++ b/src/test/java/org/folio/rest/support/ResponseUtilTest.java
@@ -1,0 +1,75 @@
+package org.folio.rest.support;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import java.lang.reflect.Constructor;
+
+import javax.ws.rs.core.Response;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class ResponseUtilTest {
+  @Rule
+  public ExpectedException expectedException = ExpectedException.none();
+
+  @Test
+  public void canReturnFalseIfNullResponse() {
+    assertFalse(ResponseUtil.hasCreatedStatus(null));
+  }
+
+  @Test
+  public void canReturnTrueIfCreatedStatus() {
+    Response response = Response.status(Response.Status.CREATED).build();
+
+    assertTrue(ResponseUtil.hasCreatedStatus(response));
+  }
+
+  @Test
+  public void canReturnFalseIfNotCreatedStatus() {
+    Response response = Response.status(Response.Status.ACCEPTED).build();
+
+    assertFalse(ResponseUtil.hasCreatedStatus(response));
+  }
+
+  @Test
+  public void canNotInstantiateClass() throws Exception {
+    final Constructor<ResponseUtil> constructor = ResponseUtil.class
+      .getDeclaredConstructor();
+
+    constructor.setAccessible(true);
+
+    expectedException.expectCause(instanceOf(UnsupportedOperationException.class));
+    constructor.newInstance();
+  }
+
+  @Test
+  public void returnNullIfResponseNull() {
+    assertNull(ResponseUtil.copyResponseWithNewEntity(null, "entity"));
+  }
+
+  @Test
+  public void copyResponseWithNewEntity() {
+    final String locationHeaderName = "location";
+    final String locationHeaderValue = "location-to-follow";
+    final String newEntityValue = "new-entity";
+
+    Response originResponse = Response.status(Response.Status.ACCEPTED)
+      .entity("old")
+      .header(locationHeaderName, locationHeaderValue)
+      .build();
+
+    Response newResponse = ResponseUtil
+      .copyResponseWithNewEntity(originResponse, newEntityValue);
+
+    assertThat(newResponse.getEntity(), is(newEntityValue));
+    assertThat(newResponse.getHeaderString(locationHeaderName), is(locationHeaderValue));
+    assertThat(newResponse.getStatusInfo(), is(Response.Status.ACCEPTED));
+  }
+}

--- a/src/test/java/org/folio/rest/support/ResponseUtilTest.java
+++ b/src/test/java/org/folio/rest/support/ResponseUtilTest.java
@@ -1,24 +1,17 @@
 package org.folio.rest.support;
 
-import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
-import java.lang.reflect.Constructor;
-
 import javax.ws.rs.core.Response;
 
-import org.junit.Rule;
+import org.folio.rest.testing.UtilityClassTester;
 import org.junit.Test;
-import org.junit.rules.ExpectedException;
 
 public class ResponseUtilTest {
-  @Rule
-  public ExpectedException expectedException = ExpectedException.none();
-
   @Test
   public void canReturnFalseIfNullResponse() {
     assertFalse(ResponseUtil.hasCreatedStatus(null));
@@ -39,14 +32,8 @@ public class ResponseUtilTest {
   }
 
   @Test
-  public void canNotInstantiateClass() throws Exception {
-    final Constructor<ResponseUtil> constructor = ResponseUtil.class
-      .getDeclaredConstructor();
-
-    constructor.setAccessible(true);
-
-    expectedException.expectCause(instanceOf(UnsupportedOperationException.class));
-    constructor.newInstance();
+  public void isUtilityClass(){
+    UtilityClassTester.assertUtilityClass(ResponseUtil.class);
   }
 
   @Test

--- a/src/test/java/org/folio/rest/support/builders/HoldingRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/HoldingRequestBuilder.java
@@ -9,6 +9,7 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
   private final UUID id;
   private final UUID instanceId;
   private final UUID permanentLocationId;
+  private final UUID temporaryLocationId;
   private JsonObject tags;
 
   public HoldingRequestBuilder() {
@@ -16,6 +17,7 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       null,
       null,
       UUID.randomUUID(),
+      null,
       null);
   }
 
@@ -23,11 +25,13 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     UUID id,
     UUID instanceId,
     UUID permanentLocationId,
+    UUID temporaryLocationId,
     JsonObject tags) {
 
     this.id = id;
     this.instanceId = instanceId;
     this.permanentLocationId = permanentLocationId;
+    this.temporaryLocationId = temporaryLocationId;
     this.tags = tags;
   }
 
@@ -38,6 +42,7 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     put(request, "id", id);
     put(request, "instanceId", instanceId);
     put(request, "permanentLocationId", permanentLocationId);
+    put(request, "temporaryLocationId", temporaryLocationId);
     put(request, "tags", tags);
 
     return request;
@@ -48,6 +53,16 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.id,
       this.instanceId,
       permanentLocationId,
+      temporaryLocationId,
+      this.tags);
+  }
+
+  public HoldingRequestBuilder withTemporaryLocation(UUID temporaryLocationId) {
+    return new HoldingRequestBuilder(
+      this.id,
+      this.instanceId,
+      this.permanentLocationId,
+      temporaryLocationId,
       this.tags);
   }
 
@@ -56,6 +71,7 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.id,
       instanceId,
       this.permanentLocationId,
+      this.temporaryLocationId,
       this.tags);
   }
 
@@ -64,6 +80,7 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       id,
       this.instanceId,
       this.permanentLocationId,
+      this.temporaryLocationId,
       this.tags);
   }
 
@@ -72,6 +89,7 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.id,
       this.instanceId,
       this.permanentLocationId,
+      this.temporaryLocationId,
       tags);
   }
 }


### PR DESCRIPTION
Add set of triggers (for item and holdings_record tables) to persist effectiveLocation for item.

**Logic to calculate item effectiveLocation:**
First not null:
1. Item temporaryLocation;
2. Item permanentLocation;
3. Holding record temporaryLocation;
4. Holding record permanentLocation;

**Holding records trigger implementation details**:
* Updates related items only if following properties have changed: 
  * temporaryLocationId; 
  * permanentLocationId;
* Only those items are updated which has no value for their's permanent or temporary locations because otherwise the update won't take any affect.

**Item trigger implementation details:**
* Item effective location is re-calculated only if following properties changed: 
  * temporaryLocationId; 
  * permanentLocationId;
  * holdingsRecordId.

Related PR https://github.com/folio-org/mod-inventory/pull/150