### PR TITLE
MODINVSTOR-376: Handle statusUpdatedDate property for instance.

### DIFF
--- a/src/main/resources/templates/db_scripts/instanceStatusUpdatedDateTrigger.sql
+++ b/src/main/resources/templates/db_scripts/instanceStatusUpdatedDateTrigger.sql
@@ -1,0 +1,17 @@
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.set_instance_status_updated_date()
+RETURNS trigger
+AS $function$
+	BEGIN
+		IF (OLD.jsonb->'statusId' IS DISTINCT FROM NEW.jsonb->'statusId') THEN
+			-- Date time in "yyyy-MM-dd'T'HH:mm:ss.SSS" format at UTC (00:00) time zone
+			NEW.jsonb = jsonb_set(NEW.jsonb, '{statusUpdatedDate}', to_jsonb(CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC'));
+		END IF;
+		RETURN NEW;
+	END;
+$function$  LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS set_instance_status_updated_date ON ${myuniversity}_${mymodule}.instance;
+
+CREATE TRIGGER set_instance_status_updated_date BEFORE
+UPDATE ON ${myuniversity}_${mymodule}.instance
+FOR EACH ROW EXECUTE PROCEDURE ${myuniversity}_${mymodule}.set_instance_status_updated_date();

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -684,6 +684,11 @@
       "run": "after",
       "snippetPath": "populateEffectiveLocationForExistingItems.sql",
       "fromModuleVersion": "17.1.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "instanceStatusUpdatedDateTrigger.sql",
+      "fromModuleVersion": "17.1.0"
     }
   ]
 }

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -1562,7 +1562,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
    * Test case for instanceStatusUpdatedDateTrigger.sql trigger.
    */
   @Test
-  public void shouldOverrideStatusUpdatedDate() throws Exception {
+  public void shouldChangeStatusUpdatedDateOnSubsequentStatusChanges() throws Exception {
     UUID id = UUID.randomUUID();
     JsonObject instanceToCreate = smallAngryPlanet(id)
       .put("statusId", getOtherInstanceType().getId().toString());
@@ -1597,7 +1597,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
    * Test case for instanceStatusUpdatedDateTrigger.sql trigger.
    */
   @Test
-  public void shouldNotOverrideStatusUpdatedDateOnSameStatusId() throws Exception {
+  public void shouldNotChangeStatusUpdatedDateWhenStatusHasNotChanged() throws Exception {
     UUID id = UUID.randomUUID();
     JsonObject instanceToCreate = smallAngryPlanet(id)
       .put("statusId", getOtherInstanceType().getId().toString());

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -12,13 +12,16 @@ import static org.folio.rest.support.http.InterfaceUrls.instancesStorageBatchIns
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.natureOfContentTermsUrl;
+import static org.folio.rest.support.matchers.DateTimeMatchers.withinSecondsBeforeNow;
 import static org.folio.util.StringUtil.urlEncode;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.core.IsNull.notNullValue;
+import static org.joda.time.Seconds.seconds;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
@@ -47,6 +50,7 @@ import org.folio.rest.jaxrs.model.NatureOfContentTerm;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.AdditionalHttpStatusCodes;
+import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.JsonArrayHelper;
 import org.folio.rest.support.JsonErrorResponse;
 import org.folio.rest.support.Response;
@@ -70,6 +74,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   private static final String TOTAL_RECORDS_KEY = "totalRecords";
   private static final String METADATA_KEY = "metadata";
   private static final String TAG_VALUE = "test-tag";
+  private static final String STATUS_UPDATED_DATE_PROPERTY = "statusUpdatedDate";
+
   private Set<String> natureOfContentIdsToRemoveAfterTest = new HashSet<>();
 
   // see also @BeforeClass TestBaseWithInventoryUtil.beforeAny()
@@ -152,6 +158,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(tags, hasItem(TAG_VALUE));
     assertThat(instanceFromGet.getJsonArray("natureOfContentTermIds"),
       containsInAnyOrder(natureOfContentIds));
+    assertThat(
+      instanceFromGet.getString(STATUS_UPDATED_DATE_PROPERTY), nullValue());
   }
 
   @Test
@@ -190,6 +198,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     JsonArray identifiers = instanceFromGet.getJsonArray("identifiers");
     assertThat(identifiers.size(), is(1));
     assertThat(identifiers, hasItem(identifierMatches(UUID_ISBN.toString(), "9781473619777")));
+    assertThat(
+      instanceFromGet.getString(STATUS_UPDATED_DATE_PROPERTY), nullValue());
   }
 
   @Test
@@ -331,6 +341,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(itemFromGet.getString("id"), is(id.toString()));
     assertThat(itemFromGet.getString("title"), is("A Long Way to a Small Angry Planet"));
+    assertThat(itemFromGet.getString(STATUS_UPDATED_DATE_PROPERTY),
+      is(replacement.getString(STATUS_UPDATED_DATE_PROPERTY)));
   }
 
   @Test
@@ -706,6 +718,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(fields.getJsonObject(1).getJsonObject("245")
         .getJsonArray("subfields").getJsonObject(0).getString("a"), is("The Yearbook of Okapiology"));
     assertThat(getResponse.getJson().getMap().keySet(), containsInAnyOrder("id", "leader", "fields"));
+    assertThat(getResponse.getJson().getString(STATUS_UPDATED_DATE_PROPERTY), nullValue());
   }
 
   @Test  // https://issues.folio.org/browse/MODINVSTOR-142?focusedCommentId=33665#comment-33665
