### PR TITLE
MODINVSTOR-410 increase number of digits for HRID

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -977,7 +977,7 @@
     },
     {
       "id": "hrid-settings-storage",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": ["GET"],

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,11 @@
     </dependency>
     <dependency>
       <groupId>org.folio</groupId>
+      <artifactId>util</artifactId>
+      <version>${raml-module-builder-version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
       <artifactId>testing</artifactId>
       <version>${raml-module-builder-version}</version>
       <scope>test</scope>

--- a/ramls/hrid-settings-storage.raml
+++ b/ramls/hrid-settings-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: HRID Settings Storage
-version: v1.0
+version: v1.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/hridsetting.json
+++ b/ramls/hridsetting.json
@@ -13,7 +13,7 @@
       "description": "The number from which to start generating HRIDs",
       "type": "integer",
       "minimum": 1,
-      "maximum": 99999999
+      "maximum": 99999999999
     }
   },
   "additionalProperties": false,

--- a/src/main/java/org/folio/rest/support/HridManager.java
+++ b/src/main/java/org/folio/rest/support/HridManager.java
@@ -152,10 +152,9 @@ public class HridManager {
     final Promise<ResultSet> promise = Promise.promise();
 
     // Only update the sequence if the start number has changed
-    if (existingHridSetting.getStartNumber().intValue() !=
-        hridSetting.getStartNumber().intValue()) {
+    if (!Objects.equals(existingHridSetting.getStartNumber(), hridSetting.getStartNumber())) {
       final String sql = String.format("select setval('hrid_%s_seq',%d,FALSE)",
-          field, hridSetting.getStartNumber().intValue());
+          field, hridSetting.getStartNumber());
       try {
         postgresClient.select(conn, sql, promise);
       } catch (Exception e) {
@@ -193,7 +192,7 @@ public class HridManager {
     final String hridPrefix = hridSetting.getPrefix();
 
     return promise.future()
-        .map(sequence -> String.format("%s%08d", Objects.toString(hridPrefix, ""),
+        .map(sequence -> String.format("%s%011d", Objects.toString(hridPrefix, ""),
             sequence.getLong(0)));
   }
 

--- a/src/main/resources/templates/db_scripts/alterHridSequences.sql
+++ b/src/main/resources/templates/db_scripts/alterHridSequences.sql
@@ -1,10 +1,13 @@
 -- Increase the initial size of the HRID sequences
 
 ALTER SEQUENCE IF EXISTS ${myuniversity}_${mymodule}.hrid_instances_seq
-  AS BIGINT MAXVALUE 99999999999;
+  AS BIGINT MAXVALUE 99999999999
+  OWNED BY ${myuniversity}_${mymodule}.hrid_settings.jsonb;
 
 ALTER SEQUENCE IF EXISTS ${myuniversity}_${mymodule}.hrid_holdings_seq
-  AS BIGINT MAXVALUE 99999999999;
+  AS BIGINT MAXVALUE 99999999999
+  OWNED BY ${myuniversity}_${mymodule}.hrid_settings.jsonb;
 
 ALTER SEQUENCE IF EXISTS ${myuniversity}_${mymodule}.hrid_items_seq
-  AS BIGINT MAXVALUE 99999999999;
+  AS BIGINT MAXVALUE 99999999999
+  OWNED BY ${myuniversity}_${mymodule}.hrid_settings.jsonb;

--- a/src/main/resources/templates/db_scripts/alterHridSequences.sql
+++ b/src/main/resources/templates/db_scripts/alterHridSequences.sql
@@ -1,0 +1,10 @@
+-- Increase the initial size of the HRID sequences
+
+ALTER SEQUENCE IF EXISTS ${myuniversity}_${mymodule}.hrid_instances_seq
+  AS BIGINT MAXVALUE 99999999999;
+
+ALTER SEQUENCE IF EXISTS ${myuniversity}_${mymodule}.hrid_holdings_seq
+  AS BIGINT MAXVALUE 99999999999;
+
+ALTER SEQUENCE IF EXISTS ${myuniversity}_${mymodule}.hrid_items_seq
+  AS BIGINT MAXVALUE 99999999999;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -713,6 +713,11 @@
       "run": "after",
       "snippetPath": "updateItemStatusDate.sql",
       "fromModuleVersion": "17.1.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "alterHridSequences.sql",
+      "fromModuleVersion": "18.2.0"
     }
   ]
 }

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -94,7 +94,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(holding.getString("id"), is(holdingId.toString()));
     assertThat(holding.getString("instanceId"), is(instanceId.toString()));
     assertThat(holding.getString("permanentLocationId"), is(mainLibraryLocationId.toString()));
-    assertThat(holding.getString("hrid"), is("ho00000001"));
+    assertThat(holding.getString("hrid"), is("ho00000000001"));
 
     Response getResponse = holdingsClient.getById(holdingId);
 
@@ -105,7 +105,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(holdingFromGet.getString("id"), is(holdingId.toString()));
     assertThat(holdingFromGet.getString("instanceId"), is(instanceId.toString()));
     assertThat(holdingFromGet.getString("permanentLocationId"), is(mainLibraryLocationId.toString()));
-    assertThat(holdingFromGet.getString("hrid"), is("ho00000001"));
+    assertThat(holdingFromGet.getString("hrid"), is("ho00000000001"));
 
     List<String> tags = holdingFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
 
@@ -220,7 +220,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(holdingFromGet.getString("id"), is(holdingId.toString()));
     assertThat(holdingFromGet.getString("instanceId"), is(instanceId.toString()));
     assertThat(holdingFromGet.getString("permanentLocationId"), is(mainLibraryLocationId.toString()));
-    assertThat(holdingFromGet.getString("hrid"), is("ho00000001"));
+    assertThat(holdingFromGet.getString("hrid"), is("ho00000000001"));
 
     List<String> tags = holdingFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
 
@@ -292,7 +292,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(holdingFromGet.getString("id"), is(holdingId.toString()));
     assertThat(holdingFromGet.getString("instanceId"), is(instanceId.toString()));
     assertThat(holdingFromGet.getString("permanentLocationId"), is(annexLibraryLocationId.toString()));
-    assertThat(holdingFromGet.getString("hrid"), is("ho00000001"));
+    assertThat(holdingFromGet.getString("hrid"), is("ho00000000001"));
 
     List<String> tags = holdingFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
 
@@ -1460,7 +1460,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       .withPermanentLocation(mainLibraryLocationId)
       .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getJson();
 
-    assertThat(holdings.getString("hrid"), is("ho00000001"));
+    assertThat(holdings.getString("hrid"), is("ho00000000001"));
 
     final Response getResponse = holdingsClient.getById(holdingsId);
 
@@ -1468,14 +1468,14 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     final JsonObject holdingsFromGet = getResponse.getJson();
 
-    assertThat(holdingsFromGet.getString("hrid"), is("ho00000001"));
+    assertThat(holdingsFromGet.getString("hrid"), is("ho00000000001"));
 
     final JsonObject duplicateHoldings = new HoldingRequestBuilder()
         .withId(UUID.randomUUID())
         .forInstance(instanceId)
         .withPermanentLocation(mainLibraryLocationId)
         .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))
-        .withHrid("ho00000001")
+        .withHrid("ho00000000001")
         .create();
 
     final Response duplicateResponse = create(holdingsStorageUrl(""), duplicateHoldings);
@@ -1496,7 +1496,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(errors.getErrors().get(0).getParameters().get(0).getKey(),
         is("lower(f_unaccent(jsonb ->> 'hrid'::text"));
     assertThat(errors.getErrors().get(0).getParameters().get(0).getValue(),
-        is("ho00000001"));
+        is("ho00000000001"));
 
     log.info("Finished cannotCreateAHoldingsWhenDuplicateHRIDIsSupplied");
   }
@@ -1513,7 +1513,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     instancesClient.create(smallAngryPlanet(instanceId));
 
