### PR TITLE
[BUGFIX]: MODINVSTOR-367: Maintain item status date even if item record is edited

### DIFF
--- a/src/main/resources/templates/db_scripts/updateItemStatusDate.sql
+++ b/src/main/resources/templates/db_scripts/updateItemStatusDate.sql
@@ -8,8 +8,9 @@ AS $$
   BEGIN
   	newStatus = NEW.jsonb->'status'->>'name';
 	  IF (newStatus IS DISTINCT FROM OLD.jsonb->'status'->>'name') THEN
-	    -- Date time in "yyyy-MM-dd'T'HH:mm:ss.SSS" format at UTC (00:00) time zone
-      NEW.jsonb = jsonb_set(NEW.jsonb, '{status,date}', to_jsonb(CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC'), true);
+	    -- Date time in "YYYY-MM-DD"T"HH24:MI:SS.ms'Z'" format at UTC (00:00) time zone
+      NEW.jsonb = jsonb_set(NEW.jsonb, '{status,date}',
+       to_jsonb(to_char(CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.ms"Z"')), true);
 	  END IF;
 	RETURN NEW;
   END;

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -12,6 +12,7 @@ import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageSyncUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
+import static org.folio.rest.support.matchers.DateTimeMatchers.hasIsoFormat;
 import static org.folio.rest.support.matchers.DateTimeMatchers.withinSecondsBeforeNow;
 import static org.folio.util.StringUtil.urlEncode;
 import static org.hamcrest.CoreMatchers.allOf;
@@ -1230,6 +1231,8 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
       is("Checked out"));
 
     assertThat(item.getStatus().getDate(), withinSecondsBeforeNow(seconds(2)));
+
+    assertThat(item.getStatus().getDate(), hasIsoFormat());
   }
 
   @Test
@@ -1303,6 +1306,8 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     String itemStatusDate = resultItem.getStatus().getDate();
 
     assertThat(itemStatusDate, withinSecondsBeforeNow(seconds(2)));
+
+    assertThat(itemStatusDate, hasIsoFormat());
 
     assertThat(itemStatusDate, not(changedStatusDate));
   }


### PR DESCRIPTION
Bugfix regarding item status date at the "item" object:
Time Zone didn't exist in this field.