@@ -720,6 +733,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(getResponse.getStatusCode(), is(200));
     JsonArray fields = getResponse.getJson().getJsonArray("fields");
     assertThat(fields.getJsonObject(0).getString("001"), is("101073931X"));
+    assertThat(getResponse.getJson().getString(STATUS_UPDATED_DATE_PROPERTY), nullValue());
   }
 
   @Test  // https://issues.folio.org/browse/MODINVSTOR-143?focusedCommentId=33618#comment-33618
@@ -734,6 +748,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(getResponse.getStatusCode(), is(200));
     JsonArray fields = getResponse.getJson().getJsonArray("fields");
     assertThat(fields.getJsonObject(0).getString("001"), is("1011273942"));
+    assertThat(getResponse.getJson().getString(STATUS_UPDATED_DATE_PROPERTY), nullValue());
   }
 
   @Test
@@ -749,6 +764,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(getResponse.getStatusCode(), is(200));
     JsonArray fields = getResponse.getJson().getJsonArray("fields");
     assertThat(fields.getJsonObject(0).getString("001"), is("101073931X"));
+    assertThat(getResponse.getJson().getString(STATUS_UPDATED_DATE_PROPERTY), nullValue());
   }
 
   @Test
@@ -1518,6 +1534,97 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(instances.size(), is(0));
   }
 
+  /**
+   * Test case for instanceStatusUpdatedDateTrigger.sql trigger.
+   */
+  @Test
+  public void shouldSetStatusUpdatedDate() throws Exception {
+    UUID id = UUID.randomUUID();
+    JsonObject instanceToCreate = smallAngryPlanet(id)
+      .put("statusId", getOtherInstanceType().getId().toString());
+
+    createInstance(instanceToCreate);
+
+    Response createdInstance = getById(id);
+    assertThat(createdInstance.getJson().getString(STATUS_UPDATED_DATE_PROPERTY),
+      nullValue());
+
+    JsonObject replacement = instanceToCreate.copy()
+      .put("statusId", getCatalogedInstanceType().getId().toString());
+
+    JsonObject updatedInstance = updateInstance(replacement).getJson();
+
+    assertThat(updatedInstance
+        .getString(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(2)));
+  }
+
+  /**
+   * Test case for instanceStatusUpdatedDateTrigger.sql trigger.
+   */
+  @Test
+  public void shouldOverrideStatusUpdatedDate() throws Exception {
+    UUID id = UUID.randomUUID();
+    JsonObject instanceToCreate = smallAngryPlanet(id)
+      .put("statusId", getOtherInstanceType().getId().toString());
+
+    createInstance(instanceToCreate);
+
+    Response createdInstance = getById(id);
+    assertThat(createdInstance.getJson().getString(STATUS_UPDATED_DATE_PROPERTY),
+      nullValue());
+
+    JsonObject instanceWithCatStatus = instanceToCreate.copy()
+      .put("statusId", getCatalogedInstanceType().getId().toString());
+    JsonObject updatedInstanceWithCatStatus = updateInstance(instanceWithCatStatus)
+      .getJson();
+
+    JsonObject instanceWithOthStatus = instanceWithCatStatus.copy()
+      .put("statusId", getOtherInstanceType().getId().toString());
+    JsonObject updatedInstanceWithOthStatus = updateInstance(instanceWithOthStatus)
+      .getJson();
+
+    // Assert that status updated date was changed since the first update
+    assertThat(updatedInstanceWithCatStatus.getString(STATUS_UPDATED_DATE_PROPERTY),
+      not(updatedInstanceWithOthStatus.getString(STATUS_UPDATED_DATE_PROPERTY)));
+
+    assertThat(updatedInstanceWithCatStatus
+        .getString(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(2)));
+    assertThat(updatedInstanceWithOthStatus
+        .getString(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(1)));
+  }
+
+  /**
+   * Test case for instanceStatusUpdatedDateTrigger.sql trigger.
+   */
+  @Test
+  public void shouldNotOverrideStatusUpdatedDateOnSameStatusId() throws Exception {
+    UUID id = UUID.randomUUID();
+    JsonObject instanceToCreate = smallAngryPlanet(id)
+      .put("statusId", getOtherInstanceType().getId().toString());
+
+    createInstance(instanceToCreate);
+
+    Response createdInstance = getById(id);
+    assertThat(createdInstance.getJson().getString(STATUS_UPDATED_DATE_PROPERTY),
+      nullValue());
+
+    JsonObject instanceWithCatStatus = instanceToCreate.copy()
+      .put("statusId", getCatalogedInstanceType().getId().toString());
+    JsonObject updatedInstanceWithCatStatus = updateInstance(instanceWithCatStatus)
+      .getJson();
+
+    JsonObject anotherInstanceWithCatStatus = updatedInstanceWithCatStatus.copy()
+      .put("statusId", getCatalogedInstanceType().getId().toString());
+    JsonObject updatedAnotherInstanceWithCatStatus =
+      updateInstance(anotherInstanceWithCatStatus)
+        .getJson();
+
+    assertThat(updatedInstanceWithCatStatus.getString(STATUS_UPDATED_DATE_PROPERTY),
+      is(updatedAnotherInstanceWithCatStatus.getString(STATUS_UPDATED_DATE_PROPERTY)));
+    assertThat(updatedInstanceWithCatStatus
+      .getString(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(2)));
+  }
+
   private void createHoldings(JsonObject holdingsToCreate)
     throws MalformedURLException,
     InterruptedException,
