### PR TITLE
MODINVSTOR-405 weaken HRID error message checks

### DIFF
--- a/quick-test.sh
+++ b/quick-test.sh
@@ -6,6 +6,13 @@
 
 mvn -q clean org.jacoco:jacoco-maven-plugin:prepare-agent test -Dorg.folio.inventory.storage.test.database=external
 
+# Convert .xml reports into .html report, but without the CSS or images
+mvn surefire-report:report-only
+
+# Put the CSS and images where they need to be without the rest of the
+# time-consuming stuff
+mvn site -DgenerateReports=false
+
 test_results=$?
 
 if [ $test_results != 0 ]; then

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -49,6 +49,8 @@ import static org.folio.rest.support.ResponseHandler.text;
 import static org.folio.rest.support.http.InterfaceUrls.*;
 import static org.folio.rest.support.matchers.DateTimeMatchers.hasIsoFormat;
 import static org.folio.rest.support.matchers.DateTimeMatchers.withinSecondsBeforeNow;
+import static org.folio.rest.support.matchers.PostgresErrorMessageMatchers.isMaximumSequenceValueError;
+import static org.folio.rest.support.matchers.PostgresqlErrorMessageMatchers.isMaximumSequenceValueError;
 import static org.folio.util.StringUtil.urlEncode;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -1894,8 +1896,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final Response response = createCompleted.get(5, SECONDS);
 
     assertThat(response.getStatusCode(), is(500));
-    assertThat(response.getBody(),
-      PostgresErrorMessageMatchers.isMaximumSequenceValueError());
+    assertThat(response.getBody(), isMaximumSequenceValueError("hrid_instances_seq"));
 
     log.info("Finished cannotCreateInstanceWithHRIDFailure");
   }
@@ -2113,7 +2114,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final Response response = createCompleted.get(5, SECONDS);
 
     assertThat(response, statusCodeIs(HttpStatus.HTTP_INTERNAL_SERVER_ERROR));
-    assertThat(response.getBody(), PostgresErrorMessageMatchers.isMaximumSequenceValueError());
+    assertThat(response.getBody(), isMaximumSequenceValueError("hrid_instances_seq"));
 
     log.info("Finished cannotPostSynchronousBatchWithHRIDFailure");
   }
@@ -2287,7 +2288,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final InstancesBatchResponse ibr = response.getJson().mapTo(InstancesBatchResponse.class);
 
     assertThat(ibr.getErrorMessages(), notNullValue());
-    assertThat(ibr.getErrorMessages().get(0), PostgresErrorMessageMatchers.isMaximumSequenceValueError());
+    assertThat(ibr.getErrorMessages().get(0), isMaximumSequenceValueError("hrid_instances_seq"));
 
     log.info("Finished cannotCreateACollectionOfInstancesWithHRIDFailure");
   }

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -71,6 +71,8 @@ import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.builders.ItemRequestBuilder;
+import org.hamcrest.Matcher;
+import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -1915,7 +1917,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(response.getStatusCode(), is(500));
     assertThat(response.getBody(),
-        is("ErrorMessage(fields=[(Severity, ERROR), (V, ERROR), (SQLSTATE, 2200H), (Message, nextval: reached maximum value of sequence \"hrid_instances_seq\" (99999999)), (File, sequence.c), (Line, 700), (Routine, nextval_internal)])"));
+      isMaximumSequenceValueError());
 
     log.info("Finished cannotCreateInstanceWithHRIDFailure");
   }
@@ -2133,7 +2135,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final Response response = createCompleted.get(5, SECONDS);
 
     assertThat(response, statusCodeIs(HttpStatus.HTTP_INTERNAL_SERVER_ERROR));
-    assertThat(response.getBody(), is("ErrorMessage(fields=[(Severity, ERROR), (V, ERROR), (SQLSTATE, 2200H), (Message, nextval: reached maximum value of sequence \"hrid_instances_seq\" (99999999)), (File, sequence.c), (Line, 700), (Routine, nextval_internal)])"));
+    assertThat(response.getBody(), isMaximumSequenceValueError());
 
     log.info("Finished cannotPostSynchronousBatchWithHRIDFailure");
   }
@@ -2307,7 +2309,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final InstancesBatchResponse ibr = response.getJson().mapTo(InstancesBatchResponse.class);
 
     assertThat(ibr.getErrorMessages(), notNullValue());
