### PR TITLE
[MODINVSTOR 357] Store effective call number on item record

### DIFF
--- a/ramls/item-storage.raml
+++ b/ramls/item-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Item Storage
-version: v7.5
+version: v7.6
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -51,10 +51,15 @@
       "type": "string",
       "description": "Identifies the source of the call number, e.g., LCC, Dewey, NLM, etc."
     },
-    "effectiveCallNumber": {
-      "type": "string",
-      "description": "Effective Call Number is an identifier assigned to an item or its holding and associated with the item.",
-      "readonly": true
+    "effectiveCallNumberComponents": {
+      "type": "object",
+      "description": "Elements of a full call number generated from the item or holding",
+      "properties": {
+        "callNumber": {
+          "type": "string",
+          "description": "Effective Call Number is an identifier assigned to an item or its holding and associated with the item."
+        }
+      }
     },
     "volume": {
       "type": "string",

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -53,7 +53,8 @@
     },
     "effectiveCallNumber": {
       "type": "string",
-      "description": "Effective Call Number is an identifier assigned to an item or its holding and associated with the item."
+      "description": "Effective Call Number is an identifier assigned to an item or its holding and associated with the item.",
+      "readonly": true
     },
     "volume": {
       "type": "string",

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -51,6 +51,10 @@
       "type": "string",
       "description": "Identifies the source of the call number, e.g., LCC, Dewey, NLM, etc."
     },
+    "effectiveCallNumber": {
+      "type": "string",
+      "description": "Effective Call Number is an identifier assigned to an item or its holding and associated with the item."
+    },
     "volume": {
       "type": "string",
       "description": "Volume is intended for monographs when a multipart monograph (e.g. a biography of George Bernard Shaw in three volumes)."

--- a/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import javax.ws.rs.core.Response;
 
@@ -443,7 +442,6 @@ public class HoldingsStorageAPI implements HoldingsStorage {
   private CompletableFuture<Void> updateEffectiveCallNumbers(Items items, HoldingsRecord holdingsRecord, Map<String, String> okapiHeaders,
       Context vertexContext) {
     CompletableFuture<Void> setEffectiveCallNumberFuture = new CompletableFuture<>();
-    AtomicInteger itemCount = new AtomicInteger();
     items.getItems().forEach(item -> {
       String updatedCallNumner = null;
       if (StringUtils.isNotBlank(item.getItemLevelCallNumber())) {
@@ -457,10 +455,8 @@ public class HoldingsStorageAPI implements HoldingsStorage {
         PgUtil.put(ITEM_TABLE, item, item.getId(), okapiHeaders, vertexContext,
           PutItemStorageItemsByItemIdResponse.class, response -> {});
       }
-      if (itemCount.incrementAndGet() == items.getItems().size()) {
-        setEffectiveCallNumberFuture.complete(null);
-      }
     });
+    setEffectiveCallNumberFuture.complete(null);
     return setEffectiveCallNumberFuture;
   }
 }

--- a/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
@@ -427,7 +427,7 @@ public class HoldingsStorageAPI implements HoldingsStorage {
   }
 
   private CompletableFuture<Void> updateItemEffectiveCallNumbersByHoldings(HoldingsRecord holdingsRecord, Map<String, String> okapiHeaders, Context vertexContext) {
-    CompletableFuture<Void> future = new CompletableFuture<Void>();
+    CompletableFuture<Void> future = new CompletableFuture<>();
     String query = String.format("holdingsRecordId==%s", holdingsRecord.getId());
     PgUtil.get(ITEM_TABLE, Item.class, Items.class, query, NO_OFFSET, NO_LIMIT, okapiHeaders, vertexContext, GetItemStorageItemsResponse.class, response -> {
       if (response.succeeded() && response.result() != null && response.result().getStatus() == 200) {

--- a/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
@@ -440,7 +440,7 @@ public class HoldingsStorageAPI implements HoldingsStorage {
       String updatedCallNumner = null;
       if (StringUtils.isNotBlank(item.getEffectiveCallNumber())) {
           updatedCallNumner = item.getItemLevelCallNumber();
-      } else if (item.getHoldingsRecordId() != null && !item.getHoldingsRecordId().isEmpty()) {
+      } else if (StringUtils.isNotBlank(holdingsRecord.getCallNumber())) {
           updatedCallNumner = holdingsRecord.getCallNumber();
       }
       if (updatedCallNumner != null && !updatedCallNumner.equals(item.getEffectiveCallNumber())) {

--- a/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
@@ -49,8 +49,6 @@ public class HoldingsStorageAPI implements HoldingsStorage {
   private static final String WHERE_CLAUSE = "WHERE id = '%s'";
   public static final String HOLDINGS_RECORD_TABLE = "holdings_record";
   public static final String ITEM_TABLE = "item";
-  public static final int NO_OFFSET = 0;
-  public static final int NO_LIMIT = -1;
 
   @Validate
   @Override

--- a/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
@@ -1,5 +1,6 @@
 package org.folio.rest.impl;
 
+import java.sql.SQLException;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -462,6 +463,8 @@ public class HoldingsStorageAPI implements HoldingsStorage {
     lastUpdate.setHandler(updateResult -> {
       if (updateResult.succeeded()) {
         allItemsUpdated.complete(null);
+      } else {
+        allItemsUpdated.completeExceptionally(updateResult.cause());
       }
     });
     return allItemsUpdated;

--- a/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
@@ -443,15 +443,15 @@ public class HoldingsStorageAPI implements HoldingsStorage {
       Context vertexContext) {
     CompletableFuture<Void> setEffectiveCallNumberFuture = new CompletableFuture<>();
     items.getItems().forEach(item -> {
-      String updatedCallNumner = null;
+      String updatedCallNumber = "";
       if (StringUtils.isNotBlank(item.getItemLevelCallNumber())) {
-        updatedCallNumner = item.getItemLevelCallNumber();
+        updatedCallNumber = item.getItemLevelCallNumber();
       } else if (StringUtils.isNotBlank(holdingsRecord.getCallNumber())) {
-        updatedCallNumner = holdingsRecord.getCallNumber();
+        updatedCallNumber = holdingsRecord.getCallNumber();
       }
 
-      if (updatedCallNumner != null && !updatedCallNumner.equals(item.getEffectiveCallNumber())) {
-        item.setEffectiveCallNumber(updatedCallNumner);
+      if (!updatedCallNumber.equals(item.getEffectiveCallNumber())) {
+        item.setEffectiveCallNumber(updatedCallNumber);
         PgUtil.put(ITEM_TABLE, item, item.getId(), okapiHeaders, vertexContext,
           PutItemStorageItemsByItemIdResponse.class, response -> {});
       }

--- a/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
@@ -466,14 +466,14 @@ public class HoldingsStorageAPI implements HoldingsStorage {
   }
 
   private Item updateItemEffectiveCallNumber(Item item, HoldingsRecord holdingsRecord) {
-    String updatedCallNumber = "";
+    String updatedCallNumber = null;
     if (StringUtils.isNotBlank(item.getItemLevelCallNumber())) {
       updatedCallNumber = item.getItemLevelCallNumber();
     } else if (StringUtils.isNotBlank(holdingsRecord.getCallNumber())) {
       updatedCallNumber = holdingsRecord.getCallNumber();
     }
 
-    if (!updatedCallNumber.equals(item.getEffectiveCallNumber())) {
+    if ((updatedCallNumber == null && item.getEffectiveCallNumber() != null) || !updatedCallNumber.equals(item.getEffectiveCallNumber())) {
       item.setEffectiveCallNumber(updatedCallNumber);
     }
     return item;

--- a/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
@@ -11,6 +11,7 @@ import javax.ws.rs.core.Response;
 import org.apache.commons.lang.StringUtils;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.EffectiveCallNumberComponents;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.HoldingsRecords;
 import org.folio.rest.jaxrs.model.Item;
@@ -477,8 +478,9 @@ public class HoldingsStorageAPI implements HoldingsStorage {
     } else if (StringUtils.isNotBlank(holdingsRecord.getCallNumber())) {
       updatedCallNumber = holdingsRecord.getCallNumber();
     }
-
-    item.setEffectiveCallNumber(updatedCallNumber);
+    EffectiveCallNumberComponents components = new EffectiveCallNumberComponents();
+    components.setCallNumber(updatedCallNumber);
+    item.setEffectiveCallNumberComponents(components);
     return item;
   }
 

--- a/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
@@ -455,11 +455,10 @@ public class HoldingsStorageAPI implements HoldingsStorage {
       if (updatedCallNumner != null && !updatedCallNumner.equals(item.getEffectiveCallNumber())) {
         item.setEffectiveCallNumber(updatedCallNumner);
         PgUtil.put(ITEM_TABLE, item, item.getId(), okapiHeaders, vertexContext,
-          PutItemStorageItemsByItemIdResponse.class, response -> {
-            if (itemCount.incrementAndGet() == items.getItems().size()) {
-              setEffectiveCallNumberFuture.complete(null);
-            }
-          });
+          PutItemStorageItemsByItemIdResponse.class, response -> {});
+      }
+      if (itemCount.incrementAndGet() == items.getItems().size()) {
+        setEffectiveCallNumberFuture.complete(null);
       }
     });
     return setEffectiveCallNumberFuture;

--- a/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
@@ -123,8 +123,8 @@ public class ItemStorageAPI implements ItemStorage {
       String itemId, String lang, Item entity, java.util.Map<String, String> okapiHeaders,
       io.vertx.core.Handler<io.vertx.core.AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
-    setEffectiveCallNumber(okapiHeaders, vertxContext, entity).thenAccept(i -> {
-      PgUtil.put(ITEM_TABLE, i, itemId, okapiHeaders, vertxContext,
+    setEffectiveCallNumber(okapiHeaders, vertxContext, entity).thenAccept(item -> {
+      PgUtil.put(ITEM_TABLE, item, itemId, okapiHeaders, vertxContext,
         PutItemStorageItemsByItemIdResponse.class, asyncResultHandler);
     });
   }

--- a/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
@@ -152,6 +152,8 @@ public class ItemStorageAPI implements ItemStorage {
           i.setEffectiveCallNumber(hr.getCallNumber());
           return i;
         });
+      } else {
+        completableFuture = CompletableFuture.supplyAsync(() -> item);
       }
     }
 

--- a/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
@@ -10,6 +10,7 @@ import java.util.concurrent.CompletableFuture;
 import javax.ws.rs.core.Response;
 
 import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.EffectiveCallNumberComponents;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.jaxrs.model.Items;
@@ -142,14 +143,17 @@ public class ItemStorageAPI implements ItemStorage {
 
   private CompletableFuture<Item> setEffectiveCallNumber(Map<String, String> okapiHeaders, Context vertxContext, Item item) {
     CompletableFuture<Item> completableFuture = null;
+    EffectiveCallNumberComponents components = new EffectiveCallNumberComponents();
     if (item.getItemLevelCallNumber() != null && !item.getItemLevelCallNumber().isEmpty()) {
-      item.setEffectiveCallNumber(item.getItemLevelCallNumber());
+      components.setCallNumber(item.getItemLevelCallNumber());
+      item.setEffectiveCallNumberComponents(components);
       completableFuture = CompletableFuture.supplyAsync(() -> item);
     } else {
       if (item.getHoldingsRecordId() != null && !item.getHoldingsRecordId().isEmpty()) {
         completableFuture = getHoldingsRecordById(okapiHeaders, vertxContext, item.getHoldingsRecordId()).thenCombineAsync(CompletableFuture.supplyAsync(() -> item), (hr, i) ->
         {
-          i.setEffectiveCallNumber(hr.getCallNumber());
+          components.setCallNumber(hr.getCallNumber());
+          i.setEffectiveCallNumberComponents(components);
           return i;
         });
       } else {

--- a/src/main/resources/templates/db_scripts/holdingsRecordHrid.sql
+++ b/src/main/resources/templates/db_scripts/holdingsRecordHrid.sql
@@ -1,5 +1,5 @@
 -- Generates an eight digit HRID prefixed with 'ho' for new holdings_record records, starting with ho00000001.
--- Ignores the value in 'hrid' -- if any -- in the holdingsRecord POSTed by the client 
+-- Ignores the value in 'hrid' -- if any -- in the holdingsRecord POSTed by the client
 CREATE SEQUENCE IF NOT EXISTS ${myuniversity}_${mymodule}.holdings_record_hrid_seq
   INCREMENT BY 1
   START WITH 1
@@ -20,7 +20,7 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.set_holdings_record_hrid(
 
 DROP TRIGGER IF EXISTS set_holdings_record_hrid ON ${myuniversity}_${mymodule}.holdings_record CASCADE;
 CREATE TRIGGER set_holdings_record_hrid
-  BEFORE INSERT ON ${myuniversity}_${mymodule}.holdings_record
+  AFTER INSERT ON ${myuniversity}_${mymodule}.holdings_record
   FOR EACH ROW EXECUTE PROCEDURE ${myuniversity}_${mymodule}.set_holdings_record_hrid();
 
 

--- a/src/main/resources/templates/db_scripts/instanceHrid.sql
+++ b/src/main/resources/templates/db_scripts/instanceHrid.sql
@@ -1,5 +1,5 @@
 -- Generates an eight digit HRID prefixed with 'in' for new instance records, starting with in00000001.
--- Ignores the value in 'hrid' -- if any -- in the instance POSTed by the client 
+-- Ignores the value in 'hrid' -- if any -- in the instance POSTed by the client
 CREATE SEQUENCE IF NOT EXISTS ${myuniversity}_${mymodule}.instance_hrid_seq
   INCREMENT BY 1
   START WITH 1

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -716,7 +716,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(getFirstUpdatedItemResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
     assertThat(firstUpdatedItemFromGet.getString("id"), is(firstItemId));
-    assertThat(firstUpdatedItemFromGet.getString("effectiveCallNumber"), is(""));
+    assertThat(firstUpdatedItemFromGet.containsKey("effectiveCallNumber"), is(false));
   }
 
   public void cannotCreateHoldingWithoutPermanentLocation() throws Exception {

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -628,10 +628,10 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(firstItemFromGet.getString("id"), is(firstItemId));
     assertThat(firstItemFromGet.getString("holdingsRecordId"), is(holdingId.toString()));
-    assertThat(firstItemFromGet.getString("effectiveCallNumber"), is("testCallNumber"));
+    assertThat(firstItemFromGet.getJsonObject("effectiveCallNumberComponents").getString("callNumber"), is("testCallNumber"));
     assertThat(secondItemFromGet.getString("id"), is(secondItemId));
     assertThat(secondItemFromGet.getString("holdingsRecordId"), is(holdingId.toString()));
-    assertThat(secondItemFromGet.getString("effectiveCallNumber"), is("testCallNumber"));
+    assertThat(secondItemFromGet.getJsonObject("effectiveCallNumberComponents").getString("callNumber"), is("testCallNumber"));
 
     URL holdingsUrl = holdingsStorageUrl(String.format("/%s", holdingId));
 
@@ -651,10 +651,10 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(getFirstUpdatedItemResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
     assertThat(firstUpdatedItemFromGet.getString("id"), is(firstItemId));
-    assertThat(firstUpdatedItemFromGet.getString("effectiveCallNumber"), is("updatedCallNumber"));
+    assertThat(firstUpdatedItemFromGet.getJsonObject("effectiveCallNumberComponents").getString("callNumber"), is("updatedCallNumber"));
     assertThat(getSecondUpdatedItemResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
     assertThat(secondUpdatedItemFromGet.getString("id"), is(secondItemId));
-    assertThat(secondUpdatedItemFromGet.getString("effectiveCallNumber"), is("updatedCallNumber"));
+    assertThat(secondUpdatedItemFromGet.getJsonObject("effectiveCallNumberComponents").getString("callNumber"), is("updatedCallNumber"));
   }
 
   @Test
@@ -699,7 +699,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(firstItemFromGet.getString("id"), is(firstItemId));
     assertThat(firstItemFromGet.getString("holdingsRecordId"), is(holdingId.toString()));
-    assertThat(firstItemFromGet.getString("effectiveCallNumber"), is("testCallNumber"));
+    assertThat(firstItemFromGet.getJsonObject("effectiveCallNumberComponents").getString("callNumber"), is("testCallNumber"));
 
     URL holdingsUrl = holdingsStorageUrl(String.format("/%s", holdingId));
 
@@ -762,7 +762,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(itemFromGet.getString("id"), is(itemId));
     assertThat(itemFromGet.getString("holdingsRecordId"), is(holdingId.toString()));
-    assertThat(itemFromGet.getString("effectiveCallNumber"), is("itemLevelCallNumber"));
+    assertThat(itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("callNumber"), is("itemLevelCallNumber"));
 
     URL holdingsUrl = holdingsStorageUrl(String.format("/%s", holdingId));
 
@@ -779,7 +779,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(getUpdatedItemResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
     assertThat(updatedItemFromGet.getString("id"), is(itemId));
-    assertThat(updatedItemFromGet.getString("effectiveCallNumber"), is("itemLevelCallNumber"));
+    assertThat(updatedItemFromGet.getJsonObject("effectiveCallNumberComponents").getString("callNumber"), is("itemLevelCallNumber"));
   }
 
   public void cannotCreateHoldingWithoutPermanentLocation() throws Exception {

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -4,12 +4,6 @@ import static org.folio.rest.support.JsonObjectMatchers.hasSoleMessgeContaining;
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.loanTypesStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locCampusStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locInstitutionStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locLibraryStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.locationsStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.materialTypesStorageUrl;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -35,11 +29,8 @@ import org.folio.rest.support.JsonErrorResponse;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
-import org.folio.rest.support.client.LoanTypesClient;
-import org.folio.rest.support.client.MaterialTypesClient;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 
@@ -49,36 +40,8 @@ import io.vertx.core.json.JsonObject;
 public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   private static final String TAG_VALUE = "test-tag";
   public static final String NEW_TEST_TAG = "new test tag";
-  private static String bookMaterialTypeID;
-  private static String canCirculateLoanTypeID;
-  private static UUID mainLibraryLocationId;
-  private static UUID annexLibraryLocationId;
 
-  @BeforeClass
-  public static void beforeAny()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException {
-
-    StorageTestSuite.deleteAll(itemsStorageUrl(""));
-    StorageTestSuite.deleteAll(holdingsStorageUrl(""));
-    StorageTestSuite.deleteAll(instancesStorageUrl(""));
-
-    StorageTestSuite.deleteAll(locationsStorageUrl(""));
-    StorageTestSuite.deleteAll(locLibraryStorageUrl(""));
-    StorageTestSuite.deleteAll(locCampusStorageUrl(""));
-    StorageTestSuite.deleteAll(locInstitutionStorageUrl(""));
-
-    StorageTestSuite.deleteAll(materialTypesStorageUrl(""));
-    StorageTestSuite.deleteAll(loanTypesStorageUrl(""));
-
-    LocationsTest.createLocUnits(true);
-    mainLibraryLocationId = LocationsTest.createLocation(null, "Main Library (H)", "H/M");
-    annexLibraryLocationId = LocationsTest.createLocation(null, "Annex Library (H)", "H/A");
-    MaterialTypesClient materialTypesClient = new MaterialTypesClient(client, materialTypesStorageUrl(""));
-    bookMaterialTypeID = materialTypesClient.create("book");
-    canCirculateLoanTypeID = new LoanTypesClient(client, loanTypesStorageUrl("")).create("Can Circulate");
-  }
+  // see also @BeforeClass TestBaseWithInventoryUtil.beforeAny()
 
   @Before
   public void beforeEach() {

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -719,6 +719,69 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(firstUpdatedItemFromGet.containsKey("effectiveCallNumber"), is(false));
   }
 
+  @Test
+  public void holdingsCallNumberDoesNotUpdateItemWithItemLevelCallNumber()
+      throws MalformedURLException, InterruptedException, TimeoutException, ExecutionException {
+    UUID instanceId = UUID.randomUUID();
+
+    instancesClient.create(smallAngryPlanet(instanceId));
+
+    UUID holdingId = UUID.randomUUID();
+
+    JsonObject holding = holdingsClient.create(new HoldingRequestBuilder()
+      .withId(holdingId)
+      .forInstance(instanceId)
+      .withPermanentLocation(mainLibraryLocationId)
+      .withCallNumber("holdingsCallNumber")
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getJson();
+
+    JsonObject itemToCreate = new JsonObject();
+
+    itemToCreate.put("holdingsRecordId", holdingId.toString());
+    itemToCreate.put("status", new JsonObject().put("name", "Available"));
+    itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
+    itemToCreate.put("temporaryLocationId", annexLibraryLocationId.toString());
+    itemToCreate.put("materialTypeId", bookMaterialTypeID.toString());
+    itemToCreate.put("itemLevelCallNumber", "itemLevelCallNumber");
+
+    Response postItemResponse = create(itemsStorageUrl(""), itemToCreate);
+
+    assertThat(postItemResponse.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+
+    JsonObject itemFromPost = postItemResponse.getJson();
+
+    String itemId = itemFromPost.getString("id");
+
+    assertThat(itemId, is(notNullValue()));
+
+    URL getItemUrl = itemsStorageUrl(String.format("/%s", itemId));
+
+    Response getItemResponse = get(getItemUrl);
+
+    JsonObject itemFromGet = getItemResponse.getJson();
+
+    assertThat(itemFromGet.getString("id"), is(itemId));
+    assertThat(itemFromGet.getString("holdingsRecordId"), is(holdingId.toString()));
+    assertThat(itemFromGet.getString("effectiveCallNumber"), is("itemLevelCallNumber"));
+
+    URL holdingsUrl = holdingsStorageUrl(String.format("/%s", holdingId));
+
+    holding.remove("callNumber");
+    holding.put("callNumber", "updatedHoldingCallNumber");
+
+    Response putResponse = update(holdingsUrl, holding);
+
+    assertThat(putResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+
+    Response getUpdatedItemResponse = get(getItemUrl);
+
+    JsonObject updatedItemFromGet = getUpdatedItemResponse.getJson();
+
+    assertThat(getUpdatedItemResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+    assertThat(updatedItemFromGet.getString("id"), is(itemId));
+    assertThat(updatedItemFromGet.getString("effectiveCallNumber"), is("itemLevelCallNumber"));
+  }
+
   public void cannotCreateHoldingWithoutPermanentLocation() throws Exception {
     UUID instanceId = UUID.randomUUID();
     instancesClient.create(smallAngryPlanet(instanceId));

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -671,12 +671,18 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     URL holdingsUrl = holdingsStorageUrl(String.format("/%s", holdingId));
 
+    holding.remove("callNumber");
     holding.put("callNumber", "updatedCallNumber");
 
-    Response putResponse = client.put(holdingsUrl, holding, StorageTestSuite.TENANT_ID)
-      .get(5, TimeUnit.SECONDS);
+    CompletableFuture<Response> putHoldingCompleted = new CompletableFuture<>();
+
+    client.put(holdingsUrl, holding, StorageTestSuite.TENANT_ID,
+      ResponseHandler.empty(putHoldingCompleted));
+
+    Response putResponse = putHoldingCompleted.get(5, TimeUnit.SECONDS);
 
     assertThat(putResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+    assertThat(holding.getString("callNumber"), is("updatedCallNumber"));
 
     CompletableFuture<Response> getUpdatedItemCompleted = new CompletableFuture<>();
 
@@ -687,6 +693,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     JsonObject updatedItemFromGet = getUpdatedItemResponse.getJson();
 
     assertThat(getUpdatedItemResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+    assertThat(updatedItemFromGet.getString("id"), is(newId));
     assertThat(updatedItemFromGet.getString("effectiveCallNumber"), is("updatedCallNumber"));
   }
 

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -284,7 +284,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(tags.size(), is(1));
     assertThat(tags, hasItem(TAG_VALUE));
-    assertThat(itemFromGet.getString("effectiveCallNumber"), is("testCallNumber"));
+    assertThat(itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("callNumber"), is("testCallNumber"));
   }
 
   @Test
@@ -337,7 +337,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(tags.size(), is(1));
     assertThat(tags, hasItem(TAG_VALUE));
-    assertThat(itemFromGet.getString("effectiveCallNumber"), is("testItemCallNumber"));
+    assertThat(itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("callNumber"), is("testItemCallNumber"));
   }
 
   @Test
@@ -364,7 +364,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject itemFromGet = getResponse.getJson();
 
-    assertThat(itemFromGet.getString("effectiveCallNumber"), is("testCallNumber"));
+    assertThat(itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("callNumber"), is("testCallNumber"));
   }
 
   @Test
@@ -392,7 +392,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject itemFromGet = getResponse.getJson();
 
-    assertThat(itemFromGet.getString("effectiveCallNumber"), is("testItemCallNumber"));
+    assertThat(itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("callNumber"), is("testItemCallNumber"));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -270,6 +270,165 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  public void canCreateAnItemWithHoldingCallNumberAsEffectiveCallNumber()
+    throws MalformedURLException, InterruptedException,
+    ExecutionException, TimeoutException {
+
+    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumber(mainLibraryLocationId);
+
+    JsonObject itemToCreate = nod(null, holdingsRecordId);
+
+    itemToCreate.put("tags", new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)));
+
+    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
+
+    client.post(itemsStorageUrl(""), itemToCreate, StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(createCompleted));
+
+    Response postResponse = createCompleted.get(5, TimeUnit.SECONDS);
+
+    assertThat(postResponse.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+
+    JsonObject itemFromPost = postResponse.getJson();
+
+    String newId = itemFromPost.getString("id");
+
+    assertThat(newId, is(notNullValue()));
+
+    Response getResponse = getById(UUID.fromString(newId));
+
+    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+
+    JsonObject itemFromGet = getResponse.getJson();
+
+    assertThat(itemFromGet.getString("id"), is(newId));
+    assertThat(itemFromGet.getString("holdingsRecordId"), is(holdingsRecordId.toString()));
+    assertThat(itemFromGet.getString("barcode"), is("565578437802"));
+    assertThat(itemFromGet.getJsonObject("status").getString("name"),
+      is("Available"));
+    assertThat(itemFromGet.getString("materialTypeId"),
+      is(journalMaterialTypeID));
+    assertThat(itemFromGet.getString("permanentLoanTypeId"),
+      is(canCirculateLoanTypeID));
+    assertThat(itemFromGet.getString("temporaryLocationId"),
+      is(annexLibraryLocationId.toString()));
+
+    List<String> tags = itemFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
+
+    assertThat(tags.size(), is(1));
+    assertThat(tags, hasItem(TAG_VALUE));
+    assertThat(itemFromGet.getString("effectiveCallNumber"), is("testCallNumber"));
+  }
+
+  @Test
+  public void canCreateAnItemWithItemLevelCallNumberAsEffectiveCallNumber()
+    throws MalformedURLException, InterruptedException,
+    ExecutionException, TimeoutException {
+
+    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumber(mainLibraryLocationId);
+
+    JsonObject itemToCreate = nod(null, holdingsRecordId);
+
+    itemToCreate.put("tags", new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)));
+
+    itemToCreate.put("itemLevelCallNumber", "testItemCallNumber");
+
+    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
+
+    client.post(itemsStorageUrl(""), itemToCreate, StorageTestSuite.TENANT_ID,
+      ResponseHandler.json(createCompleted));
+
+    Response postResponse = createCompleted.get(5, TimeUnit.SECONDS);
+
+    assertThat(postResponse.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+
+    JsonObject itemFromPost = postResponse.getJson();
+
+    String newId = itemFromPost.getString("id");
+
+    assertThat(newId, is(notNullValue()));
+
+    Response getResponse = getById(UUID.fromString(newId));
+
+    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+
+    JsonObject itemFromGet = getResponse.getJson();
+
+    assertThat(itemFromGet.getString("id"), is(newId));
+    assertThat(itemFromGet.getString("holdingsRecordId"), is(holdingsRecordId.toString()));
+    assertThat(itemFromGet.getString("barcode"), is("565578437802"));
+    assertThat(itemFromGet.getJsonObject("status").getString("name"),
+      is("Available"));
+    assertThat(itemFromGet.getString("materialTypeId"),
+      is(journalMaterialTypeID));
+    assertThat(itemFromGet.getString("permanentLoanTypeId"),
+      is(canCirculateLoanTypeID));
+    assertThat(itemFromGet.getString("temporaryLocationId"),
+      is(annexLibraryLocationId.toString()));
+
+    List<String> tags = itemFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
+
+    assertThat(tags.size(), is(1));
+    assertThat(tags, hasItem(TAG_VALUE));
+    assertThat(itemFromGet.getString("effectiveCallNumber"), is("testItemCallNumber"));
+  }
+
+  @Test
+  public void canUpdateAnItemWithHoldingCallNumberAsEffectiveCallNumber()
+    throws MalformedURLException, InterruptedException,
+    ExecutionException, TimeoutException {
+
+    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumber(mainLibraryLocationId);
+    JsonObject itemToCreate = new JsonObject();
+    String itemId = UUID.randomUUID().toString();
+    itemToCreate.put("id", itemId);
+    itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
+    itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
+    itemToCreate.put("materialTypeId", bookMaterialTypeID);
+    createItem(itemToCreate);
+
+    CompletableFuture<Response> completed = new CompletableFuture<>();
+    client.put(itemsStorageUrl("/" + itemId), itemToCreate, StorageTestSuite.TENANT_ID,
+        ResponseHandler.text(completed));
+
+    Response getResponse = getById(UUID.fromString(itemId));
+
+    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+
+    JsonObject itemFromGet = getResponse.getJson();
+
+    assertThat(itemFromGet.getString("effectiveCallNumber"), is("testCallNumber"));
+  }
+
+  @Test
+  public void canUpdateAnItemWithItemLevelCallNumberAsEffectiveCallNumber()
+    throws MalformedURLException, InterruptedException,
+    ExecutionException, TimeoutException {
+
+    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumber(mainLibraryLocationId);
+    JsonObject itemToCreate = new JsonObject();
+    String itemId = UUID.randomUUID().toString();
+    itemToCreate.put("id", itemId);
+    itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
+    itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
+    itemToCreate.put("materialTypeId", bookMaterialTypeID);
+    itemToCreate.put("itemLevelCallNumber", "testItemCallNumber");
+    createItem(itemToCreate);
+
+    CompletableFuture<Response> completed = new CompletableFuture<>();
+    client.put(itemsStorageUrl("/" + itemId), itemToCreate, StorageTestSuite.TENANT_ID,
+        ResponseHandler.text(completed));
+
+    Response getResponse = getById(UUID.fromString(itemId));
+
+    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+
+    JsonObject itemFromGet = getResponse.getJson();
+
+    assertThat(itemFromGet.getString("effectiveCallNumber"), is("testItemCallNumber"));
+  }
+
+  @Test
   public void cannotAddANonExistentPermanentLocation()
     throws MalformedURLException, InterruptedException,
     ExecutionException, TimeoutException {

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -43,6 +43,24 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     ).getId();
   }
 
+  protected static UUID createInstanceAndHoldingWithCallNumber(UUID holdingsPermanentLocationId)
+      throws ExecutionException,
+      InterruptedException,
+      MalformedURLException,
+      TimeoutException {
+
+      UUID instanceId = UUID.randomUUID();
+      instancesClient.create(instance(instanceId));
+
+      return holdingsClient.create(
+        new HoldingRequestBuilder()
+          .withId(UUID.randomUUID())
+          .forInstance(instanceId)
+          .withPermanentLocation(holdingsPermanentLocationId)
+          .withCallNumber("testCallNumber")
+      ).getId();
+  }
+
   private static JsonObject instance(UUID id) {
     return createInstanceRequest(
       id,

--- a/src/test/java/org/folio/rest/support/builders/HoldingRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/HoldingRequestBuilder.java
@@ -10,12 +10,14 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
   private final UUID instanceId;
   private final UUID permanentLocationId;
   private JsonObject tags;
+  private String callNumber;
 
   public HoldingRequestBuilder() {
     this(
       null,
       null,
       UUID.randomUUID(),
+      null,
       null);
   }
 
@@ -23,12 +25,14 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     UUID id,
     UUID instanceId,
     UUID permanentLocationId,
-    JsonObject tags) {
+    JsonObject tags,
+    String callNumber) {
 
     this.id = id;
     this.instanceId = instanceId;
     this.permanentLocationId = permanentLocationId;
     this.tags = tags;
+    this.callNumber = callNumber;
   }
 
   @Override
@@ -39,6 +43,7 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     put(request, "instanceId", instanceId);
     put(request, "permanentLocationId", permanentLocationId);
     put(request, "tags", tags);
+    put(request, "callNumber", callNumber);
 
     return request;
   }
@@ -48,7 +53,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.id,
       this.instanceId,
       permanentLocationId,
-      this.tags);
+      this.tags,
+      this.callNumber);
   }
 
   public HoldingRequestBuilder forInstance(UUID instanceId) {
@@ -56,7 +62,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.id,
       instanceId,
       this.permanentLocationId,
-      this.tags);
+      this.tags,
+      this.callNumber);
   }
 
   public HoldingRequestBuilder withId(UUID id) {
@@ -64,7 +71,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       id,
       this.instanceId,
       this.permanentLocationId,
-      this.tags);
+      this.tags,
+      this.callNumber);
   }
 
   public HoldingRequestBuilder withTags(JsonObject tags) {
@@ -72,6 +80,16 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.id,
       this.instanceId,
       this.permanentLocationId,
-      tags);
+      tags,
+      this.callNumber);
+  }
+
+  public HoldingRequestBuilder withCallNumber(String callNumber) {
+    return new HoldingRequestBuilder(
+        this.id,
+        this.instanceId,
+        this.permanentLocationId,
+        this.tags,
+        callNumber);
   }
 }


### PR DESCRIPTION
Adds effectiveCallNumber property to Item and logic to derive its value on CREATE and PUT.

effectiveCallNumber will be set to:

- itemLevelCallNumber, if it is present on the Item

- If itemLevelCallNumber is not present and the Item has a holdingsRecordId, the matching holdingsRecord will be retrieved and effectiveCallNumber will be set to its value.