@@ -1577,6 +1684,24 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       json(getCompleted));
 
     return getCompleted.get(5, SECONDS);
+  }
+
+  private IndividualResource updateInstance(JsonObject instance)
+    throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+
+    final UUID id = UUID.fromString(instance.getString("id"));
+    CompletableFuture<Response> replaceCompleted = new CompletableFuture<>();
+
+    client.put(instancesStorageUrl(String.format("/%s", id)), instance,
+      TENANT_ID, ResponseHandler.empty(replaceCompleted));
+
+    Response putResponse = replaceCompleted.get(5, SECONDS);
+    assertThat(putResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+
+    Response getResponse = getById(id);
+    assertThat(getResponse.getStatusCode(), is(HTTP_OK));
+
+    return new IndividualResource(getResponse);
   }
 
   /**

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -1,6 +1,7 @@
 package org.folio.rest.api;
 
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.instanceStatusesUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.loanTypesStorageUrl;
@@ -231,4 +232,24 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     return instanceToCreate;
   }
 
+  IndividualResource getCatalogedInstanceType() throws Exception {
+    return getInstanceStatusByCode("cat");
+  }
+
+  IndividualResource getOtherInstanceType() throws Exception {
+    return getInstanceStatusByCode("other");
+  }
+
+  private IndividualResource getInstanceStatusByCode(String code) throws Exception {
+    CompletableFuture<Response> getCompleted = new CompletableFuture<>();
+
+    client.get(instanceStatusesUrl("?query=code=" + code),
+      StorageTestSuite.TENANT_ID, ResponseHandler.json(getCompleted));
+
+    JsonObject instanceStatus = getCompleted.get(5, TimeUnit.SECONDS)
+      .getJson()
+      .getJsonArray("instanceStatuses").getJsonObject(0);
+
+    return new IndividualResource(instanceStatus);
+  }
 }

--- a/src/test/java/org/folio/rest/support/IndividualResource.java
+++ b/src/test/java/org/folio/rest/support/IndividualResource.java
@@ -6,21 +6,25 @@ import java.util.UUID;
 
 public class IndividualResource {
 
-  private final Response response;
+  private final JsonObject response;
 
   public IndividualResource(Response response) {
-    this.response = response;
+    this.response = response.getJson();
+  }
+
+  public IndividualResource(JsonObject response) {
+    this.response = response.copy();
   }
 
   public UUID getId() {
-    return UUID.fromString(response.getJson().getString("id"));
+    return UUID.fromString(response.getString("id"));
   }
 
   public JsonObject getJson() {
-    return response.getJson().copy();
+    return response.copy();
   }
 
   public JsonObject copyJson() {
-    return response.getJson().copy();
+    return response.copy();
   }
 }

--- a/src/test/java/org/folio/rest/support/matchers/DateTimeMatchers.java
+++ b/src/test/java/org/folio/rest/support/matchers/DateTimeMatchers.java
@@ -1,0 +1,41 @@
+package org.folio.rest.support.matchers;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Seconds;
+
+public final class DateTimeMatchers {
+
+  private DateTimeMatchers() {
+    throw new UnsupportedOperationException("Do no instantiate");
+  }
+
+  private static Matcher<String> withinSecondsBefore(
+    Seconds seconds, DateTime beforeDateTime) {
+
+    return new TypeSafeMatcher<String>() {
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText(String.format(
+          "a date time within [%s] seconds before [%s]",
+          seconds.getSeconds(), beforeDateTime.toString()));
+      }
+
+      @Override
+      protected boolean matchesSafely(String textRepresentation) {
+        DateTime actual = DateTime.parse(textRepresentation);
+
+        return actual.isBefore(beforeDateTime)
+          && Seconds.secondsBetween(beforeDateTime, actual).isLessThan(seconds);
+      }
+    };
+  }
+
+  public static Matcher<String> withinSecondsBeforeNow(Seconds seconds) {
+    return withinSecondsBefore(seconds, DateTime.now(DateTimeZone.UTC));
+  }
+}


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-376: Instance record. Status updated date does not populate in detailed view

### Approach:

Added new before update trigger for instance table that sets `statusUpdatedDate` = NOW in case instance's `statusId` property has been changed.

The date time in `statusUpdatedDate` has the following format `yyyy-MM-dd'T'HH:mm:ss.SSS` (ISO-8601 that is standard in java) and it is in UTC timezone.