-    setHoldingsSequence(99999999);
+    setHoldingsSequence(99_999_999_999L);
 
     final JsonObject goodHholdings = holdingsClient.create(new HoldingRequestBuilder()
       .withId(UUID.randomUUID())
@@ -1521,7 +1521,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       .withPermanentLocation(mainLibraryLocationId)
       .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getJson();
 
-    assertThat(goodHholdings.getString("hrid"), is("ho99999999"));
+    assertThat(goodHholdings.getString("hrid"), is("ho99999999999"));
 
     final JsonObject badHoldings = new HoldingRequestBuilder()
       .withId(UUID.randomUUID())
@@ -1563,7 +1563,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       .withPermanentLocation(mainLibraryLocationId)
       .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getJson();
 
-    assertThat(holdings.getString("hrid"), is("ho00000001"));
+    assertThat(holdings.getString("hrid"), is("ho00000000001"));
 
     holdings.put("hrid", "ABC123");
 
@@ -1576,7 +1576,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
     assertThat(response.getBody(),
-        is("The hrid field cannot be changed: new=ABC123, old=ho00000001"));
+        is("The hrid field cannot be changed: new=ABC123, old=ho00000000001"));
 
     log.info("Finished cannotChangeHRIDAfterCreation");
   }
@@ -1602,7 +1602,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       .withPermanentLocation(mainLibraryLocationId)
       .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getJson();
 
-    assertThat(holdings.getString("hrid"), is("ho00000001"));
+    assertThat(holdings.getString("hrid"), is("ho00000000001"));
 
     holdings.remove("hrid");
 
@@ -1615,7 +1615,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
     assertThat(response.getBody(),
-        is("The hrid field cannot be changed: new=null, old=ho00000001"));
+        is("The hrid field cannot be changed: new=null, old=ho00000000001"));
 
     log.info("Finished cannotRemoveHRIDAfterCreation");
   }
@@ -1669,7 +1669,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
         .forEach(holdings -> {
           final Response response = getById(holdings.getString("id"));
           assertExists(response, holdings);
-          assertHRIDRange(response, "ho00000001", "ho00000003");
+          assertHRIDRange(response, "ho00000000001", "ho00000000003");
         });
 
     log.info("Finished canPostSynchronousBatchWithGeneratedHRID");
@@ -1690,7 +1690,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     Response response = getById(holdingsArray.getJsonObject(0).getString("id"));
     assertExists(response, holdingsArray.getJsonObject(0));
-    assertHRIDRange(response, "ho00000001", "ho00000002");
+    assertHRIDRange(response, "ho00000000001", "ho00000000002");
 
     response = getById(holdingsArray.getJsonObject(1).getString("id"));
     assertExists(response, holdingsArray.getJsonObject(1));
@@ -1698,7 +1698,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     response = getById(holdingsArray.getJsonObject(2).getString("id"));
     assertExists(response, holdingsArray.getJsonObject(2));
-    assertHRIDRange(response, "ho00000001", "ho00000002");
+    assertHRIDRange(response, "ho00000000001", "ho00000000002");
 
     log.info("Finished canPostSynchronousBatchWithSuppliedAndGeneratedHRID");
   }
@@ -1710,7 +1710,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     setHoldingsSequence(1);
 
     final JsonArray holdingsArray = threeHoldings();
