### PR TITLE
MODINVSTOR-361: Populate effective call number type id on item.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "item-storage",
-      "version": "7.8",
+      "version": "7.9",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/item-storage.raml
+++ b/ramls/item-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Item Storage
-version: v7.8
+version: v7.9
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -69,6 +69,12 @@
           "type": "string",
           "description": "Effective Call Number Suffix is the suffix of the identifier assigned to an item or its holding and associated with the item.",
           "readonly": true
+        },
+        "typeId": {
+          "type": "string",
+          "description": "Effective Call Number Type Id is the call number type id assigned to the item or associated holding.",
+          "$ref": "uuid.json",
+          "readonly": true
         }
       },
       "additionalProperties": false

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -72,7 +72,7 @@
         },
         "typeId": {
           "type": "string",
-          "description": "Effective Call Number Type Id is the call number type id assigned to the item or associated holding.",
+          "description": "Effective Call Number Type Id is the call number type id of the item, if available, otherwise that of the holding.",
           "$ref": "uuid.json",
           "readonly": true
         }

--- a/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
@@ -156,7 +156,7 @@ public class ItemStorageAPI implements ItemStorage {
               respond500WithTextPlain(response.result().getEntity())));
         } else {
           final Item existingItem = (Item) response.result().getEntity();
-          if (Objects.equals(entity.getHrid(), existingItem.getHrid())) { 
+          if (Objects.equals(entity.getHrid(), existingItem.getHrid())) {
             setEffectiveCallNumber(okapiHeaders, vertxContext, entity).thenAccept(
                 item -> PgUtil.put(ITEM_TABLE, item, itemId, okapiHeaders, vertxContext,
                   PutItemStorageItemsByItemIdResponse.class, asyncResultHandler));
@@ -227,6 +227,8 @@ public class ItemStorageAPI implements ItemStorage {
   private boolean shouldNotRetrieveHoldingsRecord(Item item) {
     return isNoneBlank(item.getItemLevelCallNumber(),
       item.getItemLevelCallNumberPrefix(),
-      item.getItemLevelCallNumberSuffix());
+      item.getItemLevelCallNumberSuffix(),
+      item.getItemLevelCallNumberTypeId()
+    );
   }
 }

--- a/src/main/java/org/folio/rest/support/EffectiveCallNumberComponentsUtil.java
+++ b/src/main/java/org/folio/rest/support/EffectiveCallNumberComponentsUtil.java
@@ -2,6 +2,9 @@ package org.folio.rest.support;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import java.util.Optional;
+
+import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.jaxrs.model.EffectiveCallNumberComponents;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
@@ -36,9 +39,17 @@ public final class EffectiveCallNumberComponentsUtil {
       updatedCallNumberSuffix = holdings.getCallNumberSuffix();
     }
 
+    String updatedCallNumberTypeId = StringUtils.firstNonBlank(
+      item.getItemLevelCallNumberTypeId(),
+      Optional.ofNullable(holdings).map(HoldingsRecord::getCallNumberTypeId)
+        .orElse(null)
+    );
+
     components.setCallNumber(updatedCallNumber);
     components.setPrefix(updatedCallNumberPrefix);
     components.setSuffix(updatedCallNumberSuffix);
+    components.setTypeId(updatedCallNumberTypeId);
+
     return components;
   }
 }

--- a/src/main/java/org/folio/rest/support/EffectiveCallNumberComponentsUtil.java
+++ b/src/main/java/org/folio/rest/support/EffectiveCallNumberComponentsUtil.java
@@ -2,8 +2,6 @@ package org.folio.rest.support;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import java.util.Optional;
-
 import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.jaxrs.model.EffectiveCallNumberComponents;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