-    assertThat(ibr.getErrorMessages().get(0), is("ErrorMessage(fields=[(Severity, ERROR), (V, ERROR), (SQLSTATE, 2200H), (Message, nextval: reached maximum value of sequence \"hrid_instances_seq\" (99999999)), (File, sequence.c), (Line, 700), (Routine, nextval_internal)])"));
+    assertThat(ibr.getErrorMessages().get(0), isMaximumSequenceValueError());
 
     log.info("Finished cannotCreateACollectionOfInstancesWithHRIDFailure");
   }
@@ -2495,5 +2497,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     natureOfContentIdsToRemoveAfterTest.add(natureOfContentTerm.getId());
     return response.getJson().mapTo(NatureOfContentTerm.class);
+  }
+
+  @NotNull
+  private Matcher<String> isMaximumSequenceValueError() {
+    return is("ErrorMessage(fields=[(Severity, ERROR), (V, ERROR), (SQLSTATE, 2200H), (Message, nextval: reached maximum value of sequence \"hrid_instances_seq\" (99999999)), (File, sequence.c), (Line, 700), (Routine, nextval_internal)])");
   }
 }

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -18,8 +18,7 @@ import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.*;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.builders.ItemRequestBuilder;
-import org.hamcrest.Matcher;
-import org.jetbrains.annotations.NotNull;
+import org.folio.rest.support.matchers.PostgresErrorMessageMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -1896,7 +1895,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(response.getStatusCode(), is(500));
     assertThat(response.getBody(),
-      isMaximumSequenceValueError());
+      PostgresErrorMessageMatchers.isMaximumSequenceValueError());
 
     log.info("Finished cannotCreateInstanceWithHRIDFailure");
   }
@@ -2114,7 +2113,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final Response response = createCompleted.get(5, SECONDS);
 
     assertThat(response, statusCodeIs(HttpStatus.HTTP_INTERNAL_SERVER_ERROR));
-    assertThat(response.getBody(), isMaximumSequenceValueError());
+    assertThat(response.getBody(), PostgresErrorMessageMatchers.isMaximumSequenceValueError());
 
     log.info("Finished cannotPostSynchronousBatchWithHRIDFailure");
   }
@@ -2288,7 +2287,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final InstancesBatchResponse ibr = response.getJson().mapTo(InstancesBatchResponse.class);
 
     assertThat(ibr.getErrorMessages(), notNullValue());
-    assertThat(ibr.getErrorMessages().get(0), isMaximumSequenceValueError());
+    assertThat(ibr.getErrorMessages().get(0), PostgresErrorMessageMatchers.isMaximumSequenceValueError());
 
     log.info("Finished cannotCreateACollectionOfInstancesWithHRIDFailure");
   }
@@ -2476,12 +2475,5 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     natureOfContentIdsToRemoveAfterTest.add(natureOfContentTerm.getId());
     return response.getJson().mapTo(NatureOfContentTerm.class);
-  }
-
-  @NotNull
-  private Matcher<String> isMaximumSequenceValueError() {
-    return containsString(
-      "ErrorMessage(fields=[(Severity, ERROR), (V, ERROR), (SQLSTATE, 2200H), " +
-        "(Message, nextval: reached maximum value of sequence \"hrid_instances_seq\"");
   }
 }

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -19,6 +19,7 @@ import static org.folio.rest.support.http.InterfaceUrls.itemsStorageSyncUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
 import static org.folio.rest.support.matchers.DateTimeMatchers.hasIsoFormat;
 import static org.folio.rest.support.matchers.DateTimeMatchers.withinSecondsBeforeNow;
+import static org.folio.rest.support.matchers.PostgresqlErrorMessageMatchers.isMaximumSequenceValueError;
 import static org.folio.util.StringUtil.urlEncode;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
@@ -63,6 +64,7 @@ import org.folio.rest.support.JsonArrayHelper;
 import org.folio.rest.support.JsonErrorResponse;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
+import org.folio.rest.support.matchers.PostgresqlErrorMessageMatchers;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -1070,8 +1072,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     final Response postResponse = createCompleted.get(5, TimeUnit.SECONDS);
 
     assertThat(postResponse.getStatusCode(), is(HTTP_INTERNAL_ERROR));
-    assertThat(postResponse.getBody(),
-        is("ErrorMessage(fields=[(Severity, ERROR), (V, ERROR), (SQLSTATE, 2200H), (Message, nextval: reached maximum value of sequence \"hrid_items_seq\" (99999999)), (File, sequence.c), (Line, 700), (Routine, nextval_internal)])"));
+    assertThat(postResponse.getBody(), isMaximumSequenceValueError("hrid_items_seq"));
 
     log.info("Finished cannotCreateAnItemWithHRIDFailure");
   }
