### PR TITLE
MODINVSTOR-387 Admin data not updating properly on Instances created from SRS

### DIFF
--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -68,6 +68,7 @@ import io.vertx.ext.unit.junit.VertxUnitRunner;
 public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   private static final String INSTANCES_KEY = "instances";
   private static final String TOTAL_RECORDS_KEY = "totalRecords";
+  private static final String METADATA_KEY = "metadata";
   private static final String TAG_VALUE = "test-tag";
   private Set<String> natureOfContentIdsToRemoveAfterTest = new HashSet<>();
 
@@ -1442,6 +1443,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     JsonArray instances = instancesResponse.getJsonArray(INSTANCES_KEY);
     assertThat(instances.size(), is(numberOfInstances));
+    assertThat(instances.getJsonObject(1).getJsonObject(METADATA_KEY), notNullValue());
   }
 
   @Test


### PR DESCRIPTION

Expected:

When the instance is first created by data-import, the create/update date/time should be the same, and roughly equivalent to the "ended running" date/time in the import log.
When the instance is updated, the update date/time should change to be a few minutes later, but the create date/time should stay the same.

Actual:

When the instance is first created by data-import, the create/update date/time shows as unknown
When the instance is updated, the update date/time and the create date/time both change to the updated time