@@ -41,8 +39,7 @@ public final class EffectiveCallNumberComponentsUtil {
 
     String updatedCallNumberTypeId = StringUtils.firstNonBlank(
       item.getItemLevelCallNumberTypeId(),
-      Optional.ofNullable(holdings).map(HoldingsRecord::getCallNumberTypeId)
-        .orElse(null)
+      holdings != null ? holdings.getCallNumberTypeId() : null
     );
 
     components.setCallNumber(updatedCallNumber);

--- a/src/main/resources/templates/db_scripts/populateEffectiveCallNumberComponentsForExistingItems.sql
+++ b/src/main/resources/templates/db_scripts/populateEffectiveCallNumberComponentsForExistingItems.sql
@@ -5,7 +5,8 @@ SET jsonb = jsonb_set(
   jsonb_build_object(
     'callNumber', COALESCE(it.jsonb->'itemLevelCallNumber', hr.jsonb->'callNumber'),
     'prefix', COALESCE(it.jsonb->'itemLevelCallNumberPrefix', hr.jsonb->'callNumberPrefix'),
-    'suffix', COALESCE(it.jsonb->'itemLevelCallNumberSuffix', hr.jsonb->'callNumberSuffix')
+    'suffix', COALESCE(it.jsonb->'itemLevelCallNumberSuffix', hr.jsonb->'callNumberSuffix'),
+    'typeId', COALESCE(it.jsonb->'itemLevelCallNumberTypeId', hr.jsonb->'callNumberTypeId')
   )
 )
 FROM ${myuniversity}_${mymodule}.holdings_record AS hr

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -698,7 +698,7 @@
     {
       "run": "after",
       "snippetPath": "populateEffectiveCallNumberComponentsForExistingItems.sql",
-      "fromModuleVersion": "17.1.0"
+      "fromModuleVersion": "18.2.0"
     },
     {
       "run": "after",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -702,7 +702,7 @@
     {
       "run": "after",
       "snippetPath": "populateEffectiveCallNumberComponentsForExistingItems.sql",
-      "fromModuleVersion": "18.2.0"
+      "fromModuleVersion": "18.3.0"
     },
     {
       "run": "after",

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -1391,6 +1391,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       is("itemLevelCallNumberPrefix"));
   }
 
+  @Test
   public void cannotCreateHoldingWithoutPermanentLocation() throws Exception {
     UUID instanceId = UUID.randomUUID();
     instancesClient.create(smallAngryPlanet(instanceId));

--- a/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
@@ -1,7 +1,6 @@
 package org.folio.rest.api;
 
 
-import static org.apache.commons.lang3.StringUtils.capitalize;
 import static org.folio.rest.api.ItemStorageTest.nod;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertNotNull;
@@ -9,18 +8,13 @@ import static org.junit.Assert.assertThat;
 
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.lang3.StringUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.ImmutableTriple;
-import org.apache.commons.lang3.tuple.Pair;
-import org.apache.commons.lang3.tuple.Triple;
+import org.folio.rest.api.testdata.ItemEffectiveCallNumberComponentsTestData;
+import org.folio.rest.api.testdata.ItemEffectiveCallNumberComponentsTestData.CallNumberComponentPropertyNames;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
@@ -31,13 +25,14 @@ import org.junit.runner.RunWith;
 import io.vertx.core.json.JsonObject;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
+import junitparams.naming.TestCaseName;
 
 @RunWith(JUnitParamsRunner.class)
 public class ItemEffectiveCallNumberComponentsTest extends TestBaseWithInventoryUtil {
-  private static final String HOLDINGS_CALL_NUMBER_TYPE = UUID.randomUUID().toString();
-  private static final String HOLDINGS_CALL_NUMBER_TYPE_SECOND = UUID.randomUUID().toString();
-  private static final String ITEM_LEVEL_CALL_NUMBER_TYPE = UUID.randomUUID().toString();
-  private static final String ITEM_LEVEL_CALL_NUMBER_TYPE_SECOND = UUID.randomUUID().toString();
+  public static final String HOLDINGS_CALL_NUMBER_TYPE = UUID.randomUUID().toString();
+  public static final String HOLDINGS_CALL_NUMBER_TYPE_SECOND = UUID.randomUUID().toString();
+  public static final String ITEM_LEVEL_CALL_NUMBER_TYPE = UUID.randomUUID().toString();
+  public static final String ITEM_LEVEL_CALL_NUMBER_TYPE_SECOND = UUID.randomUUID().toString();
 
   @BeforeClass
   public static void createCallNumberTypes() throws Exception {
@@ -69,73 +64,84 @@ public class ItemEffectiveCallNumberComponentsTest extends TestBaseWithInventory
   }
 
   @Test
-  @Parameters(method = "createPropertiesParams")
+  @Parameters(
+    source = ItemEffectiveCallNumberComponentsTestData.class,
+    method = "createPropertiesParams"
+  )
+  @TestCaseName("[{index}]: {params}")
   public void canCalculateEffectiveCallNumberPropertyOnCreate(
-    Pair<String, String> holdingsProperties,
-    Pair<String, String> itemProperties, String effectivePropertyName) throws Exception {
+    CallNumberComponentPropertyNames callNumberProperties,
+    String holdingsPropertyValue, String itemPropertyValue) throws Exception {
 
-    final String holdingsPropertyName = holdingsProperties.getKey();
-    final String holdingsPropertyValue = holdingsProperties.getValue();
-    final String itemPropertyName = itemProperties.getKey();
-    final String itemPropertyValue = itemProperties.getValue();
     final String effectiveValue = StringUtils.firstNonBlank(itemPropertyValue, holdingsPropertyValue);
-
-    IndividualResource holdings =
-      createHoldingsWithPropertySetAndInstance(holdingsPropertyName, holdingsPropertyValue);
+    IndividualResource holdings = createHoldingsWithPropertySetAndInstance(
+      callNumberProperties.holdingsPropertyName, holdingsPropertyValue
+    );
 
     IndividualResource createdItem = itemsClient.create(
       nod(null, holdings.getId())
-        .put(itemPropertyName, itemPropertyValue)
+        .put(callNumberProperties.itemPropertyName, itemPropertyValue)
     );
-    assertThat(createdItem.getJson().getString(itemPropertyName), is(itemPropertyValue));
+    assertThat(createdItem.getJson()
+        .getString(callNumberProperties.itemPropertyName),
+      is(itemPropertyValue)
+    );
 
     Response getResponse = itemsClient.getById(createdItem.getId());
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
 
-    JsonObject effectiveCallNumberComponents = getResponse.getJson().getJsonObject("effectiveCallNumberComponents");
+    JsonObject effectiveCallNumberComponents = getResponse.getJson()
+      .getJsonObject("effectiveCallNumberComponents");
+
     assertNotNull(effectiveCallNumberComponents);
-    assertThat(effectiveCallNumberComponents.getString(effectivePropertyName), is(effectiveValue));
+    assertThat(effectiveCallNumberComponents
+        .getString(callNumberProperties.effectivePropertyName),
+      is(effectiveValue)
+    );
   }
 
   @Test
-  @Parameters(method = "updatePropertiesParams")
+  @Parameters(
+    source = ItemEffectiveCallNumberComponentsTestData.class,
+    method = "updatePropertiesParams"
+  )
+  @TestCaseName("[{index}]: {params}")
   public void canCalculateEffectiveCallNumberPropertyOnUpdate(
-    Triple<String, String, String> holdingsProperties,
-    Triple<String, String, String> itemProperties, String effectivePropertyName) throws Exception {
+    CallNumberComponentPropertyNames callNumberProperties,
+    String holdingsInitValue, String holdingsTargetValue,
+    String itemInitValue, String itemTargetValue) throws Exception {
 
-    final String holdingsPropertyName = holdingsProperties.getLeft();
-    final String holdingsPropertyInitValue = holdingsProperties.getMiddle();
-    final String holdingsPropertyTargetValue = holdingsProperties.getRight();
+    final String holdingsPropertyName = callNumberProperties.holdingsPropertyName;
+    final String itemPropertyName = callNumberProperties.itemPropertyName;
+    final String effectivePropertyName = callNumberProperties.effectivePropertyName;
 
-    final String itemPropertyName = itemProperties.getLeft();
-    final String itemPropertyInitValue = itemProperties.getMiddle();
-    final String itemPropertyTargetValue = itemProperties.getRight();
+    final String initEffectiveValue = StringUtils.firstNonBlank(itemInitValue, holdingsInitValue);
+    final String targetEffectiveValue = StringUtils.firstNonBlank(itemTargetValue, holdingsTargetValue);
 
-    final String initEffectiveValue = StringUtils.firstNonBlank(itemPropertyInitValue, holdingsPropertyInitValue);
-    final String targetEffectiveValue = StringUtils.firstNonBlank(itemPropertyTargetValue, holdingsPropertyTargetValue);
-
-    IndividualResource holdings =
-      createHoldingsWithPropertySetAndInstance(holdingsPropertyName, holdingsPropertyInitValue);
+    IndividualResource holdings = createHoldingsWithPropertySetAndInstance(
+      holdingsPropertyName, holdingsInitValue
+    );
 
     IndividualResource createdItem = itemsClient.create(
       nod(null, holdings.getId())
-        .put(itemPropertyName, itemPropertyInitValue)
+        .put(itemPropertyName, itemInitValue)
     );
 
     JsonObject effectiveCallNumberComponents = createdItem.getJson()
       .getJsonObject("effectiveCallNumberComponents");
+
     assertNotNull(effectiveCallNumberComponents);
     assertThat(effectiveCallNumberComponents.getString(effectivePropertyName),
       is(initEffectiveValue));
 
     holdingsClient.replace(holdings.getId(),
       holdings.copyJson()
-        .put(holdingsPropertyName, holdingsPropertyTargetValue)
+        .put(holdingsPropertyName, holdingsTargetValue)
     );
 
     itemsClient.replace(createdItem.getId(),
       createdItem.copyJson()
-        .put(itemPropertyName, itemPropertyTargetValue)
+        .put(itemPropertyName, itemTargetValue)
     );
 
     JsonObject updatedEffectiveCallNumberComponents = itemsClient
@@ -145,137 +151,6 @@ public class ItemEffectiveCallNumberComponentsTest extends TestBaseWithInventory
     assertNotNull(updatedEffectiveCallNumberComponents);
     assertThat(updatedEffectiveCallNumberComponents.getString(effectivePropertyName),
       is(targetEffectiveValue));
-  }
-
-  @SuppressWarnings("unused")
-  private List<Object[]> createPropertiesParams() {
-    List<Object[]> testCases = new ArrayList<>();
-
-    testCases.addAll(createPropertyTestCase("callNumber", "callNumber"));
-    testCases.addAll(createPropertyTestCase("callNumberSuffix", "suffix"));
-    testCases.addAll(createPropertyTestCase("callNumberPrefix", "prefix"));
-    testCases.addAll(createPropertyTestCase("callNumberTypeId", HOLDINGS_CALL_NUMBER_TYPE,
-      ITEM_LEVEL_CALL_NUMBER_TYPE, "typeId"
-    ));
-
-    return testCases;
-  }
-
-  private List<Object[]> createPropertyTestCase(
-    String holdingsPropertyName, String effectivePropertyName) {
-
-    return createPropertyTestCase(holdingsPropertyName,
-      "hr" + capitalize(holdingsPropertyName),
-      "it" + capitalize(holdingsPropertyName),
-      effectivePropertyName
-    );
-  }
-
-  private List<Object[]> createPropertyTestCase(
-    String holdingsPropertyName, String holdingsPropertyValue,
-    String itemPropertyValue, String effectivePropertyName) {
-
-    final String itemPropertyName = "itemLevel" + capitalize(holdingsPropertyName);
-
-    return Arrays.asList(
-      new Object[]{
-        new ImmutablePair<>(holdingsPropertyName, holdingsPropertyValue),
-        new ImmutablePair<>(itemPropertyName, null),
-        effectivePropertyName
-      },
-      new Object[]{
-        new ImmutablePair<>(holdingsPropertyName, null),
-        new ImmutablePair<>(itemPropertyName, itemPropertyValue),
-        effectivePropertyName
-      },
-      new Object[]{
-        new ImmutablePair<>(holdingsPropertyName, holdingsPropertyValue),
-        new ImmutablePair<>(itemPropertyName, itemPropertyValue),
-        effectivePropertyName
-      },
-      new Object[]{
-        new ImmutablePair<>(holdingsPropertyName, null),
-        new ImmutablePair<>(itemPropertyName, null),
-        effectivePropertyName
-      }
-    );
-  }
-
-  @SuppressWarnings("unused")
-  private List<Object[]> updatePropertiesParams() {
-    List<Object[]> testCases = new ArrayList<>();
-
-    testCases.addAll(updatePropertyTestCase("callNumber", "callNumber"));
-    testCases.addAll(updatePropertyTestCase("callNumberSuffix", "suffix"));
-    testCases.addAll(updatePropertyTestCase("callNumberPrefix", "prefix"));
-    testCases.addAll(updatePropertyTestCase(
-      "callNumberTypeId", HOLDINGS_CALL_NUMBER_TYPE, HOLDINGS_CALL_NUMBER_TYPE_SECOND,
-      ITEM_LEVEL_CALL_NUMBER_TYPE, ITEM_LEVEL_CALL_NUMBER_TYPE_SECOND, "typeId"
-    ));
-
-    return testCases;
-  }
-
-  private List<Object[]> updatePropertyTestCase(
-    String holdingsPropertyName, String holdingsInitValue, String holdingsTargetValue,
-    String itemInitValue, String itemTargetValue, String effectivePropertyName) {
-
-    final String itemPropertyName = "itemLevel" + capitalize(holdingsPropertyName);
-
-    return Arrays.asList(
-      new Object[]{
-        new ImmutableTriple<>(holdingsPropertyName, holdingsInitValue, holdingsTargetValue),
-        new ImmutableTriple<>(itemPropertyName, itemInitValue, itemTargetValue),
-        effectivePropertyName
-      },
-      new Object[]{
-        new ImmutableTriple<>(holdingsPropertyName, holdingsInitValue, null),
-        new ImmutableTriple<>(itemPropertyName, itemInitValue, itemTargetValue),
-        effectivePropertyName
-      },
-      new Object[]{
-        new ImmutableTriple<>(holdingsPropertyName, holdingsInitValue, holdingsTargetValue),
-        new ImmutableTriple<>(itemPropertyName, itemInitValue, null),
-        effectivePropertyName
-      },
-      new Object[]{
-        new ImmutableTriple<>(holdingsPropertyName, holdingsInitValue, null),
-        new ImmutableTriple<>(itemPropertyName, itemInitValue, null),
-        effectivePropertyName
-      },
-      new Object[]{
-        new ImmutableTriple<>(holdingsPropertyName, holdingsInitValue, null),
-        new ImmutableTriple<>(itemPropertyName, itemInitValue, itemInitValue),
-        effectivePropertyName
-      },
-      new Object[]{
-        new ImmutableTriple<>(holdingsPropertyName, holdingsInitValue, holdingsInitValue),
-        new ImmutableTriple<>(itemPropertyName, itemInitValue, null),
-        effectivePropertyName
-      },
-      new Object[]{
-        new ImmutableTriple<>(holdingsPropertyName, holdingsInitValue, holdingsTargetValue),
-        new ImmutableTriple<>(itemPropertyName, null, null),
-        effectivePropertyName
-      },
-      new Object[]{
-        new ImmutableTriple<>(holdingsPropertyName, null, holdingsTargetValue),
-        new ImmutableTriple<>(itemPropertyName, itemInitValue, null),
-        effectivePropertyName
-      }
-    );
-  }
-
-  private List<Object[]> updatePropertyTestCase(
-    String holdingsPropertyName, String effectivePropertyName) {
-
-    return updatePropertyTestCase(holdingsPropertyName,
-      "hr" + capitalize(holdingsPropertyName),
-      "hrUPDATED" + capitalize(holdingsPropertyName),
-      "it" + capitalize(holdingsPropertyName),
-      "itUPDATED" + capitalize(holdingsPropertyName),
-      effectivePropertyName
-    );
   }
 
   private IndividualResource createHoldingsWithPropertySetAndInstance(

--- a/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
@@ -149,8 +149,7 @@ public class ItemEffectiveCallNumberComponentsTest extends TestBaseWithInventory
     testCases.addAll(createPropertyTestCase("callNumber", "callNumber"));
     testCases.addAll(createPropertyTestCase("callNumberSuffix", "suffix"));
     testCases.addAll(createPropertyTestCase("callNumberPrefix", "prefix"));
-    testCases.addAll(createPropertyTestCase(
-      "callNumberTypeId", HOLDINGS_CALL_NUMBER_TYPE,
+    testCases.addAll(createPropertyTestCase("callNumberTypeId", HOLDINGS_CALL_NUMBER_TYPE,
       ITEM_LEVEL_CALL_NUMBER_TYPE, "typeId"
     ));
 

--- a/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
@@ -1,0 +1,294 @@
+package org.folio.rest.api;
+
+
+import static org.apache.commons.lang3.StringUtils.capitalize;
+import static org.folio.rest.api.ItemStorageTest.nod;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
+import org.folio.rest.support.IndividualResource;
+import org.folio.rest.support.Response;
+import org.folio.rest.support.builders.HoldingRequestBuilder;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.vertx.core.json.JsonObject;
+import junitparams.JUnitParamsRunner;
+import junitparams.Parameters;
+
+@RunWith(JUnitParamsRunner.class)
+public class ItemEffectiveCallNumberComponentsTest extends TestBaseWithInventoryUtil {
+  private static final String HOLDINGS_CALL_NUMBER_TYPE = UUID.randomUUID().toString();
+  private static final String HOLDINGS_CALL_NUMBER_TYPE_SECOND = UUID.randomUUID().toString();
+  private static final String ITEM_LEVEL_CALL_NUMBER_TYPE = UUID.randomUUID().toString();
+  private static final String ITEM_LEVEL_CALL_NUMBER_TYPE_SECOND = UUID.randomUUID().toString();
+
+  @BeforeClass
+  public static void createCallNumberTypes() throws Exception {
+    callNumberTypesClient.create(new JsonObject()
+      .put("id", HOLDINGS_CALL_NUMBER_TYPE)
+      .put("name", "Test Holdings call number type")
+      .put("source", "folio")
+    );
+    callNumberTypesClient.create(new JsonObject()
+      .put("id", HOLDINGS_CALL_NUMBER_TYPE_SECOND)
+      .put("name", "Test Holdings call number type second")
+      .put("source", "folio")
+    );
+    callNumberTypesClient.create(new JsonObject()
+      .put("id", ITEM_LEVEL_CALL_NUMBER_TYPE)
+      .put("name", "Test Item level call number type")
+      .put("source", "folio")
+    );
+    callNumberTypesClient.create(new JsonObject()
+      .put("id", ITEM_LEVEL_CALL_NUMBER_TYPE_SECOND)
+      .put("name", "Test Item level call number type second")
+      .put("source", "folio")
+    );
+  }
+
+  @Test
+  @Parameters(method = "createPropertiesParams")
+  public void canCalculateEffectiveCallNumberPropertyOnCreate(
+    Pair<String, String> holdingsProperties,
+    Pair<String, String> itemProperties, String effectivePropertyName) throws Exception {
+
+    final String holdingsPropertyName = holdingsProperties.getKey();
+    final String holdingsPropertyValue = holdingsProperties.getValue();
+    final String itemPropertyName = itemProperties.getKey();
+    final String itemPropertyValue = itemProperties.getValue();
+    final String effectiveValue = StringUtils.firstNonBlank(itemPropertyValue, holdingsPropertyValue);
+
+    IndividualResource holdings =
+      createHoldingsWithPropertySetAndInstance(holdingsPropertyName, holdingsPropertyValue);
+
+    IndividualResource createdItem = itemsClient.create(
+      nod(null, holdings.getId())
+        .put(itemPropertyName, itemPropertyValue)
+    );
+    assertThat(createdItem.getJson().getString(itemPropertyName), is(itemPropertyValue));
+
+    Response getResponse = itemsClient.getById(createdItem.getId());
+    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+
+    JsonObject effectiveCallNumberComponents = getResponse.getJson().getJsonObject("effectiveCallNumberComponents");
+    assertNotNull(effectiveCallNumberComponents);
+    assertThat(effectiveCallNumberComponents.getString(effectivePropertyName), is(effectiveValue));
+  }
+
+  @Test
+  @Parameters(method = "updatePropertiesParams")
+  public void canCalculateEffectiveCallNumberPropertyOnUpdate(
+    Triple<String, String, String> holdingsProperties,
+    Triple<String, String, String> itemProperties, String effectivePropertyName) throws Exception {
+
+    final String holdingsPropertyName = holdingsProperties.getLeft();
+    final String holdingsPropertyInitValue = holdingsProperties.getMiddle();
+    final String holdingsPropertyTargetValue = holdingsProperties.getRight();
+
+    final String itemPropertyName = itemProperties.getLeft();
+    final String itemPropertyInitValue = itemProperties.getMiddle();
+    final String itemPropertyTargetValue = itemProperties.getRight();
+
+    final String initEffectiveValue = StringUtils.firstNonBlank(itemPropertyInitValue, holdingsPropertyInitValue);
+    final String targetEffectiveValue = StringUtils.firstNonBlank(itemPropertyTargetValue, holdingsPropertyTargetValue);
+
+    IndividualResource holdings =
+      createHoldingsWithPropertySetAndInstance(holdingsPropertyName, holdingsPropertyInitValue);
+
+    IndividualResource createdItem = itemsClient.create(
+      nod(null, holdings.getId())
+        .put(itemPropertyName, itemPropertyInitValue)
+    );
+
+    JsonObject effectiveCallNumberComponents = createdItem.getJson()
+      .getJsonObject("effectiveCallNumberComponents");
+    assertNotNull(effectiveCallNumberComponents);
+    assertThat(effectiveCallNumberComponents.getString(effectivePropertyName),
+      is(initEffectiveValue));
+
+    holdingsClient.replace(holdings.getId(),
+      holdings.copyJson()
+        .put(holdingsPropertyName, holdingsPropertyTargetValue)
+    );
+
+    itemsClient.replace(createdItem.getId(),
+      createdItem.copyJson()
+        .put(itemPropertyName, itemPropertyTargetValue)
+    );
+
+    JsonObject updatedEffectiveCallNumberComponents = itemsClient
+      .getById(createdItem.getId()).getJson()
+      .getJsonObject("effectiveCallNumberComponents");
+
+    assertNotNull(updatedEffectiveCallNumberComponents);
+    assertThat(updatedEffectiveCallNumberComponents.getString(effectivePropertyName),
+      is(targetEffectiveValue));
+  }
+
+  @SuppressWarnings("unused")
+  private List<Object[]> createPropertiesParams() {
+    List<Object[]> testCases = new ArrayList<>();
+
+    testCases.addAll(createPropertyTestCase("callNumber", "callNumber"));
+    testCases.addAll(createPropertyTestCase("callNumberSuffix", "suffix"));
+    testCases.addAll(createPropertyTestCase("callNumberPrefix", "prefix"));
+    testCases.addAll(createPropertyTestCase(
+      "callNumberTypeId", HOLDINGS_CALL_NUMBER_TYPE,
+      ITEM_LEVEL_CALL_NUMBER_TYPE, "typeId"
+    ));
+
+    return testCases;
+  }
+
+  private List<Object[]> createPropertyTestCase(
+    String holdingsPropertyName, String effectivePropertyName) {
+
+    return createPropertyTestCase(holdingsPropertyName,
+      "hr" + capitalize(holdingsPropertyName),
+      "it" + capitalize(holdingsPropertyName),
+      effectivePropertyName
+    );
+  }
+
+  private List<Object[]> createPropertyTestCase(
+    String holdingsPropertyName, String holdingsPropertyValue,
+    String itemPropertyValue, String effectivePropertyName) {
+
+    final String itemPropertyName = "itemLevel" + capitalize(holdingsPropertyName);
+
+    return Arrays.asList(
+      new Object[]{
+        new ImmutablePair<>(holdingsPropertyName, holdingsPropertyValue),
+        new ImmutablePair<>(itemPropertyName, null),
+        effectivePropertyName
+      },
+      new Object[]{
+        new ImmutablePair<>(holdingsPropertyName, null),
+        new ImmutablePair<>(itemPropertyName, itemPropertyValue),
+        effectivePropertyName
+      },
+      new Object[]{
+        new ImmutablePair<>(holdingsPropertyName, holdingsPropertyValue),
+        new ImmutablePair<>(itemPropertyName, itemPropertyValue),
+        effectivePropertyName
+      },
+      new Object[]{
+        new ImmutablePair<>(holdingsPropertyName, null),
+        new ImmutablePair<>(itemPropertyName, null),
+        effectivePropertyName
+      }
+    );
+  }
+
+  @SuppressWarnings("unused")
+  private List<Object[]> updatePropertiesParams() {
+    List<Object[]> testCases = new ArrayList<>();
+
+    testCases.addAll(updatePropertyTestCase("callNumber", "callNumber"));
+    testCases.addAll(updatePropertyTestCase("callNumberSuffix", "suffix"));
+    testCases.addAll(updatePropertyTestCase("callNumberPrefix", "prefix"));
+    testCases.addAll(updatePropertyTestCase(
+      "callNumberTypeId", HOLDINGS_CALL_NUMBER_TYPE, HOLDINGS_CALL_NUMBER_TYPE_SECOND,
+      ITEM_LEVEL_CALL_NUMBER_TYPE, ITEM_LEVEL_CALL_NUMBER_TYPE_SECOND, "typeId"
+    ));
+
+    return testCases;
+  }
+
+  private List<Object[]> updatePropertyTestCase(
+    String holdingsPropertyName, String holdingsInitValue, String holdingsTargetValue,
+    String itemInitValue, String itemTargetValue, String effectivePropertyName) {
+
+    final String itemPropertyName = "itemLevel" + capitalize(holdingsPropertyName);
+
+    return Arrays.asList(
+      new Object[]{
+        new ImmutableTriple<>(holdingsPropertyName, holdingsInitValue, holdingsTargetValue),
+        new ImmutableTriple<>(itemPropertyName, itemInitValue, itemTargetValue),
+        effectivePropertyName
+      },
+      new Object[]{
+        new ImmutableTriple<>(holdingsPropertyName, holdingsInitValue, null),
+        new ImmutableTriple<>(itemPropertyName, itemInitValue, itemTargetValue),
+        effectivePropertyName
+      },
+      new Object[]{
+        new ImmutableTriple<>(holdingsPropertyName, holdingsInitValue, holdingsTargetValue),
+        new ImmutableTriple<>(itemPropertyName, itemInitValue, null),
+        effectivePropertyName
+      },
+      new Object[]{
+        new ImmutableTriple<>(holdingsPropertyName, holdingsInitValue, null),
+        new ImmutableTriple<>(itemPropertyName, itemInitValue, null),
+        effectivePropertyName
+      },
+      new Object[]{
+        new ImmutableTriple<>(holdingsPropertyName, holdingsInitValue, null),
+        new ImmutableTriple<>(itemPropertyName, itemInitValue, itemInitValue),
+        effectivePropertyName
+      },
+      new Object[]{
+        new ImmutableTriple<>(holdingsPropertyName, holdingsInitValue, holdingsInitValue),
+        new ImmutableTriple<>(itemPropertyName, itemInitValue, null),
+        effectivePropertyName
+      },
+      new Object[]{
+        new ImmutableTriple<>(holdingsPropertyName, holdingsInitValue, holdingsTargetValue),
+        new ImmutableTriple<>(itemPropertyName, null, null),
+        effectivePropertyName
+      },
+      new Object[]{
+        new ImmutableTriple<>(holdingsPropertyName, null, holdingsTargetValue),
+        new ImmutableTriple<>(itemPropertyName, itemInitValue, null),
+        effectivePropertyName
+      }
+    );
+  }
+
+  private List<Object[]> updatePropertyTestCase(
+    String holdingsPropertyName, String effectivePropertyName) {
+
+    return updatePropertyTestCase(holdingsPropertyName,
+      "hr" + capitalize(holdingsPropertyName),
+      "hrUPDATED" + capitalize(holdingsPropertyName),
+      "it" + capitalize(holdingsPropertyName),
+      "itUPDATED" + capitalize(holdingsPropertyName),
+      effectivePropertyName
+    );
+  }
+
+  private IndividualResource createHoldingsWithPropertySetAndInstance(
+    String propertyName, String propertyValue)
+    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+
+    IndividualResource instance = instancesClient.create(instance(UUID.randomUUID()));
+
+    IndividualResource holdings = holdingsClient.create(new HoldingRequestBuilder()
+      .withId(UUID.randomUUID())
+      .forInstance(instance.getId())
+      .withPermanentLocation(mainLibraryLocationId)
+      .create()
+      .put(propertyName, propertyValue)
+    );
+    assertThat(holdings.getJson().getString(propertyName), is(propertyValue));
+
+    return holdings;
+  }
+}

--- a/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
@@ -41,6 +41,11 @@ public class ItemEffectiveCallNumberComponentsTest extends TestBaseWithInventory
 
   @BeforeClass
   public static void createCallNumberTypes() throws Exception {
+    callNumberTypesClient.deleteIfPresent(HOLDINGS_CALL_NUMBER_TYPE);
+    callNumberTypesClient.deleteIfPresent(HOLDINGS_CALL_NUMBER_TYPE_SECOND);
+    callNumberTypesClient.deleteIfPresent(ITEM_LEVEL_CALL_NUMBER_TYPE);
+    callNumberTypesClient.deleteIfPresent(ITEM_LEVEL_CALL_NUMBER_TYPE_SECOND);
+
     callNumberTypesClient.create(new JsonObject()
       .put("id", HOLDINGS_CALL_NUMBER_TYPE)
       .put("name", "Test Holdings call number type")

--- a/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberDataUpgradeTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberDataUpgradeTest.java
@@ -48,6 +48,9 @@ public class ItemEffectiveCallNumberDataUpgradeTest extends TestBaseWithInventor
   public static void createInstanceAndCallNumberTypes() throws Exception {
     instancesClient.create(instance(instanceId));
 
+    callNumberTypesClient.deleteIfPresent(HOLDINGS_CALL_NUMBER_TYPE);
+    callNumberTypesClient.deleteIfPresent(ITEM_LEVEL_CALL_NUMBER_TYPE);
+
     callNumberTypesClient.create(new JsonObject()
       .put("id", HOLDINGS_CALL_NUMBER_TYPE)
       .put("name", "Holdings call number type")

--- a/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberDataUpgradeTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberDataUpgradeTest.java
@@ -32,7 +32,7 @@ import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 
 @RunWith(JUnitParamsRunner.class)
-public class ItemEffectiveCallNumberTest extends TestBaseWithInventoryUtil {
+public class ItemEffectiveCallNumberDataUpgradeTest extends TestBaseWithInventoryUtil {
   private static final String HOLDINGS_CALL_NUMBER_TYPE = UUID.randomUUID().toString();
   private static final String ITEM_LEVEL_CALL_NUMBER_TYPE = UUID.randomUUID().toString();
 

--- a/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.commons.lang3.ObjectUtils;
+import org.folio.rest.api.testdata.ItemEffectiveLocationTestDataProvider;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.IndividualResource;
@@ -30,7 +31,7 @@ import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.json.JsonObject;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
-import static org.folio.rest.api.ItemEffectiveLocationTestDataProvider.PermTemp;
+import static org.folio.rest.api.testdata.ItemEffectiveLocationTestDataProvider.PermTemp;
 
 /**
  * Test cases to verify effectiveLocationId property calculation that implemented

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -273,114 +273,6 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canCreateAnItemWithHoldingCallNumberAsEffectiveCallNumber()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
-
-    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumber(mainLibraryLocationId);
-
-    JsonObject itemToCreate = nod(null, holdingsRecordId);
-
-    itemToCreate.put("tags", new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)));
-
-    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
-
-    client.post(itemsStorageUrl(""), itemToCreate, StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(createCompleted));
-
-    Response postResponse = createCompleted.get(5, TimeUnit.SECONDS);
-
-    assertThat(postResponse.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
-
-    JsonObject itemFromPost = postResponse.getJson();
-
-    String newId = itemFromPost.getString("id");
-
-    assertThat(newId, is(notNullValue()));
-
-    Response getResponse = getById(UUID.fromString(newId));
-
-    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-
-    JsonObject itemFromGet = getResponse.getJson();
-
-    assertThat(itemFromGet.getString("id"), is(newId));
-    assertThat(itemFromGet.getString("holdingsRecordId"), is(holdingsRecordId.toString()));
-    assertThat(itemFromGet.getString("barcode"), is("565578437802"));
-    assertThat(itemFromGet.getJsonObject("status").getString("name"),
-      is("Available"));
-    assertThat(itemFromGet.getString("materialTypeId"),
-      is(journalMaterialTypeID));
-    assertThat(itemFromGet.getString("permanentLoanTypeId"),
-      is(canCirculateLoanTypeID));
-    assertThat(itemFromGet.getString("temporaryLocationId"),
-      is(annexLibraryLocationId.toString()));
-
-    List<String> tags = itemFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
-
-    assertThat(tags.size(), is(1));
-    assertThat(tags, hasItem(TAG_VALUE));
-    assertThat(
-      itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("callNumber"),
-      is("testCallNumber"));
-  }
-
-  @Test
-  public void canCreateAnItemWithItemLevelCallNumberAsEffectiveCallNumber()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
-
-    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumber(mainLibraryLocationId);
-
-    JsonObject itemToCreate = nod(null, holdingsRecordId);
-
-    itemToCreate.put("tags", new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)));
-
-    itemToCreate.put("itemLevelCallNumber", "testItemCallNumber");
-
-    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
-
-    client.post(itemsStorageUrl(""), itemToCreate, StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(createCompleted));
-
-    Response postResponse = createCompleted.get(5, TimeUnit.SECONDS);
-
-    assertThat(postResponse.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
-
-    JsonObject itemFromPost = postResponse.getJson();
-
-    String newId = itemFromPost.getString("id");
-
-    assertThat(newId, is(notNullValue()));
-
-    Response getResponse = getById(UUID.fromString(newId));
-
-    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-
-    JsonObject itemFromGet = getResponse.getJson();
-
-    assertThat(itemFromGet.getString("id"), is(newId));
-    assertThat(itemFromGet.getString("holdingsRecordId"), is(holdingsRecordId.toString()));
-    assertThat(itemFromGet.getString("barcode"), is("565578437802"));
-    assertThat(itemFromGet.getJsonObject("status").getString("name"),
-      is("Available"));
-    assertThat(itemFromGet.getString("materialTypeId"),
-      is(journalMaterialTypeID));
-    assertThat(itemFromGet.getString("permanentLoanTypeId"),
-      is(canCirculateLoanTypeID));
-    assertThat(itemFromGet.getString("temporaryLocationId"),
-      is(annexLibraryLocationId.toString()));
-
-    List<String> tags = itemFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
-
-    assertThat(tags.size(), is(1));
-    assertThat(tags, hasItem(TAG_VALUE));
-    assertThat(
-      itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("callNumber"),
-       is("testItemCallNumber"));
-  }
-
-  @Test
   public void canCreateAnItemWithHRIDSupplied()
       throws MalformedURLException, InterruptedException,
       ExecutionException, TimeoutException {
@@ -415,398 +307,6 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(getResponse.getJson().getString("hrid"), is("ITEM12345"));
 
     log.info("Finished canCreateAnItemWithHRIDSupplied");
-  }
-
-  @Test
-  public void canUpdateAnItemWithHoldingCallNumberAsEffectiveCallNumber()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
-
-    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumber(mainLibraryLocationId);
-    JsonObject itemToCreate = new JsonObject();
-    String itemId = UUID.randomUUID().toString();
-    itemToCreate.put("id", itemId);
-    itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
-    itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
-    itemToCreate.put("materialTypeId", bookMaterialTypeID);
-    createItem(itemToCreate);
-
-    CompletableFuture<Response> completed = new CompletableFuture<>();
-    client.put(itemsStorageUrl("/" + itemId), itemToCreate, StorageTestSuite.TENANT_ID,
-        ResponseHandler.text(completed));
-
-    Response getResponse = getById(UUID.fromString(itemId));
-
-    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-
-    JsonObject itemFromGet = getResponse.getJson();
-
-    assertThat(
-      itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("callNumber"),
-      is("testCallNumber"));
-  }
-
-  @Test
-  public void canUpdateAnItemWithItemLevelCallNumberAsEffectiveCallNumber()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
-
-    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumber(mainLibraryLocationId);
-    JsonObject itemToCreate = new JsonObject();
-    String itemId = UUID.randomUUID().toString();
-    itemToCreate.put("id", itemId);
-    itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
-    itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
-    itemToCreate.put("materialTypeId", bookMaterialTypeID);
-    itemToCreate.put("itemLevelCallNumber", "testItemCallNumber");
-    createItem(itemToCreate);
-
-    CompletableFuture<Response> completed = new CompletableFuture<>();
-    client.put(itemsStorageUrl("/" + itemId), itemToCreate, StorageTestSuite.TENANT_ID,
-        ResponseHandler.text(completed));
-
-    Response getResponse = getById(UUID.fromString(itemId));
-
-    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-
-    JsonObject itemFromGet = getResponse.getJson();
-
-    assertThat(
-      itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("callNumber"),
-      is("testItemCallNumber"));
-  }
-
-  @Test
-  public void canCreateAnItemWithHoldingCallNumberPrefixAsEffectiveCallNumberPrefix()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
-
-    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumberPrefix(mainLibraryLocationId);
-
-    JsonObject itemToCreate = nod(null, holdingsRecordId);
-
-    itemToCreate.put("tags", new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)));
-
-    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
-
-    client.post(itemsStorageUrl(""), itemToCreate, StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(createCompleted));
-
-    Response postResponse = createCompleted.get(5, TimeUnit.SECONDS);
-
-    assertThat(postResponse.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
-
-    JsonObject itemFromPost = postResponse.getJson();
-
-    String newId = itemFromPost.getString("id");
-
-    assertThat(newId, is(notNullValue()));
-
-    Response getResponse = getById(UUID.fromString(newId));
-
-    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-
-    JsonObject itemFromGet = getResponse.getJson();
-
-    assertThat(itemFromGet.getString("id"), is(newId));
-    assertThat(itemFromGet.getString("holdingsRecordId"), is(holdingsRecordId.toString()));
-    assertThat(itemFromGet.getString("barcode"), is("565578437802"));
-    assertThat(itemFromGet.getJsonObject("status").getString("name"),
-      is("Available"));
-    assertThat(itemFromGet.getString("materialTypeId"),
-      is(journalMaterialTypeID));
-    assertThat(itemFromGet.getString("permanentLoanTypeId"),
-      is(canCirculateLoanTypeID));
-    assertThat(itemFromGet.getString("temporaryLocationId"),
-      is(annexLibraryLocationId.toString()));
-
-    List<String> tags = itemFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
-
-    assertThat(tags.size(), is(1));
-    assertThat(tags, hasItem(TAG_VALUE));
-    assertThat(
-      itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("prefix"),
-      is("testCallNumberPrefix"));
-  }
-
-  @Test
-  public void canCreateAnItemWithItemLevelCallNumberPrefixAsEffectiveCallNumberPrefix()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
-
-    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumberPrefix(mainLibraryLocationId);
-
-    JsonObject itemToCreate = nod(null, holdingsRecordId);
-
-    itemToCreate.put("tags", new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)));
-
-    itemToCreate.put("itemLevelCallNumberPrefix", "testItemCallNumberPrefix");
-
-    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
-
-    client.post(itemsStorageUrl(""), itemToCreate, StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(createCompleted));
-
-    Response postResponse = createCompleted.get(5, TimeUnit.SECONDS);
-
-    assertThat(postResponse.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
-
-    JsonObject itemFromPost = postResponse.getJson();
-
-    String newId = itemFromPost.getString("id");
-
-    assertThat(newId, is(notNullValue()));
-
-    Response getResponse = getById(UUID.fromString(newId));
-
-    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-
-    JsonObject itemFromGet = getResponse.getJson();
-
-    assertThat(itemFromGet.getString("id"), is(newId));
-    assertThat(itemFromGet.getString("holdingsRecordId"), is(holdingsRecordId.toString()));
-    assertThat(itemFromGet.getString("barcode"), is("565578437802"));
-    assertThat(itemFromGet.getJsonObject("status").getString("name"),
-      is("Available"));
-    assertThat(itemFromGet.getString("materialTypeId"),
-      is(journalMaterialTypeID));
-    assertThat(itemFromGet.getString("permanentLoanTypeId"),
-      is(canCirculateLoanTypeID));
-    assertThat(itemFromGet.getString("temporaryLocationId"),
-      is(annexLibraryLocationId.toString()));
-
-    List<String> tags = itemFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
-
-    assertThat(tags.size(), is(1));
-    assertThat(tags, hasItem(TAG_VALUE));
-    assertThat(
-      itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("prefix"),
-      is("testItemCallNumberPrefix"));
-  }
-
-  @Test
-  public void canUpdateAnItemWithHoldingCallNumberPrefixAsEffectiveCallNumberPrefix()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
-
-    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumberPrefix(mainLibraryLocationId);
-    JsonObject itemToCreate = new JsonObject();
-    String itemId = UUID.randomUUID().toString();
-    itemToCreate.put("id", itemId);
-    itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
-    itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
-    itemToCreate.put("materialTypeId", bookMaterialTypeID);
-    createItem(itemToCreate);
-
-    CompletableFuture<Response> completed = new CompletableFuture<>();
-    client.put(itemsStorageUrl("/" + itemId), itemToCreate, StorageTestSuite.TENANT_ID,
-        ResponseHandler.text(completed));
-
-    Response getResponse = getById(UUID.fromString(itemId));
-
-    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-
-    JsonObject itemFromGet = getResponse.getJson();
-
-    assertThat(
-      itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("prefix"),
-      is("testCallNumberPrefix"));
-  }
-
-  @Test
-  public void canUpdateAnItemWithItemLevelCallNumberPrefixAsEffectiveCallNumberPrefix()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
-
-    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumberPrefix(mainLibraryLocationId);
-    JsonObject itemToCreate = new JsonObject();
-    String itemId = UUID.randomUUID().toString();
-    itemToCreate.put("id", itemId);
-    itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
-    itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
-    itemToCreate.put("materialTypeId", bookMaterialTypeID);
-    itemToCreate.put("itemLevelCallNumberPrefix", "testItemCallNumberPrefix");
-    createItem(itemToCreate);
-
-    CompletableFuture<Response> completed = new CompletableFuture<>();
-    client.put(itemsStorageUrl("/" + itemId), itemToCreate, StorageTestSuite.TENANT_ID,
-        ResponseHandler.text(completed));
-
-    Response getResponse = getById(UUID.fromString(itemId));
-
-    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-
-    JsonObject itemFromGet = getResponse.getJson();
-
-    assertThat(
-      itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("prefix"),
-      is("testItemCallNumberPrefix"));
-  }
-
-  @Test
-  public void canCreateAnItemWithHoldingCallNumberSuffixAsEffectiveCallNumberSuffix()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
-
-    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumberSuffix(mainLibraryLocationId);
-
-    JsonObject itemToCreate = nod(null, holdingsRecordId);
-
-    itemToCreate.put("tags", new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)));
-
-    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
-
-    client.post(itemsStorageUrl(""), itemToCreate, StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(createCompleted));
-
-    Response postResponse = createCompleted.get(5, TimeUnit.SECONDS);
-
-    assertThat(postResponse.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
-
-    JsonObject itemFromPost = postResponse.getJson();
-
-    String newId = itemFromPost.getString("id");
-
-    assertThat(newId, is(notNullValue()));
-
-    Response getResponse = getById(UUID.fromString(newId));
-
-    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-
-    JsonObject itemFromGet = getResponse.getJson();
-
-    assertThat(itemFromGet.getString("id"), is(newId));
-    assertThat(itemFromGet.getString("holdingsRecordId"), is(holdingsRecordId.toString()));
-    assertThat(itemFromGet.getString("barcode"), is("565578437802"));
-    assertThat(itemFromGet.getJsonObject("status").getString("name"),
-      is("Available"));
-    assertThat(itemFromGet.getString("materialTypeId"),
-      is(journalMaterialTypeID));
-    assertThat(itemFromGet.getString("permanentLoanTypeId"),
-      is(canCirculateLoanTypeID));
-    assertThat(itemFromGet.getString("temporaryLocationId"),
-      is(annexLibraryLocationId.toString()));
-
-    List<String> tags = itemFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
-
-    assertThat(tags.size(), is(1));
-    assertThat(tags, hasItem(TAG_VALUE));
-    assertThat(itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("suffix"),
-      is("testCallNumberSuffix"));
-  }
-
-  @Test
-  public void canCreateAnItemWithItemLevelCallNumberSuffixAsEffectiveCallNumberSuffix()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
-
-    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumberSuffix(mainLibraryLocationId);
-
-    JsonObject itemToCreate = nod(null, holdingsRecordId);
-
-    itemToCreate.put("tags", new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)));
-
-    itemToCreate.put("itemLevelCallNumberSuffix", "testItemCallNumberSuffix");
-
-    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
-
-    client.post(itemsStorageUrl(""), itemToCreate, StorageTestSuite.TENANT_ID,
-      ResponseHandler.json(createCompleted));
-
-    Response postResponse = createCompleted.get(5, TimeUnit.SECONDS);
-
-    assertThat(postResponse.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
-
-    JsonObject itemFromPost = postResponse.getJson();
-
-    String newId = itemFromPost.getString("id");
-
-    assertThat(newId, is(notNullValue()));
-
-    Response getResponse = getById(UUID.fromString(newId));
-
-    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-
-    JsonObject itemFromGet = getResponse.getJson();
-
-    assertThat(itemFromGet.getString("id"), is(newId));
-    assertThat(itemFromGet.getString("holdingsRecordId"), is(holdingsRecordId.toString()));
-    assertThat(itemFromGet.getString("barcode"), is("565578437802"));
-    assertThat(itemFromGet.getJsonObject("status").getString("name"),
-      is("Available"));
-    assertThat(itemFromGet.getString("materialTypeId"),
-      is(journalMaterialTypeID));
-    assertThat(itemFromGet.getString("permanentLoanTypeId"),
-      is(canCirculateLoanTypeID));
-    assertThat(itemFromGet.getString("temporaryLocationId"),
-      is(annexLibraryLocationId.toString()));
-
-    List<String> tags = itemFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
-
-    assertThat(tags.size(), is(1));
-    assertThat(tags, hasItem(TAG_VALUE));
-    assertThat(
-      itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("suffix"),
-      is("testItemCallNumberSuffix"));
-  }
-
-  @Test
-  public void canUpdateAnItemWithHoldingCallNumberSuffixAsEffectiveCallNumberSuffix()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
-
-    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumberSuffix(mainLibraryLocationId);
-    JsonObject itemToCreate = new JsonObject();
-    String itemId = UUID.randomUUID().toString();
-    itemToCreate.put("id", itemId);
-    itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
-    itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
-    itemToCreate.put("materialTypeId", bookMaterialTypeID);
-    createItem(itemToCreate);
-
-    CompletableFuture<Response> completed = new CompletableFuture<>();
-    client.put(itemsStorageUrl("/" + itemId), itemToCreate, StorageTestSuite.TENANT_ID,
-        ResponseHandler.text(completed));
-
-    Response getResponse = getById(UUID.fromString(itemId));
-
-    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-
-    JsonObject itemFromGet = getResponse.getJson();
-
-    assertThat(
-      itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("suffix"),
-      is("testCallNumberSuffix"));
-  }
-
-  @Test
-  public void canUpdateAnItemWithItemLevelCallNumberSuffixAsEffectiveCallNumberSuffix()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
-
-    UUID holdingsRecordId = createInstanceAndHoldingWithCallNumberSuffix(mainLibraryLocationId);
-    JsonObject itemToCreate = new JsonObject();
-    String itemId = UUID.randomUUID().toString();
-    itemToCreate.put("id", itemId);
-    itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
-    itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
-    itemToCreate.put("materialTypeId", bookMaterialTypeID);
-    itemToCreate.put("itemLevelCallNumberSuffix", "testItemCallNumberSuffix");
-    createItem(itemToCreate);
-
-    CompletableFuture<Response> completed = new CompletableFuture<>();
-    client.put(itemsStorageUrl("/" + itemId), itemToCreate, StorageTestSuite.TENANT_ID,
-        ResponseHandler.text(completed));
-
-    Response getResponse = getById(UUID.fromString(itemId));
-
-    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-
-    JsonObject itemFromGet = getResponse.getJson();
-
-    assertThat(
-      itemFromGet.getJsonObject("effectiveCallNumberComponents").getString("suffix"),
-      is("testItemCallNumberSuffix"));
   }
 
   @Test
@@ -2165,7 +1665,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     return getCompleted.get(5, TimeUnit.SECONDS);
   }
 
-  private JsonObject createItemRequest(
+  private static JsonObject createItemRequest(
       UUID id,
       UUID holdingsRecordId,
       String barcode) {
@@ -2173,7 +1673,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     return createItemRequest(id, holdingsRecordId, barcode, journalMaterialTypeID);
   }
 
-  private JsonObject createItemRequest(
+  private static JsonObject createItemRequest(
     UUID id,
     UUID holdingsRecordId,
     String barcode,
@@ -2195,31 +1695,31 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     return itemToCreate;
   }
 
-  private JsonObject smallAngryPlanet(UUID itemId, UUID holdingsRecordId) {
+  private static JsonObject smallAngryPlanet(UUID itemId, UUID holdingsRecordId) {
     return createItemRequest(itemId, holdingsRecordId, "036000291452");
   }
 
-  private JsonObject smallAngryPlanet(UUID holdingsRecordId) {
+  private static JsonObject smallAngryPlanet(UUID holdingsRecordId) {
     return smallAngryPlanet(UUID.randomUUID(), holdingsRecordId);
   }
 
-  private JsonObject nod(UUID itemId, UUID holdingsRecordId) {
+  static JsonObject nod(UUID itemId, UUID holdingsRecordId) {
     return createItemRequest(itemId, holdingsRecordId, "565578437802");
   }
 
-  private JsonObject nod(UUID holdingsRecordId) {
+  static JsonObject nod(UUID holdingsRecordId) {
     return nod(UUID.randomUUID(), holdingsRecordId);
   }
 
-  private JsonObject uprooted(UUID itemId, UUID holdingsRecordId) {
+  private static JsonObject uprooted(UUID itemId, UUID holdingsRecordId) {
     return createItemRequest(itemId, holdingsRecordId, "657670342075");
   }
 
-  private JsonObject temeraire(UUID itemId, UUID holdingsRecordId) {
+  private static JsonObject temeraire(UUID itemId, UUID holdingsRecordId) {
     return createItemRequest(itemId, holdingsRecordId, "232142443432");
   }
 
-  private JsonObject interestingTimes(UUID itemId, UUID holdingsRecordId) {
+  private static JsonObject interestingTimes(UUID itemId, UUID holdingsRecordId) {
     return createItemRequest(itemId, holdingsRecordId, "56454543534");
   }
 

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -55,7 +55,8 @@ import io.vertx.ext.sql.UpdateResult;
   ItemEffectiveLocationTest.class,
   SampleDataTest.class,
   HridSettingsStorageTest.class,
-  HridSettingsStorageParameterizedTest.class
+  HridSettingsStorageParameterizedTest.class,
+  ItemEffectiveCallNumberComponentsTest.class
 })
 public class StorageTestSuite {
   public static final String TENANT_ID = "test_tenant";

--- a/src/test/java/org/folio/rest/api/TestBase.java
+++ b/src/test/java/org/folio/rest/api/TestBase.java
@@ -33,6 +33,7 @@ public abstract class TestBase {
   static ResourceClient holdingsClient;
   static ResourceClient itemsClient;
   static ResourceClient locationsClient;
+  static ResourceClient callNumberTypesClient;
 
   @BeforeClass
   public static void testBaseBeforeClass() throws Exception {
@@ -48,6 +49,7 @@ public abstract class TestBase {
     holdingsClient = ResourceClient.forHoldings(client);
     itemsClient = ResourceClient.forItems(client);
     locationsClient = ResourceClient.forLocations(client);
+    callNumberTypesClient = ResourceClient.forCallNumberTypes(client);
   }
 
   @AfterClass

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -44,12 +44,12 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   protected static final String TEMPORARY_LOCATION_ID_KEY = "temporaryLocationId";
   protected static final String EFFECTIVE_LOCATION_ID_KEY = "effectiveLocationId";
 
-  protected static final String MAIN_LIBRARY_LOCATION = "Main Library";
-  protected static final String SECOND_FLOOR_LOCATION = "Second Floor";
-  protected static final String ANNEX_LIBRARY_LOCATION = "Annex Library";
-  protected static final String ONLINE_LOCATION = "Online";
-  protected static final String THIRD_FLOOR_LOCATION = "Third Floor";
-  protected static final String FOURTH_FLOOR_LOCATION = "Fourth Floor";
+  public static final String MAIN_LIBRARY_LOCATION = "Main Library";
+  public static final String SECOND_FLOOR_LOCATION = "Second Floor";
+  public static final String ANNEX_LIBRARY_LOCATION = "Annex Library";
+  public static final String ONLINE_LOCATION = "Online";
+  public static final String THIRD_FLOOR_LOCATION = "Third Floor";
+  public static final String FOURTH_FLOOR_LOCATION = "Fourth Floor";
 
   protected static UUID   journalMaterialTypeId;
   protected static String journalMaterialTypeID;
@@ -60,12 +60,12 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
 
   // Creating the UUIDs here because they are used in ItemEffectiveLocationTest.parameters()
   // that JUnit calls *before* the @BeforeClass beforeAny() method.
-  protected static UUID mainLibraryLocationId = UUID.randomUUID();
-  protected static UUID annexLibraryLocationId = UUID.randomUUID();
-  protected static UUID onlineLocationId = UUID.randomUUID();
-  protected static UUID secondFloorLocationId = UUID.randomUUID();
-  protected static UUID thirdFloorLocationId = UUID.randomUUID();
-  protected static UUID fourthFloorLocationId = UUID.randomUUID();
+  public static UUID mainLibraryLocationId = UUID.randomUUID();
+  public static UUID annexLibraryLocationId = UUID.randomUUID();
+  public static UUID onlineLocationId = UUID.randomUUID();
+  public static UUID secondFloorLocationId = UUID.randomUUID();
+  public static UUID thirdFloorLocationId = UUID.randomUUID();
+  public static UUID fourthFloorLocationId = UUID.randomUUID();
 
   // These UUIDs were taken from reference-data folder.
   // When the vertical gets started the data from the reference-data folder are loaded to the DB.

--- a/src/test/java/org/folio/rest/api/testdata/ItemEffectiveCallNumberComponentsTestData.java
+++ b/src/test/java/org/folio/rest/api/testdata/ItemEffectiveCallNumberComponentsTestData.java
@@ -1,0 +1,142 @@
+package org.folio.rest.api.testdata;
+
+
+import static org.folio.rest.api.ItemEffectiveCallNumberComponentsTest.HOLDINGS_CALL_NUMBER_TYPE;
+import static org.folio.rest.api.ItemEffectiveCallNumberComponentsTest.HOLDINGS_CALL_NUMBER_TYPE_SECOND;
+import static org.folio.rest.api.ItemEffectiveCallNumberComponentsTest.ITEM_LEVEL_CALL_NUMBER_TYPE;
+import static org.folio.rest.api.ItemEffectiveCallNumberComponentsTest.ITEM_LEVEL_CALL_NUMBER_TYPE_SECOND;
+
+import org.apache.commons.lang.builder.ToStringBuilder;
+import org.apache.commons.lang3.StringUtils;
+
+public class ItemEffectiveCallNumberComponentsTestData {
+
+  @SuppressWarnings("unused")
+  public Object[][] createPropertiesParams() {
+    // Format:
+    // CallNumber component names, holdings value, item value
+    return new Object[][]{
+      // Call Number
+      {forProperty("callNumber"), "hrCallNumber", "itCallNumber"},
+      {forProperty("callNumber"), null, "itCallNumber"},
+      {forProperty("callNumber"), "hrCallNumber", null},
+      {forProperty("callNumber"), null, null},
+      // CallNumberSuffix
+      {forProperty("suffix"), "hrCNSuffix", "itCNSuffix"},
+      {forProperty("suffix"), "hrCNSuffix", null},
+      {forProperty("suffix"), null, "itCNSuffix"},
+      {forProperty("suffix"), null, null},
+      // CallNumberPrefix
+      {forProperty("prefix"), "hrCNPrefix", "itCNPrefix"},
+      {forProperty("prefix"), "hrCNPrefix", null},
+      {forProperty("prefix"), null, "itCNPrefix"},
+      {forProperty("prefix"), null, null},
+      // CallNumberTypeId
+      {forProperty("typeId"), HOLDINGS_CALL_NUMBER_TYPE, ITEM_LEVEL_CALL_NUMBER_TYPE},
+      {forProperty("typeId"), HOLDINGS_CALL_NUMBER_TYPE, null},
+      {forProperty("typeId"), null, ITEM_LEVEL_CALL_NUMBER_TYPE},
+      {forProperty("typeId"), null, null},
+    };
+  }
+
+  @SuppressWarnings("unused")
+  public Object[][] updatePropertiesParams() {
+    // Format:
+    // CallNumber component names, init holdings value, target holdings value, init item value, target item value
+    return new Object[][]{
+      // CallNumber
+      {forProperty("callNumber"), "initHrCN", "targetHrCN", "initItCN", "targetItCN"},
+      {forProperty("callNumber"), "initHrCN", null, "initItCN", "targetItCN"},
+      {forProperty("callNumber"), "initHrCN", "targetHrCN", "initItCN", null},
+      {forProperty("callNumber"), "initHrCN", null, "initItCN", null},
+      {forProperty("callNumber"), "initHrCN", null, "initItCN", "initItCN"},
+      {forProperty("callNumber"), "initHrCN", "initHrCN", "initItCN", null},
+      {forProperty("callNumber"), "initHrCN", "targetHrCN", null, null},
+      {forProperty("callNumber"), null, "targetHrCN", "initItCN", null},
+      // CallNumberSuffix
+      {forProperty("suffix"), "initHrCNSuffix", "targetHrCNSuffix", "initItCNSuffix", "targetItCNSuffix"},
+      {forProperty("suffix"), "initHrCNSuffix", null, "initItCNSuffix", "targetItCNSuffix"},
+      {forProperty("suffix"), "initHrCNSuffix", "targetHrCNSuffix", "initItCNSuffix", null},
+      {forProperty("suffix"), "initHrCNSuffix", null, "initItCNSuffix", null},
+      {forProperty("suffix"), "initHrCNSuffix", null, "initItCNSuffix", "initItCNSuffix"},
+      {forProperty("suffix"), "initHrCNSuffix", "initHrCNSuffix", "initItCNSuffix", null},
+      {forProperty("suffix"), "initHrCNSuffix", "targetHrCNSuffix", null, null},
+      {forProperty("suffix"), null, "targetHrCNSuffix", "initItCNSuffix", null},
+      // CallNumberPrefix
+      {forProperty("prefix"), "initHrCNPrefix", "targetHrCNPrefix", "initItCNPrefix", "targetItCNPrefix"},
+      {forProperty("prefix"), "initHrCNPrefix", null, "initItCNPrefix", "targetItCNPrefix"},
+      {forProperty("prefix"), "initHrCNPrefix", "targetHrCNPrefix", "initItCNPrefix", null},
+      {forProperty("prefix"), "initHrCNPrefix", null, "initItCNPrefix", null},
+      {forProperty("prefix"), "initHrCNPrefix", null, "initItCNPrefix", "initItCNPrefix"},
+      {forProperty("prefix"), "initHrCNPrefix", "initHrCNPrefix", "initItCNPrefix", null},
+      {forProperty("prefix"), "initHrCNPrefix", "targetHrCNPrefix", null, null},
+      {forProperty("prefix"), null, "targetHrCNPrefix", "initItCNPrefix", null},
+      // CallNumberPrefix
+      {forProperty("prefix"), "initHrCNPrefix", "targetHrCNPrefix", "initItCNPrefix", "targetItCNPrefix"},
+      {forProperty("prefix"), "initHrCNPrefix", null, "initItCNPrefix", "targetItCNPrefix"},
+      {forProperty("prefix"), "initHrCNPrefix", "targetHrCNPrefix", "initItCNPrefix", null},
+      {forProperty("prefix"), "initHrCNPrefix", null, "initItCNPrefix", null},
+      {forProperty("prefix"), "initHrCNPrefix", null, "initItCNPrefix", "initItCNPrefix"},
+      {forProperty("prefix"), "initHrCNPrefix", "initHrCNPrefix", "initItCNPrefix", null},
+      {forProperty("prefix"), "initHrCNPrefix", "targetHrCNPrefix", null, null},
+      {forProperty("prefix"), null, "targetHrCNPrefix", "initItCNPrefix", null},
+      // CallNumberTypeId
+      {forProperty("typeId"), HOLDINGS_CALL_NUMBER_TYPE, HOLDINGS_CALL_NUMBER_TYPE_SECOND,
+        ITEM_LEVEL_CALL_NUMBER_TYPE, ITEM_LEVEL_CALL_NUMBER_TYPE_SECOND
+      },
+      {forProperty("typeId"), HOLDINGS_CALL_NUMBER_TYPE, null, ITEM_LEVEL_CALL_NUMBER_TYPE,
+        ITEM_LEVEL_CALL_NUMBER_TYPE_SECOND
+      },
+      {forProperty("typeId"), HOLDINGS_CALL_NUMBER_TYPE, HOLDINGS_CALL_NUMBER_TYPE_SECOND,
+        ITEM_LEVEL_CALL_NUMBER_TYPE, null
+      },
+      {forProperty("typeId"), HOLDINGS_CALL_NUMBER_TYPE, null, ITEM_LEVEL_CALL_NUMBER_TYPE, null},
+      {forProperty("typeId"), HOLDINGS_CALL_NUMBER_TYPE, null, ITEM_LEVEL_CALL_NUMBER_TYPE,
+        ITEM_LEVEL_CALL_NUMBER_TYPE
+      },
+      {forProperty("typeId"), HOLDINGS_CALL_NUMBER_TYPE, HOLDINGS_CALL_NUMBER_TYPE,
+        ITEM_LEVEL_CALL_NUMBER_TYPE, null
+      },
+      {forProperty("typeId"), HOLDINGS_CALL_NUMBER_TYPE, HOLDINGS_CALL_NUMBER_TYPE_SECOND, null, null},
+      {forProperty("typeId"), null, HOLDINGS_CALL_NUMBER_TYPE_SECOND, ITEM_LEVEL_CALL_NUMBER_TYPE, null},
+    };
+  }
+
+  public static final class CallNumberComponentPropertyNames {
+    public final String holdingsPropertyName;
+    public final String itemPropertyName;
+    public final String effectivePropertyName;
+
+    private CallNumberComponentPropertyNames(
+      String holdingsPropertyName, String itemPropertyName, String effectivePropertyName) {
+
+      this.holdingsPropertyName = holdingsPropertyName;
+      this.itemPropertyName = itemPropertyName;
+      this.effectivePropertyName = effectivePropertyName;
+    }
+
+    @Override
+    public String toString() {
+      return new ToStringBuilder(null)
+        .append(holdingsPropertyName)
+        .append(itemPropertyName)
+        .append(effectivePropertyName)
+        .toString();
+    }
+  }
+
+  private static CallNumberComponentPropertyNames forProperty(String effectivePropertyName) {
+    if (effectivePropertyName.equals("callNumber")) {
+      return new CallNumberComponentPropertyNames(
+        "callNumber", "itemLevelCallNumber", effectivePropertyName
+      );
+    }
+
+    final String holdingsPropertyName = "callNumber" + StringUtils.capitalize(effectivePropertyName);
+    final String itemPropertyName = "itemLevel" + StringUtils.capitalize(holdingsPropertyName);
+
+    return new CallNumberComponentPropertyNames(
+      holdingsPropertyName, itemPropertyName, effectivePropertyName
+    );
+  }
+}

--- a/src/test/java/org/folio/rest/api/testdata/ItemEffectiveLocationTestDataProvider.java
+++ b/src/test/java/org/folio/rest/api/testdata/ItemEffectiveLocationTestDataProvider.java
@@ -1,4 +1,4 @@
-package org.folio.rest.api;
+package org.folio.rest.api.testdata;
 
 import static org.folio.rest.api.TestBaseWithInventoryUtil.ANNEX_LIBRARY_LOCATION;
 import static org.folio.rest.api.TestBaseWithInventoryUtil.FOURTH_FLOOR_LOCATION;
@@ -110,11 +110,11 @@ public class ItemEffectiveLocationTestDataProvider {
     /**
      * permanent location UUID
      */
-    UUID perm;
+    public UUID perm;
     /**
      * temporary location UUID
      */
-    UUID temp;
+    public UUID temp;
 
     /**
      * @param perm permanent location UUID

--- a/src/test/java/org/folio/rest/support/builders/HoldingRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/HoldingRequestBuilder.java
@@ -15,12 +15,14 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
   private String callNumberPrefix;
   private String callNumberSuffix;
   private final String hrid;
+  private String callNumberTypeId;
 
   public HoldingRequestBuilder() {
     this(
       null,
       null,
       UUID.randomUUID(),
+      null,
       null,
       null,
       null,
@@ -38,7 +40,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     String callNumber,
     String callNumberPrefix,
     String callNumberSuffix,
-    String hrid) {
+    String hrid,
+    String callNumberTypeId) {
 
     this.id = id;
     this.instanceId = instanceId;
@@ -49,6 +52,7 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     this.callNumberPrefix = callNumberPrefix;
     this.callNumberSuffix = callNumberSuffix;
     this.hrid = hrid;
+    this.callNumberTypeId = callNumberTypeId;
   }
 
   @Override
@@ -64,6 +68,7 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     put(request, "callNumberPrefix", callNumberPrefix);
     put(request, "callNumberSuffix", callNumberSuffix);
     put(request, "hrid", hrid);
+    put(request, "callNumberTypeId", callNumberTypeId);
 
     return request;
   }
@@ -78,7 +83,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       this.callNumberPrefix,
       this.callNumberSuffix,
-      this.hrid);
+      this.hrid,
+      this.callNumberTypeId);
   }
 
   public HoldingRequestBuilder withTemporaryLocation(UUID temporaryLocationId) {
@@ -91,7 +97,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       this.callNumberPrefix,
       this.callNumberSuffix,
-      this.hrid);
+      this.hrid,
+      this.callNumberTypeId);
   }
 
   public HoldingRequestBuilder forInstance(UUID instanceId) {
@@ -104,7 +111,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       this.callNumberPrefix,
       this.callNumberSuffix,
-      this.hrid);
+      this.hrid,
+      this.callNumberTypeId);
   }
 
   public HoldingRequestBuilder withId(UUID id) {
@@ -117,7 +125,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       this.callNumberPrefix,
       this.callNumberSuffix,
-      this.hrid);
+      this.hrid,
+      this.callNumberTypeId);
   }
 
   public HoldingRequestBuilder withTags(JsonObject tags) {
@@ -130,7 +139,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       this.callNumberPrefix,
       this.callNumberSuffix,
-      this.hrid);
+      this.hrid,
+      this.callNumberTypeId);
   }
 
   public HoldingRequestBuilder withCallNumber(String callNumber) {
@@ -143,7 +153,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       callNumber,
       this.callNumberPrefix,
       this.callNumberSuffix,
-      this.hrid);
+      this.hrid,
+      this.callNumberTypeId);
   }
 
   public HoldingRequestBuilder withCallNumberPrefix(String callNumberPrefix) {
@@ -156,7 +167,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       callNumberPrefix,
       this.callNumberSuffix,
-      this.hrid);
+      this.hrid,
+      this.callNumberTypeId);
   }
 
   public HoldingRequestBuilder withCallNumberSuffix(String callNumberSuffix) {
@@ -169,7 +181,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       this.callNumberPrefix,
       callNumberSuffix,
-      this.hrid);
+      this.hrid,
+      this.callNumberTypeId);
   }
 
   public HoldingRequestBuilder withHrid(String hrid) {
@@ -182,6 +195,21 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       this.callNumberPrefix,
       this.callNumberSuffix,
-      hrid);
+      hrid,
+      this.callNumberTypeId);
+  }
+
+  public HoldingRequestBuilder withCallNumberTypeId(String callNumberTypeId) {
+    return new HoldingRequestBuilder(
+      this.id,
+      this.instanceId,
+      this.permanentLocationId,
+      this.temporaryLocationId,
+      this.tags,
+      this.callNumber,
+      this.callNumberPrefix,
+      this.callNumberSuffix,
+      this.hrid,
+      callNumberTypeId);
   }
 }

--- a/src/test/java/org/folio/rest/support/builders/HoldingRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/HoldingRequestBuilder.java
@@ -14,8 +14,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
   private String callNumber;
   private String callNumberPrefix;
   private String callNumberSuffix;
-  private final String hrid;
   private String callNumberTypeId;
+  private final String hrid;
 
   public HoldingRequestBuilder() {
     this(
@@ -40,8 +40,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     String callNumber,
     String callNumberPrefix,
     String callNumberSuffix,
-    String hrid,
-    String callNumberTypeId) {
+    String callNumberTypeId,
+    String hrid) {
 
     this.id = id;
     this.instanceId = instanceId;
@@ -51,8 +51,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     this.callNumber = callNumber;
     this.callNumberPrefix = callNumberPrefix;
     this.callNumberSuffix = callNumberSuffix;
-    this.hrid = hrid;
     this.callNumberTypeId = callNumberTypeId;
+    this.hrid = hrid;
   }
 
   @Override
@@ -67,8 +67,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     put(request, "callNumber", callNumber);
     put(request, "callNumberPrefix", callNumberPrefix);
     put(request, "callNumberSuffix", callNumberSuffix);
-    put(request, "hrid", hrid);
     put(request, "callNumberTypeId", callNumberTypeId);
+    put(request, "hrid", hrid);
 
     return request;
   }
@@ -83,8 +83,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       this.callNumberPrefix,
       this.callNumberSuffix,
-      this.hrid,
-      this.callNumberTypeId);
+      this.callNumberTypeId,
+      this.hrid);
   }
 
   public HoldingRequestBuilder withTemporaryLocation(UUID temporaryLocationId) {
@@ -97,8 +97,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       this.callNumberPrefix,
       this.callNumberSuffix,
-      this.hrid,
-      this.callNumberTypeId);
+      this.callNumberTypeId,
+      this.hrid);
   }
 
   public HoldingRequestBuilder forInstance(UUID instanceId) {
@@ -111,8 +111,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       this.callNumberPrefix,
       this.callNumberSuffix,
-      this.hrid,
-      this.callNumberTypeId);
+      this.callNumberTypeId,
+      this.hrid);
   }
 
   public HoldingRequestBuilder withId(UUID id) {
@@ -125,8 +125,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       this.callNumberPrefix,
       this.callNumberSuffix,
-      this.hrid,
-      this.callNumberTypeId);
+      this.callNumberTypeId,
+      this.hrid);
   }
 
   public HoldingRequestBuilder withTags(JsonObject tags) {
@@ -139,8 +139,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       this.callNumberPrefix,
       this.callNumberSuffix,
-      this.hrid,
-      this.callNumberTypeId);
+      this.callNumberTypeId,
+      this.hrid);
   }
 
   public HoldingRequestBuilder withCallNumber(String callNumber) {
@@ -153,8 +153,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       callNumber,
       this.callNumberPrefix,
       this.callNumberSuffix,
-      this.hrid,
-      this.callNumberTypeId);
+      this.callNumberTypeId,
+      this.hrid);
   }
 
   public HoldingRequestBuilder withCallNumberPrefix(String callNumberPrefix) {
@@ -167,8 +167,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       callNumberPrefix,
       this.callNumberSuffix,
-      this.hrid,
-      this.callNumberTypeId);
+      this.callNumberTypeId,
+      this.hrid);
   }
 
   public HoldingRequestBuilder withCallNumberSuffix(String callNumberSuffix) {
@@ -181,22 +181,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       this.callNumberPrefix,
       callNumberSuffix,
-      this.hrid,
-      this.callNumberTypeId);
-  }
-
-  public HoldingRequestBuilder withHrid(String hrid) {
-    return new HoldingRequestBuilder(
-      this.id,
-      this.instanceId,
-      this.permanentLocationId,
-      this.temporaryLocationId,
-      this.tags,
-      this.callNumber,
-      this.callNumberPrefix,
-      this.callNumberSuffix,
-      hrid,
-      this.callNumberTypeId);
+      this.callNumberTypeId,
+      this.hrid);
   }
 
   public HoldingRequestBuilder withCallNumberTypeId(String callNumberTypeId) {
@@ -209,7 +195,21 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumber,
       this.callNumberPrefix,
       this.callNumberSuffix,
-      this.hrid,
-      callNumberTypeId);
+      callNumberTypeId,
+      this.hrid);
+  }
+
+  public HoldingRequestBuilder withHrid(String hrid) {
+    return new HoldingRequestBuilder(
+      this.id,
+      this.instanceId,
+      this.permanentLocationId,
+      this.temporaryLocationId,
+      this.tags,
+      this.callNumber,
+      this.callNumberPrefix,
+      this.callNumberSuffix,
+      this.callNumberTypeId,
+      hrid);
   }
 }

--- a/src/test/java/org/folio/rest/support/builders/ItemRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/ItemRequestBuilder.java
@@ -1,8 +1,8 @@
 package org.folio.rest.support.builders;
 
-import io.vertx.core.json.JsonObject;
-
 import java.util.UUID;
+
+import io.vertx.core.json.JsonObject;
 
 public class ItemRequestBuilder extends JsonRequestBuilder implements Builder {
 
@@ -17,10 +17,11 @@ public class ItemRequestBuilder extends JsonRequestBuilder implements Builder {
   private final UUID temporaryLocationId;
   private final UUID permanentLoanTypeId;
   private final UUID temporaryLoanTypeId;
+  private final String itemLevelCallNumberTypeId;
 
   public ItemRequestBuilder() {
     this(UUID.randomUUID(), null, "565578437802", AVAILABLE_STATUS,
-      null, null, null, null);
+      null, null, null, null, null);
   }
 
   private ItemRequestBuilder(
@@ -31,7 +32,8 @@ public class ItemRequestBuilder extends JsonRequestBuilder implements Builder {
     UUID temporaryLocationId,
     UUID materialTypeId,
     UUID permanentLoanTypeId,
-    UUID temporaryLoanTypeId) {
+    UUID temporaryLoanTypeId,
+    String itemLevelCallNumberTypeId) {
 
     this.id = id;
     this.holdingId = holdingId;
@@ -41,6 +43,7 @@ public class ItemRequestBuilder extends JsonRequestBuilder implements Builder {
     this.materialTypeId = materialTypeId;
     this.permanentLoanTypeId = permanentLoanTypeId;
     this.temporaryLoanTypeId = temporaryLoanTypeId;
+    this.itemLevelCallNumberTypeId = itemLevelCallNumberTypeId;
   }
 
   public JsonObject create() {
@@ -59,6 +62,7 @@ public class ItemRequestBuilder extends JsonRequestBuilder implements Builder {
     put(itemRequest, "temporaryLoanTypeId", temporaryLoanTypeId);
 
     put(itemRequest, "temporaryLocationId", temporaryLocationId);
+    put(itemRequest, "itemLevelCallNumberTypeId", itemLevelCallNumberTypeId);
 
     return itemRequest;
   }
@@ -80,7 +84,8 @@ public class ItemRequestBuilder extends JsonRequestBuilder implements Builder {
       this.temporaryLocationId,
       this.materialTypeId,
       this.permanentLoanTypeId,
-      this.temporaryLoanTypeId);
+      this.temporaryLoanTypeId,
+      this.itemLevelCallNumberTypeId);
   }
 
   public ItemRequestBuilder withBarcode(String barcode) {
@@ -92,7 +97,8 @@ public class ItemRequestBuilder extends JsonRequestBuilder implements Builder {
       this.temporaryLocationId,
       this.materialTypeId,
       this.permanentLoanTypeId,
-      this.temporaryLoanTypeId);
+      this.temporaryLoanTypeId,
+      this.itemLevelCallNumberTypeId);
   }
 
   public ItemRequestBuilder withNoBarcode() {
@@ -112,7 +118,8 @@ public class ItemRequestBuilder extends JsonRequestBuilder implements Builder {
       temporaryLocationId,
       this.materialTypeId,
       this.permanentLoanTypeId,
-      this.temporaryLoanTypeId);
+      this.temporaryLoanTypeId,
+      this.itemLevelCallNumberTypeId);
   }
 
   public ItemRequestBuilder forHolding(UUID holdingId) {
@@ -124,7 +131,8 @@ public class ItemRequestBuilder extends JsonRequestBuilder implements Builder {
       this.temporaryLocationId,
       this.materialTypeId,
       this.permanentLoanTypeId,
-      this.temporaryLoanTypeId);
+      this.temporaryLoanTypeId,
+      this.itemLevelCallNumberTypeId);
   }
 
   public ItemRequestBuilder withMaterialType(UUID materialTypeId) {
@@ -136,7 +144,8 @@ public class ItemRequestBuilder extends JsonRequestBuilder implements Builder {
       this.temporaryLocationId,
       materialTypeId,
       this.permanentLoanTypeId,
-      this.temporaryLoanTypeId);
+      this.temporaryLoanTypeId,
+      this.itemLevelCallNumberTypeId);
   }
 
   public ItemRequestBuilder withTemporaryLoanType(UUID loanTypeId) {
@@ -148,7 +157,8 @@ public class ItemRequestBuilder extends JsonRequestBuilder implements Builder {
       this.temporaryLocationId,
       this.materialTypeId,
       this.permanentLoanTypeId,
-      loanTypeId);
+      loanTypeId,
+      this.itemLevelCallNumberTypeId);
   }
 
   public ItemRequestBuilder withPermanentLoanType(UUID loanTypeId) {
@@ -160,6 +170,20 @@ public class ItemRequestBuilder extends JsonRequestBuilder implements Builder {
       this.temporaryLocationId,
       this.materialTypeId,
       loanTypeId,
-      this.temporaryLoanTypeId);
+      this.temporaryLoanTypeId,
+      this.itemLevelCallNumberTypeId);
+  }
+
+  public ItemRequestBuilder withItemLevelCallNumberTypeId(String itemLevelCallNumberTypeId) {
+    return new ItemRequestBuilder(
+      this.id,
+      this.holdingId,
+      this.barcode,
+      this.status,
+      this.temporaryLocationId,
+      this.materialTypeId,
+      this.permanentLoanTypeId,
+      this.temporaryLoanTypeId,
+      itemLevelCallNumberTypeId);
   }
 }

--- a/src/test/java/org/folio/rest/support/http/ResourceClient.java
+++ b/src/test/java/org/folio/rest/support/http/ResourceClient.java
@@ -65,6 +65,11 @@ public class ResourceClient {
       "instance types", "instanceTypes");
   }
 
+  public static ResourceClient forCallNumberTypes(HttpClient client) {
+    return new ResourceClient(client, InterfaceUrls::callNumberTypesUrl,
+      "call number types", "callNumberTypes");
+  }
+
   private ResourceClient(
     HttpClient client,
     UrlMaker urlMaker, String resourceName,

--- a/src/test/java/org/folio/rest/support/http/ResourceClient.java
+++ b/src/test/java/org/folio/rest/support/http/ResourceClient.java
@@ -188,8 +188,7 @@ public class ResourceClient {
 
     assertThat(String.format(
       "Failed to delete %s %s: %s", resourceName, id, response.getBody()),
-      response.getStatusCode(),
-      is(204));
+      response.getStatusCode(), is(204));
   }
 
   public void deleteAll()

--- a/src/test/java/org/folio/rest/support/http/ResourceClient.java
+++ b/src/test/java/org/folio/rest/support/http/ResourceClient.java
@@ -1,9 +1,7 @@
 package org.folio.rest.support.http;
 
-import io.vertx.core.json.JsonObject;
-import org.folio.rest.api.StorageTestSuite;
-import org.folio.rest.support.*;
-import org.folio.rest.support.builders.Builder;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.junit.MatcherAssert.assertThat;
 
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -15,8 +13,15 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import static org.hamcrest.core.Is.is;
-import static org.hamcrest.junit.MatcherAssert.assertThat;
+import org.folio.rest.api.StorageTestSuite;
+import org.folio.rest.support.HttpClient;
+import org.folio.rest.support.IndividualResource;
+import org.folio.rest.support.JsonArrayHelper;
+import org.folio.rest.support.Response;
+import org.folio.rest.support.ResponseHandler;
+import org.folio.rest.support.builders.Builder;
+
+import io.vertx.core.json.JsonObject;
 
 public class ResourceClient {
 
@@ -165,22 +170,26 @@ public class ResourceClient {
     return getCompleted.get(5, TimeUnit.SECONDS);
   }
 
-  public void delete(UUID id)
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+  public Response deleteIfPresent(String id) throws MalformedURLException,
+    InterruptedException, ExecutionException, TimeoutException {
 
     CompletableFuture<Response> deleteFinished = new CompletableFuture<>();
 
     client.delete(urlMaker.combine(String.format("/%s", id)),
       StorageTestSuite.TENANT_ID, ResponseHandler.any(deleteFinished));
 
-    Response response = deleteFinished.get(5, TimeUnit.SECONDS);
+    return deleteFinished.get(5, TimeUnit.SECONDS);
+  }
+
+  public void delete(UUID id) throws MalformedURLException, InterruptedException,
+    ExecutionException, TimeoutException {
+
+    Response response = deleteIfPresent(id != null ? id.toString() : null);
 
     assertThat(String.format(
       "Failed to delete %s %s: %s", resourceName, id, response.getBody()),
-      response.getStatusCode(), is(204));
+      response.getStatusCode(),
+      is(204));
   }
 
   public void deleteAll()


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-361: Store effective call number type on item record

* Store effective call number type id on item record.
* Update migration script.
* Update API version.
* Refactor existing item call number related test cases and create parametrized tests instead.
