### PR TITLE
MODINVSTOR-386: Add last checkin properties

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "item-storage",
-      "version": "7.6",
+      "version": "7.7",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/item-storage.raml
+++ b/ramls/item-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Item Storage
-version: v7.6
+version: v7.7
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -296,6 +296,45 @@
       "folio:linkFromField": "holdingsRecordId",
       "folio:linkToField": "id",
       "folio:includedElement": "holdingsRecords.0"
+    },
+    "lastCheckIn": {
+      "type": "object",
+      "readonly": true,
+      "additionalProperties": false,
+      "properties": {
+        "date": {
+          "type": "string",
+          "description": "Date and time of the last check in of the item."
+        },
+        "servicePointName": {
+          "type": "string",
+          "description": "Service point being used by user when item was scanned in Check in app."
+        },
+        "source": {
+          "type": "object",
+          "readonly": true,
+          "additionalProperties": false,
+          "description": "Lastname, first name middle name (with link to user profile) of user who scanned the item",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "ID of user who scanned the item"
+            },
+            "firstName": {
+              "type": "string",
+              "description": "First name of user who scanned the item"
+            },
+            "middleName": {
+              "type": "string",
+              "description": "Middle name of user who scanned the item"
+            },
+            "lastName": {
+              "type": "string",
+              "description": "Last name of user who scanned the item"
+            }
+          }
+        }
+      }
     }
   },
   "additionalProperties": false,

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -311,12 +311,12 @@
         "servicePointId": {
           "type": "string",
           "description": "Service point ID being used by a staff member when item was scanned in Check in app.",
-          "pattern": "[A-F0-9]{8}-[A-F0-9]{4}-4[A-F0-9]{3}-[89AB][A-F0-9]{3}-[A-F0-9]{12}"
+          "$ref": "uuid.json"
         },
         "staffMemberId": {
           "type": "string",
           "description": "ID a staff member who scanned the item",
-          "pattern": "[A-F0-9]{8}-[A-F0-9]{4}-4[A-F0-9]{3}-[89AB][A-F0-9]{3}-[A-F0-9]{12}"
+          "$ref": "uuid.json"
         }
       }
     }

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -301,36 +301,38 @@
       "type": "object",
       "readonly": true,
       "additionalProperties": false,
