### PR TITLE
MODINVSTOR-374: Add holdings HRID support

### DIFF
--- a/sample-data/holdingsrecords/aba-holdingsrecord4.json
+++ b/sample-data/holdingsrecords/aba-holdingsrecord4.json
@@ -1,6 +1,5 @@
 {
   "id" : "0c45bb50-7c9b-48b0-86eb-178a494e25fe",
-  "hrid" : "ho00000136",
   "formerIds" : [ "ABW4508", "442882" ],
   "instanceId" : "69640328-788e-43fc-9c3c-af39e243f3b7",
   "permanentLocationId" : "fcd64ce1-6995-48f0-840e-89ffa2288371",

--- a/src/main/java/org/folio/rest/impl/HoldingsBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsBatchSyncAPI.java
@@ -1,12 +1,27 @@
 package org.folio.rest.impl;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import io.vertx.core.AsyncResult;
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+
 import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.HoldingsrecordsPost;
 import org.folio.rest.jaxrs.resource.HoldingsStorageBatchSynchronous;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.support.HridManager;
+import org.folio.rest.tools.utils.TenantTool;
+
 import javax.ws.rs.core.Response;
+
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 
 public class HoldingsBatchSyncAPI implements HoldingsStorageBatchSynchronous {
@@ -14,8 +29,43 @@ public class HoldingsBatchSyncAPI implements HoldingsStorageBatchSynchronous {
   @Override
   public void postHoldingsStorageBatchSynchronous(HoldingsrecordsPost entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    StorageHelper.postSync(HoldingsStorageAPI.HOLDINGS_RECORD_TABLE, entity.getHoldingsRecords(),
-        okapiHeaders, asyncResultHandler, vertxContext,
-        HoldingsStorageBatchSynchronous.PostHoldingsStorageBatchSynchronousResponse::respond201);
+    final List<HoldingsRecord> holdingsRecords = entity.getHoldingsRecords();
+    final PostgresClient postgresClient = PostgresClient.getInstance(
+          vertxContext.owner(), TenantTool.tenantId(okapiHeaders));
+    // Currently, there is no method on CompositeFuture to accept List<Future<String>>
+    @SuppressWarnings("rawtypes")
+    final List<Future> futures = new ArrayList<>();
+    final HridManager hridManager = new HridManager(Vertx.currentContext(), postgresClient);
+
+    for (HoldingsRecord holdingsRecord : holdingsRecords) {
+      futures.add(setHrid(holdingsRecord, hridManager));
+    }
+
+    CompositeFuture.all(futures).setHandler(ar -> {
+      if (ar.succeeded()) {
+        StorageHelper.postSync(HoldingsStorageAPI.HOLDINGS_RECORD_TABLE, holdingsRecords,
+            okapiHeaders, asyncResultHandler, vertxContext,
+            HoldingsStorageBatchSynchronous.PostHoldingsStorageBatchSynchronousResponse::respond201);
+      } else {
+        asyncResultHandler.handle(
+            Future.succeededFuture(PostHoldingsStorageBatchSynchronousResponse
+                .respond500WithTextPlain(ar.cause().getMessage())));
+      }
+    });
+  }
+
+  private Future<Void> setHrid(HoldingsRecord holdingsRecord, HridManager hridManager) {
+    final Future<String> hridFuture;
+
+    if (isBlank(holdingsRecord.getHrid())) {
+      hridFuture = hridManager.getNextHoldingsHrid();
+    } else {
+      hridFuture = Promise.succeededPromise(holdingsRecord.getHrid()).future();
+    }
+
+    return hridFuture.map(hrid -> {
+      holdingsRecord.setHrid(hrid);
+      return null;
+    });
   }
 }

--- a/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
@@ -1,7 +1,10 @@
 package org.folio.rest.impl;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -16,6 +19,7 @@ import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.HoldingsRecords;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.jaxrs.resource.HoldingsStorage;
+import org.folio.rest.persist.PgExceptionUtil;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.Criteria.Criteria;
@@ -23,7 +27,9 @@ import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.Criteria.Limit;
 import org.folio.rest.persist.Criteria.Offset;
 import org.folio.rest.persist.cql.CQLWrapper;
+import org.folio.rest.support.HridManager;
 import org.folio.rest.tools.utils.TenantTool;
+import org.folio.rest.tools.utils.ValidationHelper;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
@@ -175,30 +181,54 @@ public class HoldingsStorageAPI implements HoldingsStorage {
             }
           }
 
-          postgresClient.save(HOLDINGS_RECORD_TABLE, entity.getId(), entity,
-            reply -> {
-              try {
-                if(reply.succeeded()) {
-                  String ret = reply.result();
+          final Future<String> hridFuture;
+          if (isBlank(entity.getHrid())) {
+            final HridManager hridManager = new HridManager(vertxContext, postgresClient);
+            hridFuture = hridManager.getNextHoldingsHrid();
+          } else {
+            hridFuture = Promise.succeededPromise(entity.getHrid()).future();
+          }
+
+          hridFuture.map(hrid -> {
+            entity.setHrid(hrid);
+            postgresClient.save(HOLDINGS_RECORD_TABLE, entity.getId(), entity,
+              reply -> {
+                try {
+                  if(reply.succeeded()) {
+                    String ret = reply.result();
+                    asyncResultHandler.handle(
+                      io.vertx.core.Future.succeededFuture(
+                        PostHoldingsStorageHoldingsResponse
+                          .respond201WithApplicationJson(entity, PostHoldingsStorageHoldingsResponse.headersFor201().withLocation(ret))));
+                  }
+                  else {
+                    if (PgExceptionUtil.isUniqueViolation(reply.cause())) {
+                      ValidationHelper.handleError(reply.cause(), asyncResultHandler);
+                    } else {
+                      asyncResultHandler.handle(
+                        io.vertx.core.Future.succeededFuture(
+                          PostHoldingsStorageHoldingsResponse
+                            .respond400WithTextPlain(reply.cause().getMessage())));
+                    }
+                  }
+                } catch (Exception e) {
+                  log.error(e.getMessage());
                   asyncResultHandler.handle(
                     io.vertx.core.Future.succeededFuture(
                       PostHoldingsStorageHoldingsResponse
-                        .respond201WithApplicationJson(entity, PostHoldingsStorageHoldingsResponse.headersFor201().withLocation(ret))));
+                        .respond500WithTextPlain(e.getMessage())));
                 }
-                else {
-                  asyncResultHandler.handle(
-                    io.vertx.core.Future.succeededFuture(
-                      PostHoldingsStorageHoldingsResponse
-                        .respond400WithTextPlain(reply.cause().getMessage())));
-                }
-              } catch (Exception e) {
-                log.error(e.getMessage());
-                asyncResultHandler.handle(
-                  io.vertx.core.Future.succeededFuture(
-                    PostHoldingsStorageHoldingsResponse
-                      .respond500WithTextPlain(e.getMessage())));
-              }
-            });
+              });
+            return null;
+          })
+          .otherwise(error -> {
+            log.error(error.getMessage(), error);
+            asyncResultHandler.handle(
+              io.vertx.core.Future.succeededFuture(
+                PostHoldingsStorageHoldingsResponse
+                  .respond500WithTextPlain(error.getMessage())));
+            return null;
+          });
         } catch (Exception e) {
           log.error(e.getMessage());
           asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
@@ -333,47 +363,60 @@ public class HoldingsStorageAPI implements HoldingsStorage {
                 if (holdingsList.size() == 1) {
                   try {
                     postgresClient.startTx(connection -> {
-                      updateItemEffectiveCallNumbersByHoldings(connection, postgresClient, entity).setHandler(updateResult -> {
-                        if (updateResult.succeeded()) {
-                          postgresClient.update(connection, HOLDINGS_RECORD_TABLE, entity,
-                            "jsonb", String.format(WHERE_CLAUSE, holdingsRecordId), false,
-                            update -> {
-                              try {
-                                if (update.succeeded()) {
-                                  postgresClient.endTx(connection, done -> {
-                                    asyncResultHandler.handle(
-                                      Future.succeededFuture(
-                                        PutHoldingsStorageHoldingsByHoldingsRecordIdResponse
-                                          .respond204()));
-                                  });
-                                }
-                                else {
+                      final HoldingsRecord existingHoldings = holdingsList.get(0);
+                      if (Objects.equals(entity.getHrid(), existingHoldings.getHrid())) { 
+                        updateItemEffectiveCallNumbersByHoldings(connection, postgresClient, entity).setHandler(updateResult -> {
+                          if (updateResult.succeeded()) {
+                            postgresClient.update(connection, HOLDINGS_RECORD_TABLE, entity,
+                              "jsonb", String.format(WHERE_CLAUSE, holdingsRecordId), false,
+                              update -> {
+                                try {
+                                  if (update.succeeded()) {
+                                    postgresClient.endTx(connection, done -> {
+                                      asyncResultHandler.handle(
+                                        Future.succeededFuture(
+                                          PutHoldingsStorageHoldingsByHoldingsRecordIdResponse
+                                            .respond204()));
+                                    });
+                                  }
+                                  else {
+                                    postgresClient.rollbackTx(connection, rollback -> {
+                                      asyncResultHandler.handle(
+                                        Future.succeededFuture(
+                                          PutHoldingsStorageHoldingsByHoldingsRecordIdResponse
+                                            .respond500WithTextPlain(
+                                              update.cause().getMessage())));
+                                    });
+                                  }
+                                } catch (Exception e) {
                                   postgresClient.rollbackTx(connection, rollback -> {
                                     asyncResultHandler.handle(
                                       Future.succeededFuture(
                                         PutHoldingsStorageHoldingsByHoldingsRecordIdResponse
-                                          .respond500WithTextPlain(
-                                            update.cause().getMessage())));
+                                          .respond500WithTextPlain(e.getMessage())));
                                   });
                                 }
-                              } catch (Exception e) {
-                                postgresClient.rollbackTx(connection, rollback -> {
-                                  asyncResultHandler.handle(
-                                    Future.succeededFuture(
-                                      PutHoldingsStorageHoldingsByHoldingsRecordIdResponse
-                                        .respond500WithTextPlain(e.getMessage())));
-                                });
-                              }
-                            });
-                        } else {
-                          postgresClient.rollbackTx(connection, rollback -> {
+                              });
+                          } else {
+                            postgresClient.rollbackTx(connection, rollback ->
+                              asyncResultHandler.handle(
+                                Future.succeededFuture(
+                                  PutHoldingsStorageHoldingsByHoldingsRecordIdResponse
+                                    .respond500WithTextPlain(
+                                      updateResult.cause().getMessage()))));
+                          }
+                        });
+                      } else {
+                        postgresClient.rollbackTx(connection, rollback ->
+                          asyncResultHandler.handle(
                             Future.succeededFuture(
                               PutHoldingsStorageHoldingsByHoldingsRecordIdResponse
-                                .respond500WithTextPlain(
-                                  updateResult.cause().getMessage()));
-                          });
-                        }
-                      });
+                                .respond400WithTextPlain(
+                                    "The hrid field cannot be changed: new="
+                                      + entity.getHrid()
+                                      + ", old="
+                                      + existingHoldings.getHrid()))));
+                      }
                     });
                   } catch (Exception e) {
                     asyncResultHandler.handle(Future.succeededFuture(
@@ -383,29 +426,51 @@ public class HoldingsStorageAPI implements HoldingsStorage {
               }
               else {
                 try {
-                  postgresClient.save(HOLDINGS_RECORD_TABLE, entity.getId(), entity,
-                    save -> {
-                      try {
-                        if(save.succeeded()) {
+                  final Future<String> hridFuture;
+                  if (isBlank(entity.getHrid())) {
+                    final HridManager hridManager = new HridManager(vertxContext, postgresClient);
+                    hridFuture = hridManager.getNextHoldingsHrid();
+                  } else {
+                    hridFuture = Promise.succeededPromise(entity.getHrid()).future();
+                  }
+
+                  hridFuture.map(hrid -> {
+                    entity.setHrid(hrid);
+                    postgresClient.save(HOLDINGS_RECORD_TABLE, entity.getId(), entity,
+                      save -> {
+                        try {
+                          if(save.succeeded()) {
+                            asyncResultHandler.handle(
+                              Future.succeededFuture(
+                                PutHoldingsStorageHoldingsByHoldingsRecordIdResponse
+                                  .respond204()));
+                          }
+                          else {
+                            if (PgExceptionUtil.isUniqueViolation(save.cause())) {
+                              asyncResultHandler.handle(
+                                Future.succeededFuture(
+                                  PutHoldingsStorageHoldingsByHoldingsRecordIdResponse
+                                    .respond400WithTextPlain(PgExceptionUtil.badRequestMessage(save.cause()))));
+                            } else {
+                              asyncResultHandler.handle(
+                                Future.succeededFuture(
+                                  PutHoldingsStorageHoldingsByHoldingsRecordIdResponse
+                                    .respond500WithTextPlain(
+                                      save.cause().getMessage())));
+                            }
+                          }
+                        } catch (Exception e) {
                           asyncResultHandler.handle(
                             Future.succeededFuture(
                               PutHoldingsStorageHoldingsByHoldingsRecordIdResponse
-                                .respond204()));
+                                .respond500WithTextPlain(e.getMessage())));
                         }
-                        else {
-                          asyncResultHandler.handle(
-                            Future.succeededFuture(
-                              PutHoldingsStorageHoldingsByHoldingsRecordIdResponse
-                                .respond500WithTextPlain(
-                                  save.cause().getMessage())));
-                        }
-                      } catch (Exception e) {
-                        asyncResultHandler.handle(
-                          Future.succeededFuture(
-                            PutHoldingsStorageHoldingsByHoldingsRecordIdResponse
-                              .respond500WithTextPlain(e.getMessage())));
-                      }
-                    });
+                      });
+                    return null;
+                  })
+                  .otherwise(error -> {
+                    return null;
+                  });
                 } catch (Exception e) {
                   asyncResultHandler.handle(Future.succeededFuture(
                     PutHoldingsStorageHoldingsByHoldingsRecordIdResponse

--- a/src/main/java/org/folio/rest/support/HridManager.java
+++ b/src/main/java/org/folio/rest/support/HridManager.java
@@ -36,7 +36,7 @@ public class HridManager {
     return getNextHrid(hridSettings -> getNextHrid(hridSettings.getInstances(), "instances"));
   }
 
-  public Future<String> getNextHoldingHrid() {
+  public Future<String> getNextHoldingsHrid() {
     return getNextHrid(hridSettings -> getNextHrid(hridSettings.getHoldings(), "holdings"));
   }
 

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -1702,7 +1702,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     Response response = getById(holdingsArray.getJsonObject(0).getString("id"));
     assertExists(response, holdingsArray.getJsonObject(0));
-    assertThat(response.getJson().getString("hrid"), is("ho00000001"));
+    assertHRIDRange(response, "ho00000001", "ho00000002");
 
     response = getById(holdingsArray.getJsonObject(1).getString("id"));
     assertExists(response, holdingsArray.getJsonObject(1));
@@ -1710,7 +1710,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     response = getById(holdingsArray.getJsonObject(2).getString("id"));
     assertExists(response, holdingsArray.getJsonObject(2));
-    assertThat(response.getJson().getString("hrid"), is("ho00000002"));
+    assertHRIDRange(response, "ho00000001", "ho00000002");
 
     log.info("Finished canPostSynchronousBatchWithSuppliedAndGeneratedHRID");
   }

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -91,6 +91,8 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     instancesClient.create(smallAngryPlanet(instanceId));
 
+    setHoldingsSequence(1);
+
     UUID holdingId = UUID.randomUUID();
 
     JsonObject holding = holdingsClient.create(new HoldingRequestBuilder()
@@ -102,6 +104,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(holding.getString("id"), is(holdingId.toString()));
     assertThat(holding.getString("instanceId"), is(instanceId.toString()));
     assertThat(holding.getString("permanentLocationId"), is(mainLibraryLocationId.toString()));
+    assertThat(holding.getString("hrid"), is("ho00000001"));
 
     Response getResponse = holdingsClient.getById(holdingId);
 
@@ -112,6 +115,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(holdingFromGet.getString("id"), is(holdingId.toString()));
     assertThat(holdingFromGet.getString("instanceId"), is(instanceId.toString()));
     assertThat(holdingFromGet.getString("permanentLocationId"), is(mainLibraryLocationId.toString()));
+    assertThat(holdingFromGet.getString("hrid"), is("ho00000001"));
 
     List<String> tags = holdingFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
 
@@ -207,6 +211,8 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     instancesClient.create(smallAngryPlanet(instanceId));
 
+    setHoldingsSequence(1);
+
     UUID holdingId = UUID.randomUUID();
 
     holdingsClient.replace(holdingId, new HoldingRequestBuilder()
@@ -224,6 +230,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(holdingFromGet.getString("id"), is(holdingId.toString()));
     assertThat(holdingFromGet.getString("instanceId"), is(instanceId.toString()));
     assertThat(holdingFromGet.getString("permanentLocationId"), is(mainLibraryLocationId.toString()));
+    assertThat(holdingFromGet.getString("hrid"), is("ho00000001"));
 
     List<String> tags = holdingFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
 
@@ -271,6 +278,8 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     instancesClient.create(smallAngryPlanet(instanceId));
 
+    setHoldingsSequence(1);
+
     IndividualResource holdingResource = holdingsClient.create(new HoldingRequestBuilder()
       .forInstance(instanceId)
       .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))
@@ -293,6 +302,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(holdingFromGet.getString("id"), is(holdingId.toString()));
     assertThat(holdingFromGet.getString("instanceId"), is(instanceId.toString()));
     assertThat(holdingFromGet.getString("permanentLocationId"), is(annexLibraryLocationId.toString()));
+    assertThat(holdingFromGet.getString("hrid"), is("ho00000001"));
 
     List<String> tags = holdingFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
 
@@ -830,41 +840,6 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canCreateAHoldingsWhenHRIDNotSupplied()
-      throws MalformedURLException,
-      InterruptedException,
-      ExecutionException,
-      TimeoutException {
-    log.info("Starting canCreateAHoldingsWhenHRIDNotSupplied");
-
-    final UUID instanceId = UUID.randomUUID();
-
-    instancesClient.create(smallAngryPlanet(instanceId));
-
-    final UUID holdingsId = UUID.randomUUID();
-
-    setHoldingsSequence(1);
-
-    final JsonObject holdings = holdingsClient.create(new HoldingRequestBuilder()
-      .withId(holdingsId)
-      .forInstance(instanceId)
-      .withPermanentLocation(mainLibraryLocationId)
-      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getJson();
-
-    assertThat(holdings.getString("hrid"), is("ho00000001"));
-
-    final Response getResponse = holdingsClient.getById(holdingsId);
-
-    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-
-    final JsonObject holdingsFromGet = getResponse.getJson();
-
-    assertThat(holdingsFromGet.getString("hrid"), is("ho00000001"));
-
-    log.info("Finished canCreateAHoldingsWhenHRIDNotSupplied");
-  }
-
-  @Test
   public void canCreateAHoldingsWhenHRIDIsSupplied()
       throws MalformedURLException,
       InterruptedException,
@@ -1084,39 +1059,6 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canUsePutToCreateAHoldingsWhenHRIDNotSupplied()
-      throws MalformedURLException,
-      InterruptedException,
-      ExecutionException,
-      TimeoutException {
-    log.info("Starting canUsePutToCreateAHoldingsWhenHRIDNotSupplied");
-
-    final UUID instanceId = UUID.randomUUID();
-
-    instancesClient.create(smallAngryPlanet(instanceId));
-
-    final UUID holdingsId = UUID.randomUUID();
-
-    setHoldingsSequence(1);
-
-    holdingsClient.replace(holdingsId, new HoldingRequestBuilder()
-      .withId(holdingsId)
-      .forInstance(instanceId)
-      .withPermanentLocation(mainLibraryLocationId)
-      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE))));
-
-    final Response getResponse = holdingsClient.getById(holdingsId);
-
-    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-
-    final JsonObject holdingsFromGet = getResponse.getJson();
-
-    assertThat(holdingsFromGet.getString("hrid"), is("ho00000001"));
-
-    log.info("Finished canUsePutToCreateAHoldingsWhenHRIDNotSupplied");
-  }
-
-  @Test
   public void canUsePutToCreateAHoldingsWhenHRIDIsSupplied()
       throws MalformedURLException,
       InterruptedException,
@@ -1172,8 +1114,8 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canPostSynchronousBatchWithSuppliedAndHRID() {
-    log.info("Starting canPostSynchronousBatchWithSuppliedAndHRID");
+  public void canPostSynchronousBatchWithSuppliedAndGeneratedHRID() {
+    log.info("Starting canPostSynchronousBatchWithSuppliedAndGeneratedHRID");
 
     setHoldingsSequence(1);
 
@@ -1196,7 +1138,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertExists(response, holdingsArray.getJsonObject(2));
     assertThat(response.getJson().getString("hrid"), is("ho00000002"));
 
-    log.info("Finished canPostSynchronousBatchWithSuppliedAndHRID");
+    log.info("Finished canPostSynchronousBatchWithSuppliedAndGeneratedHRID");
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -7,6 +7,7 @@ import static org.folio.rest.support.HttpResponseMatchers.errorParametersValueIs
 import static org.folio.rest.support.HttpResponseMatchers.statusCodeIs;
 import static org.folio.rest.support.JsonObjectMatchers.hasSoleMessageContaining;
 import static org.folio.rest.support.ResponseHandler.json;
+import static org.folio.rest.support.ResponseHandler.text;
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageSyncUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
@@ -15,8 +16,12 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.Matchers.both;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.hamcrest.Matchers.lessThanOrEqualTo;
 import static org.hamcrest.core.IsCollectionContaining.hasItem;
 import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
 
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -31,6 +36,8 @@ import java.util.function.Predicate;
 
 import org.apache.commons.lang.StringUtils;
 import org.folio.HttpStatus;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.AdditionalHttpStatusCodes;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.JsonArrayHelper;
@@ -42,11 +49,15 @@ import org.junit.After;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
+  private static final Logger log = LoggerFactory.getLogger(HoldingsStorageTest.class);
   private static final String TAG_VALUE = "test-tag";
   public static final String NEW_TEST_TAG = "new test tag";
 
@@ -62,6 +73,11 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   @After
   public void checkIdsAfterEach() {
     StorageTestSuite.checkForMismatchedIDs("holdings_record");
+  }
+
+  @After
+  public void resetHoldingsHRID() {
+    setHoldingsSequence(1);
   }
 
   @Test
@@ -813,6 +829,443 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       is("permanentLocationId"));
   }
 
+  @Test
+  public void canCreateAHoldingsWhenHRIDNotSupplied()
+      throws MalformedURLException,
+      InterruptedException,
+      ExecutionException,
+      TimeoutException {
+    log.info("Starting canCreateAHoldingsWhenHRIDNotSupplied");
+
+    final UUID instanceId = UUID.randomUUID();
+
+    instancesClient.create(smallAngryPlanet(instanceId));
+
+    final UUID holdingsId = UUID.randomUUID();
+
+    setHoldingsSequence(1);
+
+    final JsonObject holdings = holdingsClient.create(new HoldingRequestBuilder()
+      .withId(holdingsId)
+      .forInstance(instanceId)
+      .withPermanentLocation(mainLibraryLocationId)
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getJson();
+
+    assertThat(holdings.getString("hrid"), is("ho00000001"));
+
+    final Response getResponse = holdingsClient.getById(holdingsId);
+
+    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+
+    final JsonObject holdingsFromGet = getResponse.getJson();
+
+    assertThat(holdingsFromGet.getString("hrid"), is("ho00000001"));
+
+    log.info("Finished canCreateAHoldingsWhenHRIDNotSupplied");
+  }
+
+  @Test
+  public void canCreateAHoldingsWhenHRIDIsSupplied()
+      throws MalformedURLException,
+      InterruptedException,
+      ExecutionException,
+      TimeoutException {
+    log.info("Starting canCreateAHoldingsWhenHRIDIsSupplied");
+
+    final UUID instanceId = UUID.randomUUID();
+
+    instancesClient.create(smallAngryPlanet(instanceId));
+
+    final UUID holdingsId = UUID.randomUUID();
+
+    final String hrid = "TEST1001";
+
+    final JsonObject holdings = holdingsClient.create(new HoldingRequestBuilder()
+      .withId(holdingsId)
+      .forInstance(instanceId)
+      .withPermanentLocation(mainLibraryLocationId)
+      .withHrid(hrid)
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getJson();
+
+    assertThat(holdings.getString("hrid"), is(hrid));
+
+    final Response getResponse = holdingsClient.getById(holdingsId);
+
+    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+
+    final JsonObject holdingsFromGet = getResponse.getJson();
+
+    assertThat(holdingsFromGet.getString("hrid"), is(hrid));
+
+    log.info("Finished canCreateAHoldingsWhenHRIDIsSupplied");
+  }
+
+  @Test
+  public void cannotCreateAHoldingsWhenDuplicateHRIDIsSupplied()
+      throws MalformedURLException,
+      InterruptedException,
+      ExecutionException,
+      TimeoutException {
+    log.info("Starting cannotCreateAHoldingsWhenDuplicateHRIDIsSupplied");
+
+    final UUID instanceId = UUID.randomUUID();
+
+    instancesClient.create(smallAngryPlanet(instanceId));
+
+    final UUID holdingsId = UUID.randomUUID();
+
+    setHoldingsSequence(1);
+
+    final JsonObject holdings = holdingsClient.create(new HoldingRequestBuilder()
+      .withId(holdingsId)
+      .forInstance(instanceId)
+      .withPermanentLocation(mainLibraryLocationId)
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getJson();
+
+    assertThat(holdings.getString("hrid"), is("ho00000001"));
+
+    final Response getResponse = holdingsClient.getById(holdingsId);
+
+    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+
+    final JsonObject holdingsFromGet = getResponse.getJson();
+
+    assertThat(holdingsFromGet.getString("hrid"), is("ho00000001"));
+
+    final JsonObject duplicateHoldings = new HoldingRequestBuilder()
+        .withId(UUID.randomUUID())
+        .forInstance(instanceId)
+        .withPermanentLocation(mainLibraryLocationId)
+        .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))
+        .withHrid("ho00000001")
+        .create();
+
+    final Response duplicateResponse = create(holdingsStorageUrl(""), duplicateHoldings);
+
+    assertThat(duplicateResponse.getStatusCode(), is(422));
+
+    final Errors errors = duplicateResponse.getJson().mapTo(Errors.class);
+
+    assertThat(errors, notNullValue());
+    assertThat(errors.getErrors(), notNullValue());
+    assertThat(errors.getErrors().size(), is(1));
+    assertThat(errors.getErrors().get(0), notNullValue());
+    assertThat(errors.getErrors().get(0).getMessage(),
+        is("duplicate key value violates unique constraint \"holdings_record_hrid_idx_unique\""));
+    assertThat(errors.getErrors().get(0).getParameters(), notNullValue());
+    assertThat(errors.getErrors().get(0).getParameters().size(), is(1));
+    assertThat(errors.getErrors().get(0).getParameters().get(0), notNullValue());
+    assertThat(errors.getErrors().get(0).getParameters().get(0).getKey(),
+        is("lower(f_unaccent(jsonb ->> 'hrid'::text"));
+    assertThat(errors.getErrors().get(0).getParameters().get(0).getValue(),
+        is("ho00000001"));
+
+    log.info("Finished cannotCreateAHoldingsWhenDuplicateHRIDIsSupplied");
+  }
+
+  @Test
+  public void cannotCreateAHoldingsWithHRIDFailure()
+      throws MalformedURLException,
+      InterruptedException,
+      ExecutionException,
+      TimeoutException {
+    log.info("Starting cannotCreateAHoldingsWithHRIDFailure");
+
+    final UUID instanceId = UUID.randomUUID();
+
+    instancesClient.create(smallAngryPlanet(instanceId));
+
+    setHoldingsSequence(99999999);
+
+    final JsonObject goodHholdings = holdingsClient.create(new HoldingRequestBuilder()
+      .withId(UUID.randomUUID())
+      .forInstance(instanceId)
+      .withPermanentLocation(mainLibraryLocationId)
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getJson();
+
+    assertThat(goodHholdings.getString("hrid"), is("ho99999999"));
+
+    final JsonObject badHoldings = new HoldingRequestBuilder()
+      .withId(UUID.randomUUID())
+      .forInstance(instanceId)
+      .withPermanentLocation(mainLibraryLocationId)
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))
+      .create();
+
+    final CompletableFuture<Response> createCompleted = new CompletableFuture<>();
+
+    client.post(holdingsStorageUrl(""), badHoldings, TENANT_ID, text(createCompleted));
+
+    final Response response = createCompleted.get(5, TimeUnit.SECONDS);
+
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
+    assertThat(response.getBody(),
+        is("ErrorMessage(fields=[(Severity, ERROR), (V, ERROR), (SQLSTATE, 2200H), (Message, nextval: reached maximum value of sequence \"hrid_holdings_seq\" (99999999)), (File, sequence.c), (Line, 700), (Routine, nextval_internal)])"));
+
+    log.info("Finished cannotCreateAHoldingsWithHRIDFailure");
+  }
+
+  @Test
+  public void cannotChangeHRIDAfterCreation()
+      throws MalformedURLException,
+      InterruptedException,
+      ExecutionException,
+      TimeoutException {
+    log.info("Starting cannotChangeHRIDAfterCreation");
+
+    final UUID instanceId = UUID.randomUUID();
+    final UUID holdingsId = UUID.randomUUID();
+
+    instancesClient.create(smallAngryPlanet(instanceId));
+
+    setHoldingsSequence(1);
+
+    final JsonObject holdings = holdingsClient.create(new HoldingRequestBuilder()
+      .withId(holdingsId)
+      .forInstance(instanceId)
+      .withPermanentLocation(mainLibraryLocationId)
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getJson();
+
+    assertThat(holdings.getString("hrid"), is("ho00000001"));
+
+    holdings.put("hrid", "ABC123");
+
+    final CompletableFuture<Response> updateCompleted = new CompletableFuture<>();
+
+    client.put(holdingsStorageUrl(String.format("/%s", holdingsId)), holdings, TENANT_ID,
+        text(updateCompleted));
+
+    final Response response = updateCompleted.get(5, TimeUnit.SECONDS);
+
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
+    assertThat(response.getBody(),
+        is("The hrid field cannot be changed: new=ABC123, old=ho00000001"));
+
+    log.info("Finished cannotChangeHRIDAfterCreation");
+  }
+
+  @Test
+  public void cannotRemoveHRIDAfterCreation()
+      throws MalformedURLException,
+      InterruptedException,
+      ExecutionException,
+      TimeoutException {
+    log.info("Starting cannotRemoveHRIDAfterCreation");
+
+    final UUID instanceId = UUID.randomUUID();
+    final UUID holdingsId = UUID.randomUUID();
+
+    instancesClient.create(smallAngryPlanet(instanceId));
+
+    setHoldingsSequence(1);
+
+    final JsonObject holdings = holdingsClient.create(new HoldingRequestBuilder()
+      .withId(holdingsId)
+      .forInstance(instanceId)
+      .withPermanentLocation(mainLibraryLocationId)
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getJson();
+
+    assertThat(holdings.getString("hrid"), is("ho00000001"));
+
+    holdings.remove("hrid");
+
+    final CompletableFuture<Response> updateCompleted = new CompletableFuture<>();
+
+    client.put(holdingsStorageUrl(String.format("/%s", holdingsId)), holdings, TENANT_ID,
+        text(updateCompleted));
+
+    final Response response = updateCompleted.get(5, TimeUnit.SECONDS);
+
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
+    assertThat(response.getBody(),
+        is("The hrid field cannot be changed: new=null, old=ho00000001"));
+
+    log.info("Finished cannotRemoveHRIDAfterCreation");
+  }
+
+  @Test
+  public void canUsePutToCreateAHoldingsWhenHRIDNotSupplied()
+      throws MalformedURLException,
+      InterruptedException,
+      ExecutionException,
+      TimeoutException {
+    log.info("Starting canUsePutToCreateAHoldingsWhenHRIDNotSupplied");
+
+    final UUID instanceId = UUID.randomUUID();
+
+    instancesClient.create(smallAngryPlanet(instanceId));
+
+    final UUID holdingsId = UUID.randomUUID();
+
+    setHoldingsSequence(1);
+
+    holdingsClient.replace(holdingsId, new HoldingRequestBuilder()
+      .withId(holdingsId)
+      .forInstance(instanceId)
+      .withPermanentLocation(mainLibraryLocationId)
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE))));
+
+    final Response getResponse = holdingsClient.getById(holdingsId);
+
+    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+
+    final JsonObject holdingsFromGet = getResponse.getJson();
+
+    assertThat(holdingsFromGet.getString("hrid"), is("ho00000001"));
+
+    log.info("Finished canUsePutToCreateAHoldingsWhenHRIDNotSupplied");
+  }
+
+  @Test
+  public void canUsePutToCreateAHoldingsWhenHRIDIsSupplied()
+      throws MalformedURLException,
+      InterruptedException,
+      ExecutionException,
+      TimeoutException {
+    log.info("Starting canUsePutToCreateAHoldingsWhenHRIDIsSupplied");
+
+    final UUID instanceId = UUID.randomUUID();
+
+    instancesClient.create(smallAngryPlanet(instanceId));
+
+    final UUID holdingsId = UUID.randomUUID();
+
+    final String hrid = "TEST1001";
+
+    holdingsClient.replace(holdingsId, new HoldingRequestBuilder()
+      .withId(holdingsId)
+      .forInstance(instanceId)
+      .withPermanentLocation(mainLibraryLocationId)
+      .withHrid(hrid)
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE))));
+
+    final Response getResponse = holdingsClient.getById(holdingsId);
+
+    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+
+    final JsonObject holdingsFromGet = getResponse.getJson();
+
+    assertThat(holdingsFromGet.getString("hrid"), is(hrid));
+
+    log.info("Finished canUsePutToCreateAHoldingsWhenHRIDIsSupplied");
+  }
+
+  @Test
+  public void canPostSynchronousBatchWithGeneratedHRID() {
+    log.info("Starting canPostSynchronousBatchWithGeneratedHRID");
+
+    setHoldingsSequence(1);
+
+    final JsonArray holdingsArray = threeHoldings();
+
+    assertThat(postSynchronousBatch(holdingsArray), statusCodeIs(HttpStatus.HTTP_CREATED));
+
+    holdingsArray.stream()
+        .map(o -> (JsonObject) o)
+        .forEach(holdings -> {
+          final Response response = getById(holdings.getString("id"));
+          assertExists(response, holdings);
+          assertHRIDRange(response, "ho00000001", "ho00000003");
+        });
+
+    log.info("Finished canPostSynchronousBatchWithGeneratedHRID");
+  }
+
+  @Test
+  public void canPostSynchronousBatchWithSuppliedAndHRID() {
+    log.info("Starting canPostSynchronousBatchWithSuppliedAndHRID");
+
+    setHoldingsSequence(1);
+
+    final String hrid = "ABC123";
+    final JsonArray holdingsArray = threeHoldings();
+
+    holdingsArray.getJsonObject(1).put("hrid", hrid);
+
+    assertThat(postSynchronousBatch(holdingsArray), statusCodeIs(HttpStatus.HTTP_CREATED));
+
+    Response response = getById(holdingsArray.getJsonObject(0).getString("id"));
+    assertExists(response, holdingsArray.getJsonObject(0));
+    assertThat(response.getJson().getString("hrid"), is("ho00000001"));
+
+    response = getById(holdingsArray.getJsonObject(1).getString("id"));
+    assertExists(response, holdingsArray.getJsonObject(1));
+    assertThat(response.getJson().getString("hrid"), is(hrid));
+
+    response = getById(holdingsArray.getJsonObject(2).getString("id"));
+    assertExists(response, holdingsArray.getJsonObject(2));
+    assertThat(response.getJson().getString("hrid"), is("ho00000002"));
+
+    log.info("Finished canPostSynchronousBatchWithSuppliedAndHRID");
+  }
+
+  @Test
+  public void cannotPostSynchronousBatchWithDuplicateHRIDs() {
+    log.info("Starting cannotPostSynchronousBatchWithDuplicateHRIDs");
+
+    setHoldingsSequence(1);
+
+    final JsonArray holdingsArray = threeHoldings();
+    final String duplicateHRID = "ho00000001";
+    holdingsArray.getJsonObject(1).put("hrid", duplicateHRID);
+
+    assertThat(postSynchronousBatch(holdingsArray), allOf(
+        statusCodeIs(HttpStatus.HTTP_UNPROCESSABLE_ENTITY),
+        errorMessageContains("duplicate key"),
+        errorParametersValueIs(duplicateHRID)));
+
+    for (int i = 0; i < holdingsArray.size(); i++) {
+      assertGetNotFound(holdingsStorageUrl("/" + holdingsArray.getJsonObject(i).getString("id")));
+    }
+
+    log.info("Finished cannotPostSynchronousBatchWithDuplicateHRIDs");
+  }
+
+  @Test
+  public void cannotPostSynchronousBatchWithHRIDFailure() {
+    log.info("Starting cannotPostSynchronousBatchWithHRIDFailure");
+
+    setHoldingsSequence(99999999);
+
+    final JsonArray holdingsArray = threeHoldings();
+
+    final Response response = postSynchronousBatch(holdingsArray);
+
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
+    assertThat(response.getBody(),
+        is("ErrorMessage(fields=[(Severity, ERROR), (V, ERROR), (SQLSTATE, 2200H), (Message, nextval: reached maximum value of sequence \"hrid_holdings_seq\" (99999999)), (File, sequence.c), (Line, 700), (Routine, nextval_internal)])"));
+
+    for (int i = 0; i < holdingsArray.size(); i++) {
+      assertGetNotFound(holdingsStorageUrl("/" + holdingsArray.getJsonObject(i).getString("id")));
+    }
+
+    log.info("Finished cannotPostSynchronousBatchWithHRIDFailure");
+  }
+
+  private void setHoldingsSequence(int sequenceNumber) {
+    final Vertx vertx = StorageTestSuite.getVertx();
+    final PostgresClient postgresClient =
+        PostgresClient.getInstance(vertx, TENANT_ID);
+    final CompletableFuture<Void> sequenceSet = new CompletableFuture<>();
+
+    vertx.runOnContext(v -> {
+      postgresClient.selectSingle("select setval('hrid_holdings_seq',"
+          + sequenceNumber + ",FALSE)", r -> {
+            if (r.succeeded()) {
+              sequenceSet.complete(null);
+            } else {
+              sequenceSet.completeExceptionally(r.cause());
+            }
+          });
+    });
+
+    try {
+      sequenceSet.get(2, SECONDS);
+    } catch (Exception e) {
+      fail(e.getMessage());
+    }
+  }
+
   /**
    * Create three instances, and for each of them return a JsonObject of a new holding belonging to it.
    * The holdings are not created.
@@ -927,6 +1380,16 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     Response response = getById(expectedHolding.getString("id"));
     assertThat(response, statusCodeIs(HttpStatus.HTTP_OK));
     assertThat(response.getBody(), containsString(expectedHolding.getString("instanceId")));
+  }
+
+  private void assertExists(Response response, JsonObject expectedHolding) {
+    assertThat(response, statusCodeIs(HttpStatus.HTTP_OK));
+    assertThat(response.getBody(), containsString(expectedHolding.getString("instanceId")));
+  }
+
+  private void assertHRIDRange(Response response, String minHRID, String maxHRID) {
+    assertThat(response.getJson().getString("hrid"),
+        is(both(greaterThanOrEqualTo(minHRID)).and(lessThanOrEqualTo(maxHRID))));
   }
 
   private Response create(URL url, Object entity) throws InterruptedException, ExecutionException, TimeoutException {

--- a/src/test/java/org/folio/rest/api/HridSettingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HridSettingsStorageTest.java
@@ -308,7 +308,7 @@ public class HridSettingsStorageTest extends TestBase {
 
     final HridManager hridManager = new HridManager(vertx.getOrCreateContext(), postgresClient);
 
-    hridManager.getNextHoldingHrid()
+    hridManager.getNextHoldingsHrid()
       .compose(hrid -> validateHrid(hrid, "ho00000001", testContext))
       .setHandler(testContext.asyncAssertSuccess(
           v -> log.info("Finished canGetNextHoldingHrid()")));
@@ -331,7 +331,7 @@ public class HridSettingsStorageTest extends TestBase {
 
     hridManager.updateHridSettings(newHridSettings).setHandler(
         testContext.asyncAssertSuccess(
-            hridSettings -> hridManager.getNextHoldingHrid().compose(
+            hridSettings -> hridManager.getNextHoldingsHrid().compose(
                 hrid -> validateHrid(hrid, "ho00007890", testContext))
               .setHandler(testContext.asyncAssertSuccess(
                   v -> log.info("Finished canGetNextHoldingHridAfterSettingStartNumber()")))));

--- a/src/test/java/org/folio/rest/support/builders/HoldingRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/HoldingRequestBuilder.java
@@ -12,12 +12,14 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
   private final UUID temporaryLocationId;
   private JsonObject tags;
   private String callNumber;
+  private final String hrid;
 
   public HoldingRequestBuilder() {
     this(
       null,
       null,
       UUID.randomUUID(),
+      null,
       null,
       null,
       null);
@@ -29,7 +31,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     UUID permanentLocationId,
     UUID temporaryLocationId,
     JsonObject tags,
-    String callNumber) {
+    String callNumber,
+    String hrid) {
 
     this.id = id;
     this.instanceId = instanceId;
@@ -37,6 +40,7 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     this.temporaryLocationId = temporaryLocationId;
     this.tags = tags;
     this.callNumber = callNumber;
+    this.hrid = hrid;
   }
 
   @Override
@@ -49,6 +53,7 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     put(request, "temporaryLocationId", temporaryLocationId);
     put(request, "tags", tags);
     put(request, "callNumber", callNumber);
+    put(request, "hrid", hrid);
 
     return request;
   }
@@ -60,7 +65,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       permanentLocationId,
       this.temporaryLocationId,
       this.tags,
-      this.callNumber);
+      this.callNumber,
+      this.hrid);
   }
 
   public HoldingRequestBuilder withTemporaryLocation(UUID temporaryLocationId) {
@@ -70,7 +76,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.permanentLocationId,
       temporaryLocationId,
       this.tags,
-      this.callNumber);
+      this.callNumber,
+      this.hrid);
   }
 
   public HoldingRequestBuilder forInstance(UUID instanceId) {
@@ -80,7 +87,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.permanentLocationId,
       this.temporaryLocationId,
       this.tags,
-      this.callNumber);
+      this.callNumber,
+      this.hrid);
   }
 
   public HoldingRequestBuilder withId(UUID id) {
@@ -90,7 +98,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.permanentLocationId,
       this.temporaryLocationId,
       this.tags,
-      this.callNumber);
+      this.callNumber,
+      this.hrid);
   }
 
   public HoldingRequestBuilder withTags(JsonObject tags) {
@@ -100,7 +109,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.permanentLocationId,
       this.temporaryLocationId,
       tags,
-      this.callNumber);
+      this.callNumber,
+      this.hrid);
   }
 
   public HoldingRequestBuilder withCallNumber(String callNumber) {
@@ -110,6 +120,18 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.permanentLocationId,
       this.temporaryLocationId,
       this.tags,
-      callNumber);
+      callNumber,
+      this.hrid);
+  }
+
+  public HoldingRequestBuilder withHrid(String hrid) {
+    return new HoldingRequestBuilder(
+      this.id,
+      this.instanceId,
+      this.permanentLocationId,
+      this.temporaryLocationId,
+      this.tags,
+      this.callNumber,
+      hrid);
   }
 }


### PR DESCRIPTION
When creating holdings records set a generated HRID when not present.
When modifying holdings records ensure the HRID cannot be changed.