### PR TITLE
MODINVSTOR-409: effectiveLocationId foreign key upgrade script

### DIFF
--- a/src/main/resources/templates/db_scripts/populateEffectiveLocationForeignKey.sql
+++ b/src/main/resources/templates/db_scripts/populateEffectiveLocationForeignKey.sql
@@ -1,0 +1,1 @@
+UPDATE ${myuniversity}_${mymodule}.item SET effectiveLocationId = (jsonb->>'effectiveLocationId')::uuid;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -697,7 +697,7 @@
     {
       "run": "after",
       "snippetPath": "populateEffectiveLocationForeignKey.sql",
-      "fromModuleVersion": "18.1.1"
+      "fromModuleVersion": "18.2.0"
     },
     {
       "run": "after",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -696,6 +696,11 @@
     },
     {
       "run": "after",
+      "snippetPath": "populateEffectiveLocationForeignKey.sql",
+      "fromModuleVersion": "18.1.1"
+    },
+    {
+      "run": "after",
       "snippetPath": "populateEffectiveCallNumberComponentsForExistingItems.sql",
       "fromModuleVersion": "17.1.0"
     },


### PR DESCRIPTION
RMB creates the UUID column `effectiveLocationId` with NULL as inital value
for all existing item records.

This is wrong.

This upgrade script populates the UUID column with the value from the jsonb column.