@@ -1432,8 +1433,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     final Response response = postSynchronousBatch(itemArray);
 
     assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_INTERNAL_ERROR));
-    assertThat(response.getBody(),
-        is("ErrorMessage(fields=[(Severity, ERROR), (V, ERROR), (SQLSTATE, 2200H), (Message, nextval: reached maximum value of sequence \"hrid_items_seq\" (99999999)), (File, sequence.c), (Line, 700), (Routine, nextval_internal)])"));
+    assertThat(response.getBody(), isMaximumSequenceValueError("hrid_items_seq"));
 
     for (int i = 0; i < itemArray.size(); i++) {
       assertGetNotFound(itemsStorageUrl("/" + itemArray.getJsonObject(i).getString("id")));

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -1,16 +1,12 @@
 package org.folio.rest.api;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
-
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.Locale;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
+import io.vertx.core.DeploymentOptions;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.sql.ResultSet;
+import io.vertx.ext.sql.UpdateResult;
 import org.folio.rest.RestVerticle;
 import org.folio.rest.impl.StorageHelperTest;
 import org.folio.rest.persist.PostgresClient;
@@ -25,13 +21,16 @@ import org.junit.BeforeClass;
 import org.junit.runner.RunWith;
 import org.junit.runners.Suite;
 
-import io.vertx.core.DeploymentOptions;
-import io.vertx.core.Promise;
-import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.ext.sql.ResultSet;
-import io.vertx.ext.sql.UpdateResult;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Locale;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 @RunWith(Suite.class)
 
@@ -251,8 +250,7 @@ public class StorageTestSuite {
   static void prepareTenant(String tenantId, String moduleFrom, String moduleTo, boolean loadSample)
     throws InterruptedException,
     ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+    TimeoutException {
 
     CompletableFuture<Response> tenantPrepared = new CompletableFuture<>();
 
@@ -272,7 +270,7 @@ public class StorageTestSuite {
     client.post(storageUrl("/_/tenant"), jo, tenantId,
       ResponseHandler.any(tenantPrepared));
 
-    Response response = tenantPrepared.get(30, TimeUnit.SECONDS);
+    Response response = tenantPrepared.get(60, TimeUnit.SECONDS);
 
     String failureMessage = String.format("Tenant init failed: %s: %s",
       response.getStatusCode(), response.getBody());

--- a/src/test/java/org/folio/rest/support/matchers/PostgresErrorMessageMatchers.java
+++ b/src/test/java/org/folio/rest/support/matchers/PostgresErrorMessageMatchers.java
@@ -1,0 +1,17 @@
+package org.folio.rest.support.matchers;
+
+import org.hamcrest.Matcher;
+import org.jetbrains.annotations.NotNull;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+public class PostgresErrorMessageMatchers {
+  private PostgresErrorMessageMatchers() { }
+
+  @NotNull
+  public static Matcher<String> isMaximumSequenceValueError() {
+    return containsString(
+      "ErrorMessage(fields=[(Severity, ERROR), (V, ERROR), (SQLSTATE, 2200H), " +
+        "(Message, nextval: reached maximum value of sequence \"hrid_instances_seq\"");
+  }
+}

--- a/src/test/java/org/folio/rest/support/matchers/PostgresErrorMessageMatchers.java
+++ b/src/test/java/org/folio/rest/support/matchers/PostgresErrorMessageMatchers.java
@@ -9,9 +9,10 @@ public class PostgresErrorMessageMatchers {
   private PostgresErrorMessageMatchers() { }
 
   @NotNull
-  public static Matcher<String> isMaximumSequenceValueError() {
+  public static Matcher<String> isMaximumSequenceValueError(final String sequenceName) {
     return containsString(
       "ErrorMessage(fields=[(Severity, ERROR), (V, ERROR), (SQLSTATE, 2200H), " +
-        "(Message, nextval: reached maximum value of sequence \"hrid_instances_seq\"");
+        "(Message, nextval: reached maximum value of sequence \""
+        + sequenceName + "\"");
   }
 }


### PR DESCRIPTION
The error messages produced by PostgreSQL vary by version, meaning that the build could fail using a PostgreSQL server to the one used by embedded PostgreSQL.

This even occurs within the same major version (the line number reference differs).

This pull request weakens the check on the error message, to not include the line number or the maximum value of the sequence.