### PR TITLE
[BUGFIX] MODINVSTOR-376: Fix date time format.

### DIFF
--- a/src/main/resources/templates/db_scripts/instanceStatusUpdatedDateTrigger.sql
+++ b/src/main/resources/templates/db_scripts/instanceStatusUpdatedDateTrigger.sql
@@ -3,8 +3,11 @@ RETURNS trigger
 AS $function$
 	BEGIN
 		IF (OLD.jsonb->'statusId' IS DISTINCT FROM NEW.jsonb->'statusId') THEN
-			-- Date time in "yyyy-MM-dd'T'HH:mm:ss.SSS" format at UTC (00:00) time zone
-			NEW.jsonb = jsonb_set(NEW.jsonb, '{statusUpdatedDate}', to_jsonb(CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC'));
+			-- Date time in "yyyy-MM-dd'T'HH:mm:ss.SSS'+0000'" format at UTC (00:00) time zone
+			NEW.jsonb = jsonb_set(
+		    NEW.jsonb, '{statusUpdatedDate}',
+			  to_jsonb(to_char(CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.ms"+0000"'))
+		  );
 		END IF;
 		RETURN NEW;
 	END;

--- a/src/main/resources/templates/db_scripts/instanceStatusUpdatedDateTrigger.sql
+++ b/src/main/resources/templates/db_scripts/instanceStatusUpdatedDateTrigger.sql
@@ -3,10 +3,10 @@ RETURNS trigger
 AS $function$
 	BEGIN
 		IF (OLD.jsonb->'statusId' IS DISTINCT FROM NEW.jsonb->'statusId') THEN
-			-- Date time in "yyyy-MM-dd'T'HH:mm:ss.SSS'+0000'" format at UTC (00:00) time zone
+			-- Date time in "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'" format at UTC (00:00) time zone
 			NEW.jsonb = jsonb_set(
 		    NEW.jsonb, '{statusUpdatedDate}',
-			  to_jsonb(to_char(CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.ms"+0000"'))
+			  to_jsonb(to_char(CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.ms"Z"'))
 		  );
 		END IF;
 		RETURN NEW;

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -16,6 +16,7 @@ import static org.folio.rest.support.http.InterfaceUrls.instancesStorageSyncUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.natureOfContentTermsUrl;
+import static org.folio.rest.support.matchers.DateTimeMatchers.hasIsoFormat;
 import static org.folio.rest.support.matchers.DateTimeMatchers.withinSecondsBeforeNow;
 import static org.folio.util.StringUtil.urlEncode;
 import static org.hamcrest.CoreMatchers.allOf;
@@ -1651,6 +1652,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject updatedInstance = updateInstance(replacement).getJson();
 
+    assertThat(updatedInstance.getString(STATUS_UPDATED_DATE_PROPERTY), hasIsoFormat());
     assertThat(updatedInstance
         .getString(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(2)));
   }
@@ -1685,6 +1687,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(updatedInstanceWithCatStatus.getString(STATUS_UPDATED_DATE_PROPERTY),
       not(updatedInstanceWithOthStatus.getString(STATUS_UPDATED_DATE_PROPERTY)));
 
+    assertThat(updatedInstanceWithCatStatus.getString(STATUS_UPDATED_DATE_PROPERTY), hasIsoFormat());
+    assertThat(updatedInstanceWithOthStatus.getString(STATUS_UPDATED_DATE_PROPERTY), hasIsoFormat());
+
     assertThat(updatedInstanceWithCatStatus
         .getString(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(2)));
     assertThat(updatedInstanceWithOthStatus
@@ -1717,6 +1722,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     JsonObject updatedAnotherInstanceWithCatStatus =
       updateInstance(anotherInstanceWithCatStatus)
         .getJson();
+
+    assertThat(updatedInstanceWithCatStatus.getString(STATUS_UPDATED_DATE_PROPERTY), hasIsoFormat());
 
     assertThat(updatedInstanceWithCatStatus.getString(STATUS_UPDATED_DATE_PROPERTY),
       is(updatedAnotherInstanceWithCatStatus.getString(STATUS_UPDATED_DATE_PROPERTY)));

--- a/src/test/java/org/folio/rest/support/matchers/DateTimeMatchers.java
+++ b/src/test/java/org/folio/rest/support/matchers/DateTimeMatchers.java
@@ -1,11 +1,15 @@
 package org.folio.rest.support.matchers;
 
+import java.util.Arrays;
+import java.util.List;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.joda.time.Seconds;
+import org.joda.time.format.DateTimeFormat;
 
 public final class DateTimeMatchers {
 
@@ -37,5 +41,36 @@ public final class DateTimeMatchers {
 
   public static Matcher<String> withinSecondsBeforeNow(Seconds seconds) {
     return withinSecondsBefore(seconds, DateTime.now(DateTimeZone.UTC));
+  }
+
+  public static Matcher<String> hasIsoFormat() {
+    List<String> acceptableFormats = Arrays.asList(
+      "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
+      "yyyy-MM-dd'T'HH:mm:ss.SSS+0000"
+    );
+
+    return new TypeSafeMatcher<String>() {
+      @Override
+      protected boolean matchesSafely(String dateTimeAsString) {
+        return acceptableFormats.stream()
+          .anyMatch(dateTimeFormat -> {
+            try {
+              DateTimeFormat.forPattern(dateTimeFormat)
+                .parseDateTime(dateTimeAsString);
+            } catch (IllegalArgumentException ex) {
+              return false;
+            }
+
+            return true;
+          });
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description
+          .appendText("Has an ISO-8601 format:")
+          .appendValue(String.join("; ", acceptableFormats));
+      }
+    };
   }
 }

--- a/src/test/java/org/folio/rest/support/matchers/DateTimeMatchers.java
+++ b/src/test/java/org/folio/rest/support/matchers/DateTimeMatchers.java
@@ -1,8 +1,5 @@
 package org.folio.rest.support.matchers;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -44,32 +41,26 @@ public final class DateTimeMatchers {
   }
 
   public static Matcher<String> hasIsoFormat() {
-    List<String> acceptableFormats = Arrays.asList(
-      "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'",
-      "yyyy-MM-dd'T'HH:mm:ss.SSS+0000"
-    );
+    String acceptableFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZ";
 
     return new TypeSafeMatcher<String>() {
       @Override
       protected boolean matchesSafely(String dateTimeAsString) {
-        return acceptableFormats.stream()
-          .anyMatch(dateTimeFormat -> {
-            try {
-              DateTimeFormat.forPattern(dateTimeFormat)
-                .parseDateTime(dateTimeAsString);
-            } catch (IllegalArgumentException ex) {
-              return false;
-            }
+        try {
+          DateTimeFormat.forPattern(acceptableFormat)
+            .parseDateTime(dateTimeAsString);
+        } catch (IllegalArgumentException ex) {
+          return false;
+        }
 
-            return true;
-          });
+        return true;
       }
 
       @Override
       public void describeTo(Description description) {
         description
-          .appendText("Has an ISO-8601 format:")
-          .appendValue(String.join("; ", acceptableFormats));
+          .appendText("Has ISO-8601 format:")
+          .appendValue(acceptableFormat);
       }
     };
   }


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-376 - Instance record. Status updated date does not populate in detailed view.

Previously `statusUpdatedDate` was returned with no time zone information, which causes UI to display it in a wrong time zone. 

This PR changes `statusUpdatedDate` to has `yyyy-MM-dd'T'HH:mm:ss.SSS'+0000'` pattern (the same that used for metadata fields).