+      "description": "Information about when an item was last scanned on the Inventory app.",
       "properties": {
-        "date": {
+        "dateTime": {
           "type": "string",
-          "description": "Date and time of the last check in of the item."
+          "description": "Date and time of the last check in of the item.",
+          "format": "date-time"
         },
         "servicePointName": {
           "type": "string",
-          "description": "Service point being used by user when item was scanned in Check in app."
+          "description": "Service point being used by a staff member when item was scanned in Check in app."
         },
         "source": {
           "type": "object",
-          "readonly": true,
           "additionalProperties": false,
-          "description": "Lastname, first name middle name (with link to user profile) of user who scanned the item",
+          "description": "Last name, first name middle name of a staff member who scanned the item",
           "properties": {
-            "id": {
+            "staffMemberId": {
               "type": "string",
-              "description": "ID of user who scanned the item"
+              "description": "ID a staff member who scanned the item",
+              "pattern": "[A-F0-9]{8}-[A-F0-9]{4}-4[A-F0-9]{3}-[89AB][A-F0-9]{3}-[A-F0-9]{12}"
             },
             "firstName": {
               "type": "string",
-              "description": "First name of user who scanned the item"
+              "description": "First name of a staff member who scanned the item"
             },
             "middleName": {
               "type": "string",
-              "description": "Middle name of user who scanned the item"
+              "description": "Middle name of a staff member who scanned the item"
             },
             "lastName": {
               "type": "string",
-              "description": "Last name of user who scanned the item"
+              "description": "Last name of a staff member who scanned the item"
             }
           }
         }

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -299,7 +299,6 @@
     },
     "lastCheckIn": {
       "type": "object",
-      "readonly": true,
       "additionalProperties": false,
       "description": "Information about when an item was last scanned in the Inventory app.",
       "properties": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -301,52 +301,22 @@
       "type": "object",
       "readonly": true,
       "additionalProperties": false,
-      "description": "Information about when an item was last scanned on the Inventory app.",
+      "description": "Information about when an item was last scanned in the Inventory app.",
       "properties": {
         "dateTime": {
           "type": "string",
           "description": "Date and time of the last check in of the item.",
           "format": "date-time"
         },
-        "servicePointInfo": {
-          "type": "object",
-          "additionalProperties": false,
-          "description": "Service point being used by a staff member when item was scanned in Check in app.",
-          "properties": {
-            "id": {
-              "type": "string",
-              "description": "Service point ID being used by a staff member when item was scanned in Check in app.",
-              "pattern": "[A-F0-9]{8}-[A-F0-9]{4}-4[A-F0-9]{3}-[89AB][A-F0-9]{3}-[A-F0-9]{12}"
-            },
-            "name": {
-              "type": "string",
-              "description": "Service point name being used by a staff member when item was scanned in Check in app."
-            }
-          }
+        "servicePointId": {
+          "type": "string",
+          "description": "Service point ID being used by a staff member when item was scanned in Check in app.",
+          "pattern": "[A-F0-9]{8}-[A-F0-9]{4}-4[A-F0-9]{3}-[89AB][A-F0-9]{3}-[A-F0-9]{12}"
         },
-        "source": {
-          "type": "object",
-          "additionalProperties": false,
-          "description": "Last name, first name middle name of a staff member who scanned the item",
-          "properties": {
-            "staffMemberId": {
-              "type": "string",
-              "description": "ID a staff member who scanned the item",
-              "pattern": "[A-F0-9]{8}-[A-F0-9]{4}-4[A-F0-9]{3}-[89AB][A-F0-9]{3}-[A-F0-9]{12}"
-            },
-            "firstName": {
-              "type": "string",
-              "description": "First name of a staff member who scanned the item"
-            },
-            "middleName": {
-              "type": "string",
-              "description": "Middle name of a staff member who scanned the item"
-            },
-            "lastName": {
-              "type": "string",
-              "description": "Last name of a staff member who scanned the item"
-            }
-          }
+        "staffMemberId": {
+          "type": "string",
+          "description": "ID a staff member who scanned the item",
+          "pattern": "[A-F0-9]{8}-[A-F0-9]{4}-4[A-F0-9]{3}-[89AB][A-F0-9]{3}-[A-F0-9]{12}"
         }
       }
     }

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -308,9 +308,21 @@
           "description": "Date and time of the last check in of the item.",
           "format": "date-time"
         },
-        "servicePointName": {
-          "type": "string",
-          "description": "Service point being used by a staff member when item was scanned in Check in app."
+        "servicePointInfo": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Service point being used by a staff member when item was scanned in Check in app.",
+          "properties": {
+            "id": {
+              "type": "string",
+              "description": "Service point ID being used by a staff member when item was scanned in Check in app.",
+              "pattern": "[A-F0-9]{8}-[A-F0-9]{4}-4[A-F0-9]{3}-[89AB][A-F0-9]{3}-[A-F0-9]{12}"
+            },
+            "name": {
+              "type": "string",
+              "description": "Service point name being used by a staff member when item was scanned in Check in app."
+            }
+          }
         },
         "source": {
           "type": "object",

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -20,6 +20,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.UUID;
@@ -31,6 +32,7 @@ import java.util.stream.Collectors;
 
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.jaxrs.model.Items;
+import org.folio.rest.jaxrs.model.LastCheckIn;
 import org.folio.rest.support.AdditionalHttpStatusCodes;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.JsonArrayHelper;
@@ -1086,6 +1088,38 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(response.getStatusCode(), is(400));
     assertThat(response.getBody(), is("Unable to process request Tenant must be set"));
   }
+
+  @Test
+  public void testItemHasLastCheckInProperties()
+      throws MalformedURLException,
+      InterruptedException,
+      ExecutionException,
+      TimeoutException {
+    UUID itemId = UUID.randomUUID();
+    UUID userId = UUID.randomUUID();
+    UUID servicePointId = UUID.randomUUID();
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
+    JsonObject itemData = smallAngryPlanet(itemId, holdingsRecordId);
+    createItem(itemData);
+
+    LastCheckIn expected = new LastCheckIn();
+    expected.setStaffMemberId(userId.toString());
+    expected.setServicePointId(servicePointId.toString());
+    expected.setDateTime(new Date());
+    JsonObject lastCheckInData = JsonObject.mapFrom(expected);
+    itemData.put("lastCheckIn", lastCheckInData);
+
+    itemsClient.replace(itemId, itemData);
+    JsonObject actualItem = itemsClient.getById(itemId).getJson();
+    JsonObject actualLastCheckin = actualItem.getJsonObject("lastCheckIn");
+
+    LastCheckIn actual = actualLastCheckin.mapTo(LastCheckIn.class);
+
+    assertThat(expected.getDateTime(), is(actual.getDateTime()));
+    assertThat(expected.getServicePointId(), is(actual.getServicePointId()));
+    assertThat(expected.getStaffMemberId(), is(actual.getStaffMemberId()));
+  }
+
 
    private Response getById(UUID id)
     throws MalformedURLException, InterruptedException,


### PR DESCRIPTION
# Purpose

Store the information about when, where and by whom an item was last checked in, even when there is no loan.
This data is to be displayed in the item details.

This resolves MODINVSTOR-386
To be used in UIIN-749