-    final String duplicateHRID = "ho00000001";
+    final String duplicateHRID = "ho00000000001";
     holdingsArray.getJsonObject(1).put("hrid", duplicateHRID);
 
     assertThat(postSynchronousBatch(holdingsArray), allOf(
@@ -1729,7 +1729,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   public void cannotPostSynchronousBatchWithHRIDFailure() {
     log.info("Starting cannotPostSynchronousBatchWithHRIDFailure");
 
-    setHoldingsSequence(99999999);
+    setHoldingsSequence(99999999999L);
 
     final JsonArray holdingsArray = threeHoldings();
 
@@ -1745,7 +1745,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     log.info("Finished cannotPostSynchronousBatchWithHRIDFailure");
   }
 
-  private void setHoldingsSequence(int sequenceNumber) {
+  private void setHoldingsSequence(long sequenceNumber) {
     final Vertx vertx = StorageTestSuite.getVertx();
     final PostgresClient postgresClient =
         PostgresClient.getInstance(vertx, TENANT_ID);

--- a/src/test/java/org/folio/rest/api/HridSettingsIncreaseMaxValueMigrationTest.java
+++ b/src/test/java/org/folio/rest/api/HridSettingsIncreaseMaxValueMigrationTest.java
@@ -46,13 +46,13 @@ public class HridSettingsIncreaseMaxValueMigrationTest extends TestBase {
     executeSql(dropSequenceSql(HOLDINGS_SEQ));
     executeSql(dropSequenceSql(ITEMS_SEQ));
 
-    executeSqlFile(CREATE_SEQUENCE_SQL);
+    executeMultipleSqlStatements(CREATE_SEQUENCE_SQL);
   }
 
   private void alterSequences() throws InterruptedException, ExecutionException,
     TimeoutException {
 
-    executeSqlFile(ALTER_SEQUENCE_SQL);
+    executeMultipleSqlStatements(ALTER_SEQUENCE_SQL);
   }
 
   private Long incrementSequence(String sequenceName)

--- a/src/test/java/org/folio/rest/api/HridSettingsIncreaseMaxValueMigrationTest.java
+++ b/src/test/java/org/folio/rest/api/HridSettingsIncreaseMaxValueMigrationTest.java
@@ -2,22 +2,21 @@ package org.folio.rest.api;
 
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.folio.rest.api.StorageTestSuite.getVertx;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.folio.rest.persist.PostgresClient;
 import org.folio.util.ResourceUtil;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
-import io.vertx.ext.unit.TestContext;
-import io.vertx.ext.unit.junit.VertxUnitRunner;
 
-@RunWith(VertxUnitRunner.class)
 public class HridSettingsIncreaseMaxValueMigrationTest extends TestBase {
   private static final String CREATE_SEQUENCE_SQL = loadCreateSequenceSqlFile();
   private static final String ALTER_SEQUENCE_SQL = loadAlterSequenceSqlFile();
@@ -26,94 +25,76 @@ public class HridSettingsIncreaseMaxValueMigrationTest extends TestBase {
   private static final String ITEMS_SEQ = "hrid_items_seq";
 
   @Test
-  public void retainsCurrentValueOfSequences(TestContext testContext) {
-    reCreateSequences()
-      // Increment sequences and and set a new value
-      .compose(notUsed -> incrementSequence(INSTANCES_SEQ, 10))
-      .map(hrid -> testContext.assertEquals(10L, hrid))
-      .compose(notUsed -> incrementSequence(HOLDINGS_SEQ, 7))
-      .map(hrid -> testContext.assertEquals(7L, hrid))
-      .compose(notUsed -> setValue(ITEMS_SEQ, 999_999_99L))
-      .compose(notUsed -> incrementSequence(ITEMS_SEQ))
-      .map(hrid -> testContext.assertEquals(999_999_99L, hrid))
-      // Alter sequences
-      .compose(notUsed -> alterSequences())
-      // Assert that current value has not been changed
-      .compose(notUsed -> incrementSequence(INSTANCES_SEQ))
-      .map(hrid -> testContext.assertEquals(11L, hrid))
-      .compose(notUsed -> incrementSequence(HOLDINGS_SEQ))
-      .map(hrid -> testContext.assertEquals(8L, hrid))
-      .compose(notUsed -> incrementSequence(ITEMS_SEQ))
-      .map(hrid -> testContext.assertEquals(1_000_000_00L, hrid))
-      // Handle test result
-      .setHandler(testContext.asyncAssertSuccess());
+  public void retainsCurrentValueOfSequences() throws Exception {
+    reCreateSequences();
+
+    assertThat(incrementSequence(INSTANCES_SEQ, 10), is(10L));
+    assertThat(incrementSequence(HOLDINGS_SEQ, 7), is(7L));
+
+    setValue(ITEMS_SEQ, 999_999_99L);
+    assertThat(incrementSequence(ITEMS_SEQ), is(999_999_99L));
+
+    alterSequences();
+
+    assertThat(incrementSequence(INSTANCES_SEQ), is(11L));
+    assertThat(incrementSequence(HOLDINGS_SEQ), is(8L));
+    assertThat(incrementSequence(ITEMS_SEQ), is(1_000_000_00L));
   }
 
-  @Test
-  public void canSetBigIntValue(TestContext testContext) {
-    reCreateSequences()
-      .compose(notUsed -> alterSequences())
-      // Set large values
-      .compose(notUsed -> setValue(INSTANCES_SEQ, 99_999_999_990L))
-      .compose(notUsed -> setValue(HOLDINGS_SEQ, 99_999_999_991L))
-      .compose(notUsed -> setValue(ITEMS_SEQ, 99_999_999_992L))
-      // Assert that the large values are set
-      .compose(notUsed -> incrementSequence(INSTANCES_SEQ))
-      .map(hrid -> testContext.assertEquals(99_999_999_990L, hrid))
-      .compose(notUsed -> incrementSequence(HOLDINGS_SEQ))
-      .map(hrid -> testContext.assertEquals(99_999_999_991L, hrid))
-      .compose(notUsed -> incrementSequence(ITEMS_SEQ))
-      .map(hrid -> testContext.assertEquals(99_999_999_992L, hrid))
-      // Handle test result
-      .setHandler(testContext.asyncAssertSuccess());
+  private void reCreateSequences() throws Exception {
+    executeSql(dropSequenceSql(INSTANCES_SEQ));
+    executeSql(dropSequenceSql(HOLDINGS_SEQ));
+    executeSql(dropSequenceSql(ITEMS_SEQ));
+
+    executeSqlFile(CREATE_SEQUENCE_SQL);
   }
 
-  private Future<Void> reCreateSequences() {
-    return CompositeFuture.all(
-      executeSql(dropSequenceSql(INSTANCES_SEQ)),
-      executeSql(dropSequenceSql(HOLDINGS_SEQ)),
-      executeSql(dropSequenceSql(ITEMS_SEQ))
-    ).compose(notUsed -> executeSqlFile(CREATE_SEQUENCE_SQL));
+  private void alterSequences() throws InterruptedException, ExecutionException,
+    TimeoutException {
+
+    executeSqlFile(ALTER_SEQUENCE_SQL);
   }
 
-  private Future<Void> alterSequences() {
-    return executeSqlFile(ALTER_SEQUENCE_SQL);
-  }
+  private Long incrementSequence(String sequenceName)
+    throws InterruptedException, ExecutionException, TimeoutException {
 
-  private Future<Long> incrementSequence(String sequenceName) {
-    final Promise<Long> nextValue = Promise.promise();
+    final CompletableFuture<Long> nextValue = new CompletableFuture<>();
     final String sql = String.format(
       "SELECT nextVal('%s.%s')", getSchemaName(), sequenceName
     );
 
     PostgresClient.getInstance(getVertx()).select(sql, result -> {
       if (result.failed()) {
-        nextValue.fail(result.cause());
+        nextValue.completeExceptionally(result.cause());
       } else {
         List<JsonArray> results = result.result().getResults();
         if (results.isEmpty()) {
-          nextValue.fail("Empty result set");
+          nextValue.completeExceptionally(new RuntimeException("Empty result set"));
         } else {
           nextValue.complete(results.get(0).getLong(0));
         }
       }
     });
 
-    return nextValue.future();
+    return nextValue.get(5, TimeUnit.SECONDS);
   }
 
-  private Future<Long> incrementSequence(String sequenceName, int times) {
-    Future<Long> last = Future.succeededFuture();
+  private Long incrementSequence(String sequenceName, int times)
+    throws InterruptedException, ExecutionException, TimeoutException {
+
+    Long last = null;
 
     for (int i = 0; i < times; i++) {
-      last = last.compose(prev -> incrementSequence(sequenceName));
+      last = incrementSequence(sequenceName);
     }
 
     return last;
   }
 
-  private Future<Void> setValue(String sequenceName, Long value) {
-    return executeSql(String.format(
+  private void setValue(String sequenceName, Long value)
+    throws InterruptedException, ExecutionException, TimeoutException {
+
+    executeSql(String.format(
       "SELECT setVal('%s.%s', %d, FALSE)", getSchemaName(), sequenceName, value
     ));
   }

--- a/src/test/java/org/folio/rest/api/HridSettingsIncreaseMaxValueMigrationTest.java
+++ b/src/test/java/org/folio/rest/api/HridSettingsIncreaseMaxValueMigrationTest.java
@@ -1,0 +1,139 @@
+package org.folio.rest.api;
+
+import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
+import static org.folio.rest.api.StorageTestSuite.getVertx;
+
+import java.util.List;
+
+import org.folio.rest.persist.PostgresClient;
+import org.folio.util.ResourceUtil;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+
+@RunWith(VertxUnitRunner.class)
+public class HridSettingsIncreaseMaxValueMigrationTest extends TestBase {
+  private static final String CREATE_SEQUENCE_SQL = loadCreateSequenceSqlFile();
+  private static final String ALTER_SEQUENCE_SQL = loadAlterSequenceSqlFile();
+  private static final String INSTANCES_SEQ = "hrid_instances_seq";
+  private static final String HOLDINGS_SEQ = "hrid_holdings_seq";
+  private static final String ITEMS_SEQ = "hrid_items_seq";
+
+  @Test
+  public void canSaveCurrentValueOfSequences(TestContext testContext) {
+    reCreateSequences()
+      // Increment sequences and and set a new value
+      .compose(notUsed -> incrementSequence(INSTANCES_SEQ, 10))
+      .map(hrid -> testContext.assertEquals(10L, hrid))
+      .compose(notUsed -> incrementSequence(HOLDINGS_SEQ, 7))
+      .map(hrid -> testContext.assertEquals(7L, hrid))
+      .compose(notUsed -> setValue(ITEMS_SEQ, 999_999_99L))
+      .compose(notUsed -> incrementSequence(ITEMS_SEQ))
+      .map(hrid -> testContext.assertEquals(999_999_99L, hrid))
+      // Alter sequences
+      .compose(notUsed -> alterSequences())
+      // Assert that current value has not been changed
+      .compose(notUsed -> incrementSequence(INSTANCES_SEQ))
+      .map(hrid -> testContext.assertEquals(11L, hrid))
+      .compose(notUsed -> incrementSequence(HOLDINGS_SEQ))
+      .map(hrid -> testContext.assertEquals(8L, hrid))
+      .compose(notUsed -> incrementSequence(ITEMS_SEQ))
+      .map(hrid -> testContext.assertEquals(1_000_000_00L, hrid))
+      // Handle test result
+      .setHandler(testContext.asyncAssertSuccess());
+  }
+
+  @Test
+  public void canSetBigIntValue(TestContext testContext) {
+    reCreateSequences()
+      .compose(notUsed -> alterSequences())
+      // Set large values
+      .compose(notUsed -> setValue(INSTANCES_SEQ, 99_999_999_990L))
+      .compose(notUsed -> setValue(HOLDINGS_SEQ, 99_999_999_991L))
+      .compose(notUsed -> setValue(ITEMS_SEQ, 99_999_999_992L))
+      // Assert that the large values are set
+      .compose(notUsed -> incrementSequence(INSTANCES_SEQ))
+      .map(hrid -> testContext.assertEquals(99_999_999_990L, hrid))
+      .compose(notUsed -> incrementSequence(HOLDINGS_SEQ))
+      .map(hrid -> testContext.assertEquals(99_999_999_991L, hrid))
+      .compose(notUsed -> incrementSequence(ITEMS_SEQ))
+      .map(hrid -> testContext.assertEquals(99_999_999_992L, hrid))
+      // Handle test result
+      .setHandler(testContext.asyncAssertSuccess());
+  }
+
+  private Future<Void> reCreateSequences() {
+    return CompositeFuture.all(
+      executeSql(dropSequenceSql(INSTANCES_SEQ)),
+      executeSql(dropSequenceSql(HOLDINGS_SEQ)),
+      executeSql(dropSequenceSql(ITEMS_SEQ))
+    ).compose(notUsed -> executeSqlFile(CREATE_SEQUENCE_SQL));
+  }
+
+  private Future<Void> alterSequences() {
+    return executeSqlFile(ALTER_SEQUENCE_SQL);
+  }
+
+  private Future<Long> incrementSequence(String sequenceName) {
+    final Promise<Long> nextValue = Promise.promise();
+    final String sql = String.format(
+      "SELECT nextVal('%s.%s')", getSchemaName(), sequenceName
+    );
+
+    PostgresClient.getInstance(getVertx()).select(sql, result -> {
+      if (result.failed()) {
+        nextValue.fail(result.cause());
+      } else {
+        List<JsonArray> results = result.result().getResults();
+        if (results.isEmpty()) {
+          nextValue.fail("Empty result set");
+        } else {
+          nextValue.complete(results.get(0).getLong(0));
+        }
+      }
+    });
+
+    return nextValue.future();
+  }
+
+  private Future<Long> incrementSequence(String sequenceName, int times) {
+    Future<Long> last = Future.succeededFuture();
+
+    for (int i = 0; i < times; i++) {
+      last = last.compose(prev -> incrementSequence(sequenceName));
+    }
+
+    return last;
+  }
+
+  private Future<Void> setValue(String sequenceName, Long value) {
+    return executeSql(String.format(
+      "SELECT setVal('%s.%s', %d, FALSE)", getSchemaName(), sequenceName, value
+    ));
+  }
+
+  private String dropSequenceSql(String sequenceName) {
+    return String.format("DROP SEQUENCE %s.%s", getSchemaName(), sequenceName);
+  }
+
+  private static String loadCreateSequenceSqlFile() {
+    return ResourceUtil.asString("/templates/db_scripts/hridSettings.sql")
+      .replace("${myuniversity}_${mymodule}", getSchemaName())
+      .replace("${table.tableName}", "hrid_settings");
+  }
+
+  private static String loadAlterSequenceSqlFile() {
+    return ResourceUtil.asString("/templates/db_scripts/alterHridSequences.sql")
+      .replace("${myuniversity}_${mymodule}", getSchemaName());
+  }
+
+  private static String getSchemaName() {
+    return String.format("%s_mod_inventory_storage", TENANT_ID);
+  }
+}

--- a/src/test/java/org/folio/rest/api/HridSettingsIncreaseMaxValueMigrationTest.java
+++ b/src/test/java/org/folio/rest/api/HridSettingsIncreaseMaxValueMigrationTest.java
@@ -26,7 +26,7 @@ public class HridSettingsIncreaseMaxValueMigrationTest extends TestBase {
   private static final String ITEMS_SEQ = "hrid_items_seq";
 
   @Test
-  public void canSaveCurrentValueOfSequences(TestContext testContext) {
+  public void retainsCurrentValueOfSequences(TestContext testContext) {
     reCreateSequences()
       // Increment sequences and and set a new value
       .compose(notUsed -> incrementSequence(INSTANCES_SEQ, 10))

--- a/src/test/java/org/folio/rest/api/HridSettingsStorageParameterizedTest.java
+++ b/src/test/java/org/folio/rest/api/HridSettingsStorageParameterizedTest.java
@@ -36,9 +36,9 @@ public class HridSettingsStorageParameterizedTest extends TestBase {
   @Parameters(name = "{index}: test validation failure {6}.{7} = {8}")
   public static Collection<Object[]> data() {
     return Arrays.asList(new Object[][] {
-      {"in", 999999999, "ho", 1, "it", 1, "instances", "startNumber", "999999999"},
-      {"in", 1, "ho", 999999999, "it", 1, "holdings", "startNumber", "999999999"},
-      {"in", 1, "ho", 1, "it", 999999999, "items", "startNumber", "999999999"},
+      {"in", 999_999_999_999L, "ho", 1, "it", 1, "instances", "startNumber", "999999999999"},
+      {"in", 1, "ho", 999_999_999_999L, "it", 1, "holdings", "startNumber", "999999999999"},
+      {"in", 1, "ho", 1, "it", 999_999_999_999L, "items", "startNumber", "999999999999"},
       {"in", 0, "ho", 1, "it", 1, "instances", "startNumber", "0"},
       {"in", 1, "ho", 0, "it", 1, "holdings", "startNumber", "0"},
       {"in", 1, "ho", 1, "it", 0, "items", "startNumber", "0"},
@@ -52,19 +52,19 @@ public class HridSettingsStorageParameterizedTest extends TestBase {
   }
 
   private final String instancePrefix;
-  private final int instanceStartNumber;
+  private final long instanceStartNumber;
   private final String holdingPrefix;
-  private final int holdingStartNumber;
+  private final long holdingStartNumber;
   private final String itemPrefix;
-  private final int itemStartNumber;
+  private final long itemStartNumber;
   private final String keyPart;
   private final String testField;
   private final String expectedValue;
 
   public HridSettingsStorageParameterizedTest(
-      String instancePrefix, int instanceStartNumber,
-      String holdingPrefix, int holdingStartNumber,
-      String itemPrefix, int itemStartNumber,
+      String instancePrefix, long instanceStartNumber,
+      String holdingPrefix, long holdingStartNumber,
+      String itemPrefix, long itemStartNumber,
       String keyPart, String testField, String expectedValue) {
     this.instancePrefix = instancePrefix;
     this.instanceStartNumber = instanceStartNumber;

--- a/src/test/java/org/folio/rest/api/HridSettingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HridSettingsStorageTest.java
@@ -16,6 +16,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
+import org.folio.rest.impl.StorageHelper;
 import org.folio.rest.jaxrs.model.HridSetting;
 import org.folio.rest.jaxrs.model.HridSettings;
 import org.folio.rest.persist.PostgresClient;
@@ -35,19 +36,18 @@ import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.unit.Async;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.folio.rest.impl.StorageHelper;
 
 @RunWith(VertxUnitRunner.class)
 public class HridSettingsStorageTest extends TestBase {
   private static final Logger log = LoggerFactory.getLogger(HridSettingsStorageTest.class);
 
   private final HridSettings initialHridSettings = new HridSettings()
-      .withInstances(new HridSetting().withPrefix("in").withStartNumber(1))
-      .withHoldings(new HridSetting().withPrefix("ho").withStartNumber(1))
-      .withItems(new HridSetting().withPrefix("it").withStartNumber(1));
+      .withInstances(new HridSetting().withPrefix("in").withStartNumber(1L))
+      .withHoldings(new HridSetting().withPrefix("ho").withStartNumber(1L))
+      .withItems(new HridSetting().withPrefix("it").withStartNumber(1L));
 
   @Before
-  public void setUp(TestContext testContext) throws Exception {
+  public void setUp(TestContext testContext) {
     log.info("Initializing values");
     final Async async = testContext.async();
     final Vertx vertx = StorageTestSuite.getVertx();
@@ -96,15 +96,15 @@ public class HridSettingsStorageTest extends TestBase {
 
     assertThat(actualHridSettings.getInstances(), is(notNullValue()));
     assertThat(actualHridSettings.getInstances().getPrefix(), is("in"));
-    assertThat(actualHridSettings.getInstances().getStartNumber(), is(1));
+    assertThat(actualHridSettings.getInstances().getStartNumber(), is(1L));
 
     assertThat(actualHridSettings.getHoldings(), is(notNullValue()));
     assertThat(actualHridSettings.getHoldings().getPrefix(), is("ho"));
-    assertThat(actualHridSettings.getHoldings().getStartNumber(), is(1));
+    assertThat(actualHridSettings.getHoldings().getStartNumber(), is(1L));
 
     assertThat(actualHridSettings.getItems(), is(notNullValue()));
     assertThat(actualHridSettings.getItems().getPrefix(), is("it"));
-    assertThat(actualHridSettings.getItems().getStartNumber(), is(1));
+    assertThat(actualHridSettings.getItems().getStartNumber(), is(1L));
 
     log.info("Finished canRetrieveHridSettings()");
   }
@@ -132,9 +132,9 @@ public class HridSettingsStorageTest extends TestBase {
     final CompletableFuture<Response> putCompleted = new CompletableFuture<>();
 
     final HridSettings newHridSettings = new HridSettings()
-        .withInstances(new HridSetting().withPrefix("inst").withStartNumber(100))
-        .withHoldings(new HridSetting().withPrefix("hold").withStartNumber(200))
-        .withItems(new HridSetting().withPrefix("item").withStartNumber(500));
+        .withInstances(new HridSetting().withPrefix("inst").withStartNumber(100L))
+        .withHoldings(new HridSetting().withPrefix("hold").withStartNumber(200L))
+        .withItems(new HridSetting().withPrefix("item").withStartNumber(500L));
 
     client.put(InterfaceUrls.hridSettingsStorageUrl(""), newHridSettings, TENANT_ID,
         empty(putCompleted));
@@ -180,9 +180,9 @@ public class HridSettingsStorageTest extends TestBase {
     final CompletableFuture<Response> putCompleted = new CompletableFuture<>();
 
     final HridSettings newHridSettings = new HridSettings()
-        .withInstances(new HridSetting().withPrefix("inst").withStartNumber(100))
-        .withHoldings(new HridSetting().withPrefix("hold").withStartNumber(200))
-        .withItems(new HridSetting().withPrefix("item").withStartNumber(500));
+        .withInstances(new HridSetting().withPrefix("inst").withStartNumber(100L))
+        .withHoldings(new HridSetting().withPrefix("hold").withStartNumber(200L))
+        .withItems(new HridSetting().withPrefix("item").withStartNumber(500L));
 
     client.put(InterfaceUrls.hridSettingsStorageUrl(""), newHridSettings, "BAD",
         text(putCompleted));
@@ -214,9 +214,9 @@ public class HridSettingsStorageTest extends TestBase {
 
     final HridSettings newHridSettings = new HridSettings()
         .withId(uuid)
-        .withInstances(new HridSetting().withPrefix("inst").withStartNumber(100))
-        .withHoldings(new HridSetting().withPrefix("hold").withStartNumber(200))
-        .withItems(new HridSetting().withPrefix("item").withStartNumber(500));
+        .withInstances(new HridSetting().withPrefix("inst").withStartNumber(100L))
+        .withHoldings(new HridSetting().withPrefix("hold").withStartNumber(200L))
+        .withItems(new HridSetting().withPrefix("item").withStartNumber(500L));
 
     final CompletableFuture<Response> putCompleted = new CompletableFuture<>();
 
@@ -261,8 +261,7 @@ public class HridSettingsStorageTest extends TestBase {
   }
 
   @Test
-  public void canGetNextInstanceHrid(TestContext testContext)
-      throws InterruptedException, ExecutionException, TimeoutException {
+  public void canGetNextInstanceHrid(TestContext testContext) {
     log.info("Starting canGetNextInstanceHrid()");
 
     final Vertx vertx = StorageTestSuite.getVertx();
@@ -271,14 +270,13 @@ public class HridSettingsStorageTest extends TestBase {
     final HridManager hridManager = new HridManager(vertx.getOrCreateContext(), postgresClient);
 
     hridManager.getNextInstanceHrid()
-      .compose(hrid -> validateHrid(hrid, "in00000001", testContext))
+      .compose(hrid -> validateHrid(hrid, "in00000000001", testContext))
       .setHandler(testContext.asyncAssertSuccess(
           v -> log.info("Finished canGetNextInstanceHrid()")));
   }
 
   @Test
-  public void canGetNextInstanceHridAfterSettingStartNumber(TestContext testContext)
-      throws InterruptedException, ExecutionException, TimeoutException {
+  public void canGetNextInstanceHridAfterSettingStartNumber(TestContext testContext) {
     log.info("Starting canGetNextInstanceHridAfterSettingStartNumber()");
 
     final Vertx vertx = StorageTestSuite.getVertx();
@@ -287,21 +285,20 @@ public class HridSettingsStorageTest extends TestBase {
     final HridManager hridManager = new HridManager(vertx.getOrCreateContext(), postgresClient);
 
     final HridSettings newHridSettings = new HridSettings()
-        .withInstances(new HridSetting().withPrefix("in").withStartNumber(250))
-        .withHoldings(new HridSetting().withPrefix("ho").withStartNumber(1))
-        .withItems(new HridSetting().withPrefix("it").withStartNumber(1));
+        .withInstances(new HridSetting().withPrefix("in").withStartNumber(250L))
+        .withHoldings(new HridSetting().withPrefix("ho").withStartNumber(1L))
+        .withItems(new HridSetting().withPrefix("it").withStartNumber(1L));
 
     hridManager.updateHridSettings(newHridSettings).setHandler(
         testContext.asyncAssertSuccess(
             hridSettingsResult -> hridManager.getNextInstanceHrid().compose(
-                hrid -> validateHrid(hrid, "in00000250", testContext))
+                hrid -> validateHrid(hrid, "in00000000250", testContext))
               .setHandler(testContext.asyncAssertSuccess(
                   v -> log.info("Finished canGetNextInstanceHridAfterSettingStartNumber()")))));
   }
 
   @Test
-  public void canGetNextHoldingHrid(TestContext testContext)
-      throws InterruptedException, ExecutionException, TimeoutException {
+  public void canGetNextHoldingHrid(TestContext testContext) {
     log.info("Starting canGetNextHoldingHrid()");
 
     final Vertx vertx = StorageTestSuite.getVertx();
@@ -310,14 +307,13 @@ public class HridSettingsStorageTest extends TestBase {
     final HridManager hridManager = new HridManager(vertx.getOrCreateContext(), postgresClient);
 
     hridManager.getNextHoldingsHrid()
-      .compose(hrid -> validateHrid(hrid, "ho00000001", testContext))
+      .compose(hrid -> validateHrid(hrid, "ho00000000001", testContext))
       .setHandler(testContext.asyncAssertSuccess(
           v -> log.info("Finished canGetNextHoldingHrid()")));
   }
 
   @Test
-  public void canGetNextHoldingHridAfterSettingStartNumber(TestContext testContext)
-      throws InterruptedException, ExecutionException, TimeoutException {
+  public void canGetNextHoldingHridAfterSettingStartNumber(TestContext testContext) {
     log.info("Starting canGetNextHoldingHridAfterSettingStartNumber()");
 
     final Vertx vertx = StorageTestSuite.getVertx();
@@ -326,21 +322,20 @@ public class HridSettingsStorageTest extends TestBase {
     final HridManager hridManager = new HridManager(vertx.getOrCreateContext(), postgresClient);
 
     final HridSettings newHridSettings = new HridSettings()
-        .withInstances(new HridSetting().withPrefix("in").withStartNumber(1))
-        .withHoldings(new HridSetting().withPrefix("ho").withStartNumber(7890))
-        .withItems(new HridSetting().withPrefix("it").withStartNumber(1));
+        .withInstances(new HridSetting().withPrefix("in").withStartNumber(1L))
+        .withHoldings(new HridSetting().withPrefix("ho").withStartNumber(7890L))
+        .withItems(new HridSetting().withPrefix("it").withStartNumber(1L));
 
     hridManager.updateHridSettings(newHridSettings).setHandler(
         testContext.asyncAssertSuccess(
             hridSettings -> hridManager.getNextHoldingsHrid().compose(
-                hrid -> validateHrid(hrid, "ho00007890", testContext))
+                hrid -> validateHrid(hrid, "ho00000007890", testContext))
               .setHandler(testContext.asyncAssertSuccess(
                   v -> log.info("Finished canGetNextHoldingHridAfterSettingStartNumber()")))));
   }
 
   @Test
-  public void canGetNextItemHrid(TestContext testContext)
-      throws InterruptedException, ExecutionException, TimeoutException {
+  public void canGetNextItemHrid(TestContext testContext) {
     log.info("Starting canGetNextItemHrid()");
 
     final Vertx vertx = StorageTestSuite.getVertx();
@@ -349,13 +344,12 @@ public class HridSettingsStorageTest extends TestBase {
     final HridManager hridManager = new HridManager(vertx.getOrCreateContext(), postgresClient);
 
     hridManager.getNextItemHrid()
-      .compose(hrid -> validateHrid(hrid, "it00000001", testContext))
+      .compose(hrid -> validateHrid(hrid, "it00000000001", testContext))
       .setHandler(testContext.asyncAssertSuccess(v -> log.info("Finished canGetNextItemHrid()")));
   }
 
   @Test
-  public void canGetNextItemHridAfterSettingStartNumber(TestContext testContext)
-      throws InterruptedException, ExecutionException, TimeoutException {
+  public void canGetNextItemHridAfterSettingStartNumber(TestContext testContext) {
     log.info("Starting canGetNextItemHridAfterSettingStartNumber()");
 
     final Vertx vertx = StorageTestSuite.getVertx();
@@ -364,21 +358,20 @@ public class HridSettingsStorageTest extends TestBase {
     final HridManager hridManager = new HridManager(vertx.getOrCreateContext(), postgresClient);
 
     final HridSettings newHridSettings = new HridSettings()
-        .withInstances(new HridSetting().withPrefix("in").withStartNumber(1))
-        .withHoldings(new HridSetting().withPrefix("ho").withStartNumber(1))
-        .withItems(new HridSetting().withPrefix("it").withStartNumber(87654321));
+        .withInstances(new HridSetting().withPrefix("in").withStartNumber(1L))
+        .withHoldings(new HridSetting().withPrefix("ho").withStartNumber(1L))
+        .withItems(new HridSetting().withPrefix("it").withStartNumber(87654321L));
 
     hridManager.updateHridSettings(newHridSettings).setHandler(
         testContext.asyncAssertSuccess(
             hridSettings -> hridManager.getNextItemHrid().compose(
-                hrid -> validateHrid(hrid, "it87654321", testContext))
+                hrid -> validateHrid(hrid, "it00087654321", testContext))
               .setHandler(testContext.asyncAssertSuccess(
                   v -> log.info("Finished canGetNextItemHridAfterSettingStartNumber()")))));
   }
 
   @Test
-  public void canGetNextItemHridMultipleTimes(TestContext testContext)
-      throws InterruptedException, ExecutionException, TimeoutException {
+  public void canGetNextItemHridMultipleTimes(TestContext testContext) {
     log.info("Starting canGetNextItemHridMultipleTimes()");
 
     final Vertx vertx = StorageTestSuite.getVertx();
@@ -386,22 +379,21 @@ public class HridSettingsStorageTest extends TestBase {
 
     final HridManager hridManager = new HridManager(vertx.getOrCreateContext(), postgresClient);
 
-    hridManager.getNextItemHrid().compose(hrid -> validateHrid(hrid, "it00000001", testContext))
+    hridManager.getNextItemHrid().compose(hrid -> validateHrid(hrid, "it00000000001", testContext))
       .compose(v -> hridManager.getNextItemHrid())
-      .compose(hrid -> validateHrid(hrid, "it00000002", testContext))
+      .compose(hrid -> validateHrid(hrid, "it00000000002", testContext))
       .compose(v -> hridManager.getNextItemHrid())
-      .compose(hrid -> validateHrid(hrid, "it00000003", testContext))
+      .compose(hrid -> validateHrid(hrid, "it00000000003", testContext))
       .compose(v -> hridManager.getNextItemHrid())
-      .compose(hrid -> validateHrid(hrid, "it00000004", testContext))
+      .compose(hrid -> validateHrid(hrid, "it00000000004", testContext))
       .compose(v -> hridManager.getNextItemHrid())
-      .compose(hrid -> validateHrid(hrid, "it00000005", testContext))
+      .compose(hrid -> validateHrid(hrid, "it00000000005", testContext))
       .setHandler(testContext.asyncAssertSuccess(
           v -> log.info("Finished canGetNextItemHridMultipleTimes()")));
   }
 
   @Test
-  public void canGetNextItemHridWithNoPrefix(TestContext testContext)
-      throws InterruptedException, ExecutionException, TimeoutException {
+  public void canGetNextItemHridWithNoPrefix(TestContext testContext) {
     log.info("Starting canGetNextItemHridWithNoPrefix()");
 
     final Vertx vertx = StorageTestSuite.getVertx();
@@ -410,21 +402,20 @@ public class HridSettingsStorageTest extends TestBase {
     final HridManager hridManager = new HridManager(vertx.getOrCreateContext(), postgresClient);
 
     final HridSettings newHridSettings = new HridSettings()
-        .withInstances(new HridSetting().withStartNumber(100))
-        .withHoldings(new HridSetting().withStartNumber(200))
-        .withItems(new HridSetting().withStartNumber(300));
+        .withInstances(new HridSetting().withStartNumber(100L))
+        .withHoldings(new HridSetting().withStartNumber(200L))
+        .withItems(new HridSetting().withStartNumber(300L));
 
     hridManager.updateHridSettings(newHridSettings)
       .setHandler(testContext.asyncAssertSuccess(
           hridSettings -> hridManager.getNextItemHrid().compose(
-              hrid -> validateHrid(hrid, "00000300", testContext))
+              hrid -> validateHrid(hrid, "00000000300", testContext))
             .setHandler(testContext.asyncAssertSuccess(
               v -> log.info("Finished canGetNextItemHridWithNoPrefix()")))));
   }
 
   @Test
-  public void canRollbackFailedTransaction(TestContext testContext)
-      throws InterruptedException, ExecutionException, TimeoutException {
+  public void canRollbackFailedTransaction(TestContext testContext) {
     log.info("Starting canRollbackFailedTransaction()");
 
     final Vertx vertx = StorageTestSuite.getVertx();
@@ -433,9 +424,9 @@ public class HridSettingsStorageTest extends TestBase {
     final HridManager hridManager = new HridManager(vertx.getOrCreateContext(), postgresClient);
 
     final HridSettings newHridSettings = new HridSettings()
-        .withInstances(new HridSetting().withStartNumber(999999999))
-        .withHoldings(new HridSetting().withStartNumber(200))
-        .withItems(new HridSetting().withStartNumber(300));
+        .withInstances(new HridSetting().withStartNumber(999_999_999_999L))
+        .withHoldings(new HridSetting().withStartNumber(200L))
+        .withItems(new HridSetting().withStartNumber(300L));
 
     hridManager.getHridSettings()
         .compose(originalHridSettings -> {
@@ -465,6 +456,27 @@ public class HridSettingsStorageTest extends TestBase {
         })
         .setHandler(testContext.asyncAssertSuccess(
             v1 -> log.info("Finished canRollbackFailedTransaction()")));
+  }
+
+  @Test
+  public void canGetNextHridWhenStartNumberIsLong(TestContext testContext) {
+    final Vertx vertx = StorageTestSuite.getVertx();
+    final PostgresClient postgresClient = PostgresClient.getInstance(vertx, TENANT_ID);
+
+    final HridManager hridManager = new HridManager(vertx.getOrCreateContext(), postgresClient);
+    final HridSettings newHridSettings = new HridSettings()
+      .withInstances(new HridSetting().withStartNumber(9_999_999_997L))
+      .withHoldings(new HridSetting().withStartNumber(9_999_999_998L))
+      .withItems(new HridSetting().withStartNumber(9_999_999_999L));
+
+    hridManager.updateHridSettings(newHridSettings)
+      .compose(v -> hridManager.getNextInstanceHrid())
+      .compose(hrid -> validateHrid(hrid, "09999999997", testContext))
+      .compose(v -> hridManager.getNextHoldingsHrid())
+      .compose(hrid -> validateHrid(hrid, "09999999998", testContext))
+      .compose(v -> hridManager.getNextItemHrid())
+      .compose(hrid -> validateHrid(hrid, "09999999999", testContext))
+      .setHandler(testContext.asyncAssertSuccess());
   }
 
   private Future<String> validateHrid(String hrid, String expectedValue, TestContext testContext) {

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -1812,7 +1812,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     final Response createdInstance = getById(id);
 
-    assertThat(createdInstance.getJson().getString("hrid"), is("in00000001"));
+    assertThat(createdInstance.getJson().getString("hrid"), is("in00000000001"));
 
     log.info("Finished canGenerateInstanceHRIDWhenNotSupplied");
   }
@@ -1849,10 +1849,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     final Response createdInstance = getById(id);
 
-    assertThat(createdInstance.getJson().getString("hrid"), is("in00000001"));
+    assertThat(createdInstance.getJson().getString("hrid"), is("in00000000001"));
 
     final JsonObject instanceToCreateWithSameHRID = nod(UUID.randomUUID());
-    instanceToCreateWithSameHRID.put("hrid", "in00000001");
+    instanceToCreateWithSameHRID.put("hrid", "in00000000001");
 
     final CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
@@ -1863,7 +1863,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(response.getStatusCode(), is(400));
     assertThat(response.getBody(),
-        is("duplicate key value violates unique constraint \"instance_hrid_idx_unique\": Key (lower(f_unaccent(jsonb ->> 'hrid'::text)))=(in00000001) already exists."));
+        is("duplicate key value violates unique constraint \"instance_hrid_idx_unique\": " +
+          "Key (lower(f_unaccent(jsonb ->> 'hrid'::text)))=(in00000000001) already exists."));
 
     log.info("Finished cannotCreateInstanceWithDuplicateHRID");
   }
@@ -1876,13 +1877,13 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final JsonObject instanceToCreate = smallAngryPlanet(id);
     instanceToCreate.remove("hrid");
 
-    setInstanceSequence(99999999);
+    setInstanceSequence(99_999_999_999L);
 
     createInstance(instanceToCreate);
 
     final Response createdInstance = getById(id);
 
-    assertThat(createdInstance.getJson().getString("hrid"), is("in99999999"));
+    assertThat(createdInstance.getJson().getString("hrid"), is("in99999999999"));
 
     final JsonObject instanceToFail = nod(UUID.randomUUID());
     instanceToFail.remove("hrid");
@@ -1912,7 +1913,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     createInstance(instanceToCreate);
 
     final JsonObject instance = getById(id).getJson();
-    final String expectedHRID = "in00000001";
+    final String expectedHRID = "in00000000001";
 
     assertThat(instance.getString("hrid"), is(expectedHRID));
 
@@ -1927,7 +1928,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(putResponse.getStatusCode(), is(400));
     assertThat(putResponse.getBody(),
-        is("The hrid field cannot be changed: new=testHRID, old=in00000001"));
+        is("The hrid field cannot be changed: new=testHRID, old=in00000000001"));
 
     log.info("Finished cannotChageHRIDAfterCreation");
   }
@@ -1945,7 +1946,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     createInstance(instanceToCreate);
 
     final JsonObject instance = getById(id).getJson();
-    final String expectedHRID = "in00000001";
+    final String expectedHRID = "in00000000001";
 
     assertThat(instance.getString("hrid"), is(expectedHRID));
 
@@ -1960,7 +1961,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(putResponse.getStatusCode(), is(400));
     assertThat(putResponse.getBody(),
-        is("The hrid field cannot be changed: new=null, old=in00000001"));
+        is("The hrid field cannot be changed: new=null, old=in00000000001"));
 
     log.info("Finished cannotRemoveHRIDAfterCreation");
   }
@@ -1992,8 +1993,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       final Response response = getById(instance.getString("id"));
       assertThat(response, statusCodeIs(HttpStatus.HTTP_OK));
       assertThat(response.getJson().getString("hrid"),
-          is(both(greaterThanOrEqualTo("in00000001"))
-              .and(lessThanOrEqualTo("in00001000"))));
+          is(both(greaterThanOrEqualTo("in00000000001"))
+              .and(lessThanOrEqualTo("in00000001000"))));
     }
 
     log.info("Finished canPostSynchronousBatchWithGeneratedHRID");
@@ -2028,7 +2029,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     JsonObject instance = instancesArray.getJsonObject(0);
     Response response = getById(instance.getString("id"));
 
-    assertThat(response.getJson().getString("hrid"), either(is("in00000001")).or(is("in00000002")));
+    assertThat(response.getJson().getString("hrid"),
+      either(is("in00000000001")).or(is("in00000000002")));
 
     for (int i = 2; i < numberOfInstances; i++) {
       instance = instancesArray.getJsonObject(i);
@@ -2041,7 +2043,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     instance = instancesArray.getJsonObject(1);
     response = getById(instance.getString("id"));
 
-    assertThat(response.getJson().getString("hrid"), either(is("in00000001")).or(is("in00000002")));
+    assertThat(response.getJson().getString("hrid"),
+      either(is("in00000000001")).or(is("in00000000002")));
 
     log.info("Finisted canPostSynchronousBatchWithExistingAndGeneratedHRID");
   }
@@ -2057,7 +2060,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     instancesArray.add(uprooted(uuids[0] = UUID.randomUUID()));
 
     final JsonObject t = temeraire(uuids[1] = UUID.randomUUID());
-    t.put("hrid", "in00000001");
+    t.put("hrid", "in00000000001");
     instancesArray.add(t);
 
     final JsonObject instanceCollection = new JsonObject().put(INSTANCES_KEY, instancesArray);
@@ -2083,7 +2086,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(errors.getErrors().get(0).getParameters().get(0).getKey(),
         is("lower(f_unaccent(jsonb ->> 'hrid'::text"));
     assertThat(errors.getErrors().get(0).getParameters().get(0).getValue(),
-        is("in00000001"));
+        is("in00000000001"));
 
     log.info("Finished cannotPostSynchronousBatchWithDuplicateHRIDs");
   }
@@ -2104,7 +2107,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     final JsonObject instanceCollection = new JsonObject().put(INSTANCES_KEY, instancesArray);
 
-    setInstanceSequence(99999999);
+    setInstanceSequence(99_999_999_999L);
 
     final CompletableFuture<Response> createCompleted = new CompletableFuture<>();
     client.post(instancesStorageSyncUrl(""), instanceCollection, TENANT_ID, text(createCompleted));
@@ -2162,8 +2165,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       final Response instanceResponse = getById(instance.getString("id"));
       assertThat(instanceResponse, statusCodeIs(HttpStatus.HTTP_OK));
       assertThat(instanceResponse.getJson().getString("hrid"),
-          is(both(greaterThanOrEqualTo("in00000001"))
-              .and(lessThanOrEqualTo("in00001000"))));
+          is(both(greaterThanOrEqualTo("in00000000001"))
+              .and(lessThanOrEqualTo("in00000001000"))));
     }
 
     log.info("Finished canCreateACollectionOfInstancesWithGeneratedHRIDs");
@@ -2201,7 +2204,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     JsonObject instance = instancesArray.getJsonObject(0);
     Response response = getById(instance.getString("id"));
 
-    assertThat(response.getJson().getString("hrid"), either(is("in00000001")).or(is("in00000002")));
+    assertThat(response.getJson().getString("hrid"),
+      either(is("in00000000001")).or(is("in00000000002")));
 
     for (int i = 2; i < numberOfInstances; i++) {
       instance = instancesArray.getJsonObject(i);
@@ -2214,7 +2218,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     instance = instancesArray.getJsonObject(1);
     response = getById(instance.getString("id"));
 
-    assertThat(response.getJson().getString("hrid"), either(is("in00000001")).or(is("in00000002")));
+    assertThat(response.getJson().getString("hrid"),
+      either(is("in00000000001")).or(is("in00000000002")));
 
     log.info("Finisted canCreateACollectionOfInstancesWithExistingAndGeneratedHRIDs");
   }
@@ -2230,7 +2235,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     instancesArray.add(uprooted(uuids[0] = UUID.randomUUID()));
 
     final JsonObject t = temeraire(uuids[1] = UUID.randomUUID());
-    t.put("hrid", "in00000001");
+    t.put("hrid", "in00000000001");
     instancesArray.add(t);
 
     final JsonObject instanceCollection = new JsonObject()
@@ -2250,7 +2255,12 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final InstancesBatchResponse ibr = response.getJson().mapTo(InstancesBatchResponse.class);
 
     assertThat(ibr.getErrorMessages(), notNullValue());
-    assertThat(ibr.getErrorMessages().get(0), is("ErrorMessage(fields=[(Severity, ERROR), (V, ERROR), (SQLSTATE, 23505), (Message, duplicate key value violates unique constraint \"instance_hrid_idx_unique\"), (Detail, Key (lower(f_unaccent(jsonb ->> 'hrid'::text)))=(in00000001) already exists.), (s, test_tenant_mod_inventory_storage), (t, instance), (n, instance_hrid_idx_unique), (File, nbtinsert.c), (Line, 434), (Routine, _bt_check_unique)])"));
+    assertThat(ibr.getErrorMessages().get(0), is(
+      "ErrorMessage(fields=[(Severity, ERROR), (V, ERROR), (SQLSTATE, 23505), " +
+        "(Message, duplicate key value violates unique constraint \"instance_hrid_idx_unique\"), " +
+        "(Detail, Key (lower(f_unaccent(jsonb ->> 'hrid'::text)))=(in00000000001) already exists.), " +
+        "(s, test_tenant_mod_inventory_storage), (t, instance), (n, instance_hrid_idx_unique), " +
+        "(File, nbtinsert.c), (Line, 434), (Routine, _bt_check_unique)])"));
 
     log.info("Finished cannotCreateACollectionOfInstancesWithDuplicatedHRIDs");
   }
@@ -2273,7 +2283,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
         .put(INSTANCES_KEY, instancesArray)
         .put(TOTAL_RECORDS_KEY, numberOfInstances);
 
-    setInstanceSequence(99999999);
+    setInstanceSequence(99_999_999_999L);
 
     final CompletableFuture<Response> createCompleted = new CompletableFuture<>();
     client.post(instancesStorageBatchInstancesUrl(StringUtils.EMPTY), instanceCollection, TENANT_ID,
@@ -2291,7 +2301,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     log.info("Finished cannotCreateACollectionOfInstancesWithHRIDFailure");
   }
 
-  private void setInstanceSequence(int sequenceNumber) {
+  private void setInstanceSequence(long sequenceNumber) {
     final Vertx vertx = StorageTestSuite.getVertx();
     final PostgresClient postgresClient =
         PostgresClient.getInstance(vertx, TENANT_ID);

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -130,7 +130,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
       is(annexLibraryLocationId.toString()));
     assertThat(itemFromPost.getString("inTransitDestinationServicePointId"),
         is(inTransitServicePointId));
-    assertThat(itemFromPost.getString("hrid"), is("it00000001"));
+    assertThat(itemFromPost.getString("hrid"), is("it00000000001"));
 
     Response getResponse = getById(id);
 
@@ -151,7 +151,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
       is(annexLibraryLocationId.toString()));
     assertThat(itemFromGet.getString("inTransitDestinationServicePointId"),
       is(inTransitServicePointId));
-    assertThat(itemFromGet.getString("hrid"), is("it00000001"));
+    assertThat(itemFromGet.getString("hrid"), is("it00000000001"));
 
     List<String> tags = itemFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
 
@@ -818,7 +818,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     final Response getResponse = getById(UUID.fromString(itemId));
 
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-    assertThat(getResponse.getJson().getString("hrid"), is("it00000001"));
+    assertThat(getResponse.getJson().getString("hrid"), is("it00000000001"));
 
     log.info("Finished canUpdateAnItemHRIDDoesNotChange");
   }
@@ -988,12 +988,12 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     final Response response = getById(itemToCreate.getString("id"));
 
     assertThat(response.getStatusCode(), is(HTTP_OK));
-    assertThat(response.getJson().getString("hrid"), is("it00000001"));
+    assertThat(response.getJson().getString("hrid"), is("it00000000001"));
 
     final CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
     itemToCreate.put("id", UUID.randomUUID().toString());
-    itemToCreate.put("hrid", "it00000001");
+    itemToCreate.put("hrid", "it00000000001");
 
     client.post(itemsStorageUrl(""), itemToCreate, StorageTestSuite.TENANT_ID,
         json(createCompleted));
@@ -1008,13 +1008,13 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(errors.getErrors(), notNullValue());
     assertThat(errors.getErrors().get(0), notNullValue());
     assertThat(errors.getErrors().get(0).getMessage(),
-        is("lower(f_unaccent(jsonb ->> 'hrid'::text)) value already exists in table item: it00000001"));
+        is("lower(f_unaccent(jsonb ->> 'hrid'::text)) value already exists in table item: it00000000001"));
     assertThat(errors.getErrors().get(0).getParameters(), notNullValue());
     assertThat(errors.getErrors().get(0).getParameters().get(0), notNullValue());
     assertThat(errors.getErrors().get(0).getParameters().get(0).getKey(),
         is("lower(f_unaccent(jsonb ->> 'hrid'::text))"));
     assertThat(errors.getErrors().get(0).getParameters().get(0).getValue(),
-        is("it00000001"));
+        is("it00000000001"));
 
     log.info("Finished cannotCreateAnItemWithDuplicateHRID");
   }
@@ -1033,14 +1033,14 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
         .put("permanentLoanTypeId", canCirculateLoanTypeID)
         .put("materialTypeId", journalMaterialTypeID);
 
-    setItemSequence(99999999);
+    setItemSequence(99_999_999_999L);
 
     createItem(itemToCreate);
 
     final Response response = getById(itemToCreate.getString("id"));
 
     assertThat(response.getStatusCode(), is(HTTP_OK));
-    assertThat(response.getJson().getString("hrid"), is("it99999999"));
+    assertThat(response.getJson().getString("hrid"), is("it99999999999"));
 
     final CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
@@ -1113,7 +1113,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
     assertThat(response.getBody(),
-        is("The hrid field cannot be changed: new=ABC123, old=it00000001"));
+        is("The hrid field cannot be changed: new=ABC123, old=it00000000001"));
 
     log.info("Finished cannotUpdateAnItemWithChangedHRID");
   }
@@ -1147,7 +1147,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
     assertThat(response.getBody(),
-        is("The hrid field cannot be changed: new=null, old=it00000001"));
+        is("The hrid field cannot be changed: new=null, old=it00000000001"));
 
     log.info("Finished cannotUpdateAnItemWithRemovedHRID");
   }
@@ -1346,7 +1346,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
         .forEach(item -> {
           final Response response = getById(item.getString("id"));
           assertExists(response, item);
-          assertHRIDRange(response, "it00000001", "it00000003");
+          assertHRIDRange(response, "it00000000001", "it00000000003");
         });
 
     log.info("Finished canPostSynchronousBatchWithGeneratedHRID");
@@ -1367,7 +1367,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     Response response = getById(itemsArray.getJsonObject(0).getString("id"));
     assertExists(response, itemsArray.getJsonObject(0));
-    assertHRIDRange(response, "it00000001", "it00000002");
+    assertHRIDRange(response, "it00000000001", "it00000000002");
 
     response = getById(itemsArray.getJsonObject(1).getString("id"));
     assertExists(response, itemsArray.getJsonObject(1));
@@ -1375,7 +1375,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     response = getById(itemsArray.getJsonObject(2).getString("id"));
     assertExists(response, itemsArray.getJsonObject(2));
-    assertHRIDRange(response, "it00000001", "it00000002");
+    assertHRIDRange(response, "it00000000001", "it00000000002");
 
     log.info("Finished canPostSynchronousBatchWithSuppliedAndGeneratedHRID");
   }
@@ -1387,7 +1387,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     setItemSequence(1);
 
     final JsonArray itemsArray = threeItems();
-    final String duplicateHRID = "it00000001";
+    final String duplicateHRID = "it00000000001";
     itemsArray.getJsonObject(1).put("hrid", duplicateHRID);
 
     assertThat(postSynchronousBatch(itemsArray), allOf(
@@ -1406,7 +1406,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   public void cannotPostSynchronousBatchWithHRIDFailure() {
     log.info("Starting cannotPostSynchronousBatchWithHRIDFailure");
 
-    setItemSequence(99999999);
+    setItemSequence(99_999_999_999L);
 
     final JsonArray itemArray = threeItems();
 
@@ -2245,7 +2245,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
           .add(tagValue)));
   }
 
-  private void setItemSequence(int sequenceNumber) {
+  private void setItemSequence(long sequenceNumber) {
     final Vertx vertx = StorageTestSuite.getVertx();
     final PostgresClient postgresClient =
         PostgresClient.getInstance(vertx, TENANT_ID);

--- a/src/test/java/org/folio/rest/api/TestBase.java
+++ b/src/test/java/org/folio/rest/api/TestBase.java
@@ -80,13 +80,21 @@ public abstract class TestBase {
     }
   }
 
-  void executeSqlFile(String fileContent)
+  /**
+   * Executes multiply SQL statements separated by a line separator (either CRLF|CR|LF).
+   *
+   * @param allStatements - Statements to execute (separated by a line separator).
+   * @throws InterruptedException
+   * @throws ExecutionException
+   * @throws TimeoutException
+   */
+  void executeMultipleSqlStatements(String allStatements)
     throws InterruptedException, ExecutionException, TimeoutException {
 
     final CompletableFuture<Void> result = new CompletableFuture<>();
     final Vertx vertx = StorageTestSuite.getVertx();
 
-    PostgresClient.getInstance(vertx).runSQLFile(fileContent, true, handler -> {
+    PostgresClient.getInstance(vertx).runSQLFile(allStatements, true, handler -> {
       if (handler.failed()) {
         result.completeExceptionally(handler.cause());
       } else if (!handler.result().isEmpty()) {


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-410: Increase digits for Inventory Instance HRIDs
https://issues.folio.org/browse/MODINVSTOR-411: Increase digits for Inventory Holdings HRIDs
https://issues.folio.org/browse/MODINVSTOR-412: Increase digits for Inventory Item HRIDs
https://issues.folio.org/browse/MODINVSTOR-406: Make the HRID sequences consistent


* Add alter holdings/instance/item HRID sequences script.
* Expand HRID to be 11-digits instead of 8-digits.
* Add unit test to verify that current value of the sequence has not been changed.
* Modify existing unit tests.

**Open question**: Do we need to migrate existing issued HRIDs to be 11-digits?
