### PR TITLE
MODINVSTOR-397 include HRID in sample records

### DIFF
--- a/sample-data/holdingsrecords/aba-holdingsrecord3.json
+++ b/sample-data/holdingsrecords/aba-holdingsrecord3.json
@@ -1,5 +1,6 @@
 {
  "id" : "c4a15834-0184-4a6f-9c0c-0ca5bad8286d",
+  "hrid" : "hold000000000001",
  "formerIds" : [ ],
  "instanceId" : "69640328-788e-43fc-9c3c-af39e243f3b7",
  "permanentLocationId" : "53cf956f-c1df-410b-8bea-27f712cca7c0",
@@ -28,4 +29,4 @@
  "holdingsStatementsForSupplements" : [ ],
  "statisticalCodeIds" : [ ],
  "holdingsItems" : [ ]
-} 
+}

--- a/sample-data/holdingsrecords/aba-holdingsrecord4.json
+++ b/sample-data/holdingsrecords/aba-holdingsrecord4.json
@@ -1,5 +1,6 @@
 {
   "id" : "0c45bb50-7c9b-48b0-86eb-178a494e25fe",
+  "hrid" : "hold000000000002",
   "formerIds" : [ "ABW4508", "442882" ],
   "instanceId" : "69640328-788e-43fc-9c3c-af39e243f3b7",
   "permanentLocationId" : "fcd64ce1-6995-48f0-840e-89ffa2288371",

--- a/sample-data/holdingsrecords/american-journal-of-medicine.json
+++ b/sample-data/holdingsrecords/american-journal-of-medicine.json
@@ -1,11 +1,12 @@
 {
   "id" : "133a7916-f05e-4df4-8f7f-09eb2a7076d1",
+  "hrid" : "hold000000000003",
   "instanceId" : "30fcc8e7-a019-43f4-b642-2edc389f4501",
   "permanentLocationId" : "fcd64ce1-6995-48f0-840e-89ffa2288371",
   "callNumber" : "R11.A38",
-  "holdingsStatements" : [ 
+  "holdingsStatements" : [
     {
       "statement": "v1-128, July 1946-December 2016"
-    } 
+    }
   ]
 }

--- a/sample-data/holdingsrecords/bridget-jones-baby-holdingsrecord1.json
+++ b/sample-data/holdingsrecords/bridget-jones-baby-holdingsrecord1.json
@@ -1,5 +1,6 @@
 {
   "id": "65cb2bf0-d4c2-4886-8ad0-b76f1ba75d61",
+  "hrid" : "hold000000000004",
   "instanceId": "7fbd5d84-62d1-44c6-9c45-6cb173998bbd",
   "callNumber": "PR6056.I4588 B749 2016",
   "permanentLocationId": "fcd64ce1-6995-48f0-840e-89ffa2288371"

--- a/sample-data/holdingsrecords/bridget-jones-baby-holdingsrecord2.json
+++ b/sample-data/holdingsrecords/bridget-jones-baby-holdingsrecord2.json
@@ -1,5 +1,6 @@
 {
   "id": "fb7b70f1-b898-4924-a991-0e4b6312bb5f",
+  "hrid" : "hold000000000005",
   "instanceId": "7fbd5d84-62d1-44c6-9c45-6cb173998bbd",
   "callNumber": "PR6056.I4588 B749 2016",
   "permanentLocationId": "53cf956f-c1df-410b-8bea-27f712cca7c0"

--- a/sample-data/holdingsrecords/girl-on-the-train-holdingsrecord.json
+++ b/sample-data/holdingsrecords/girl-on-the-train-holdingsrecord.json
@@ -1,5 +1,6 @@
 {
   "id": "65032151-39a5-4cef-8810-5350eb316300",
+  "hrid" : "hold000000000006",
   "instanceId": "f31a36de-fcf8-44f9-87ef-a55d06ad21ae",
   "callNumber": "MCN FICTION",
   "permanentLocationId": "b241764c-1466-4e1d-a028-1a3684a5da87",

--- a/sample-data/holdingsrecords/interesting-times-holdingsrecord.json
+++ b/sample-data/holdingsrecords/interesting-times-holdingsrecord.json
@@ -1,5 +1,6 @@
 {
   "id": "67cd0046-e4f1-4e4f-9024-adf0b0039d09",
+  "hrid" : "hold000000000007",
   "instanceId": "a89eccf0-57a6-495e-898d-32b9b2210f2f",
   "callNumber": "D15.H63 A3 2002",
   "permanentLocationId": "f34d27c6-a8eb-461b-acd6-5dea81771e70",

--- a/sample-data/holdingsrecords/nod-holdingsrecord.json
+++ b/sample-data/holdingsrecords/nod-holdingsrecord.json
@@ -1,5 +1,6 @@
 {
   "id": "68872d8a-bf16-420b-829f-206da38f6c10",
+  "hrid" : "hold000000000008",
   "instanceId": "6506b79b-7702-48b2-9774-a1c538fdd34e",
   "callNumber": "some-callnumber",
   "permanentLocationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",

--- a/sample-data/holdingsrecords/semantic-web-primer.json
+++ b/sample-data/holdingsrecords/semantic-web-primer.json
@@ -1,5 +1,6 @@
 {
   "id" : "e3ff6133-b9a2-4d4c-a1c9-dc1867d4df19",
+  "hrid" : "hold000000000009",
   "holdingsTypeId" : "03c9c400-b9e3-4a07-ac0e-05ab470233ed",
   "formerIds" : [ ],
   "instanceId" : "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39",

--- a/sample-data/holdingsrecords/temeraire-holdingsrecord.json
+++ b/sample-data/holdingsrecords/temeraire-holdingsrecord.json
@@ -1,5 +1,6 @@
 {
   "id": "e6d7e91a-4dbc-4a70-9b38-e000d2fbdc79",
+  "hrid" : "hold000000000010",
   "instanceId": "cf23adf0-61ba-4887-bf82-956c4aae2260",
   "callNumber": "some-callnumber",
   "permanentLocationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",

--- a/sample-data/holdingsrecords/transparent-water-holdingsrecord.json
+++ b/sample-data/holdingsrecords/transparent-water-holdingsrecord.json
@@ -1,5 +1,6 @@
 {
   "id": "e9285a1c-1dfc-4380-868c-e74073003f43",
+  "hrid" : "hold000000000011",
   "instanceId": "e54b1f4d-7d05-4b1a-9368-3c36b75d8ac6",
   "callNumber": "M1366.S67 T73 2017",
   "permanentLocationId": "fcd64ce1-6995-48f0-840e-89ffa2288371",

--- a/sample-data/holdingsrecords/water-resources-of-east-feliciana-parish.json
+++ b/sample-data/holdingsrecords/water-resources-of-east-feliciana-parish.json
@@ -1,5 +1,6 @@
 {
   "id": "55f48dc6-efa7-4cfe-bc7c-4786efe493e3",
+  "hrid" : "hold000000000012",
   "instanceId": "bbd4a5e1-c9f3-44b9-bfdf-d184e04f0ba0",
   "permanentLocationId": "f34d27c6-a8eb-461b-acd6-5dea81771e70"
 }

--- a/sample-data/instances/aba.json
+++ b/sample-data/instances/aba.json
@@ -1,5 +1,6 @@
 {
   "id": "69640328-788e-43fc-9c3c-af39e243f3b7",
+  "hrid" : "inst000000000001",
   "source": "FOLIO",
   "title": "ABA Journal",
   "publication": [

--- a/sample-data/instances/american-bar-association.json
+++ b/sample-data/instances/american-bar-association.json
@@ -1,5 +1,6 @@
 {
   "id": "00f10ab9-d845-4334-92d2-ff55862bf4f9",
+  "hrid" : "inst000000000002",
   "source": "FOLIO",
   "title": "American Bar Association journal.",
   "indexTitle": "American Bar Association journal.",

--- a/sample-data/instances/american-journal-of-medicine.json
+++ b/sample-data/instances/american-journal-of-medicine.json
@@ -1,5 +1,6 @@
 {
   "id": "30fcc8e7-a019-43f4-b642-2edc389f4501",
+  "hrid" : "inst000000000003",
   "source": "FOLIO",
   "title": "The American Journal of Medicine",
   "alternativeTitles": [

--- a/sample-data/instances/anglo-saxon-manuscripts.json
+++ b/sample-data/instances/anglo-saxon-manuscripts.json
@@ -1,5 +1,6 @@
 {
   "id": "8be05cf5-fb4f-4752-8094-8e179d08fb99",
+  "hrid" : "inst000000000004",
   "source": "FOLIO",
   "title": "Anglo-Saxon manuscripts in microfiche facsimile Volume 25 Corpus Christi College, Cambridge II, MSS 12, 144, 162, 178, 188, 198, 265, 285, 322, 326, 449 microform A. N. Doane (editor and director), Matthew T. Hussey (associate editor), Phillip Pulsiano (founding editor)",
   "alternativeTitles": [],

--- a/sample-data/instances/biometrics-and-neuroscience.json
+++ b/sample-data/instances/biometrics-and-neuroscience.json
@@ -1,5 +1,6 @@
 {
   "id": "1640f178-f243-4e4a-bf1c-9e1e62b3171d",
+  "hrid" : "inst000000000005",
   "source": "FOLIO",
   "title": "Futures, biometrics and neuroscience research Luiz Moutinho, Mladen Sokele, editors",
   "alternativeTitles": [],

--- a/sample-data/instances/bridget-jones-baby.json
+++ b/sample-data/instances/bridget-jones-baby.json
@@ -1,5 +1,6 @@
 {
   "id": "7fbd5d84-62d1-44c6-9c45-6cb173998bbd",
+  "hrid" : "inst000000000006",
   "source": "FOLIO",
   "title": "Bridget Jones's Baby: the diaries",
   "editions": [

--- a/sample-data/instances/cantatas-for-bass.json
+++ b/sample-data/instances/cantatas-for-bass.json
@@ -1,5 +1,6 @@
 {
   "id": "ce00bca2-9270-4c6b-b096-b83a2e56e8e9",
+  "hrid" : "inst000000000007",
   "source": "FOLIO",
   "title": "Cantatas for bass 4 Ich habe genug : BWV 82 / Johann Sebastian Bach ; Matthias Goerne, baritone ; Freiburger Barockorchester, Gottfried von der Goltz, violin and conductor",
   "alternativeTitles": [

--- a/sample-data/instances/chess-player.json
+++ b/sample-data/instances/chess-player.json
@@ -1,5 +1,6 @@
 {
   "id": "3c4ae3f3-b460-4a89-a2f9-78ce3145e4fc",
+  "hrid" : "inst000000000008",
   "source": "FOLIO",
   "title": "The chess player’s mating guide Computer Datei Robert Ris",
   "alternativeTitles": [],

--- a/sample-data/instances/city-post-modernity.json
+++ b/sample-data/instances/city-post-modernity.json
@@ -1,5 +1,6 @@
 {
   "id": "c1d3be12-ecec-4fab-9237-baf728575185",
+  "hrid" : "inst000000000009",
   "source": "FOLIO",
   "title": "The city post-modernity edited by Alan Latham",
   "alternativeTitles": [],

--- a/sample-data/instances/concepts-of-fashion.json
+++ b/sample-data/instances/concepts-of-fashion.json
@@ -1,5 +1,6 @@
 {
   "id": "5b1eb450-ff9f-412d-a9e7-887f6eaeb5b4",
+  "hrid" : "inst000000000010",
   "source": "FOLIO",
   "title": "Concepts of fashion 1921 - 1987 microform a study of garments worn by selected winners of the Miss America Pageant Marian Ann J. Matwiejczyk-Montgomery",
   "alternativeTitles": [],

--- a/sample-data/instances/dc-motor-control-experiment.json
+++ b/sample-data/instances/dc-motor-control-experiment.json
@@ -1,5 +1,6 @@
 {
   "id": "6eee8eb9-db1a-46e2-a8ad-780f19974efa",
+  "hrid" : "inst000000000011",
   "source": "FOLIO",
   "title": "DC Motor Control Experiment Objekt for introduction to control systems Herbert Werner",
   "alternativeTitles": [],

--- a/sample-data/instances/girl-on-the-train.json
+++ b/sample-data/instances/girl-on-the-train.json
@@ -1,5 +1,6 @@
 {
   "id": "f31a36de-fcf8-44f9-87ef-a55d06ad21ae",
+  "hrid" : "inst000000000012",
   "source": "FOLIO",
   "title": "The Girl on the Train",
   "alternativeTitles": [

--- a/sample-data/instances/global-africa-series.json
+++ b/sample-data/instances/global-africa-series.json
@@ -1,5 +1,6 @@
 {
   "id": "f7e82a1e-fc06-4b82-bb1d-da326cb378ce",
+  "hrid" : "inst000000000013",
   "source": "FOLIO",
   "title": "Global Africa",
   "identifiers": [

--- a/sample-data/instances/global-africa-v1.json
+++ b/sample-data/instances/global-africa-v1.json
@@ -1,5 +1,6 @@
 {
   "id": "81825729-e824-4d52-9d15-1695e9bf1831",
+  "hrid" : "inst000000000014",
   "source": "FOLIO",
   "title": "Dissent, protest and dispute in Africa edited by Emmanuel M. Mbah and Toyin Falola",
   "series": [

--- a/sample-data/instances/global-africa-v2.json
+++ b/sample-data/instances/global-africa-v2.json
@@ -1,5 +1,6 @@
 {
   "id": "04489a01-f3cd-4f9e-9be4-d9c198703f45",
+  "hrid" : "inst000000000015",
   "source": "FOLIO",
   "title": "Environment and identity politics in colonial Africa Fulani migrations and land conflict by Emmanuel M. Mbah",
   "series": [

--- a/sample-data/instances/global-africa-v3.json
+++ b/sample-data/instances/global-africa-v3.json
@@ -1,5 +1,6 @@
 {
   "id": "7ab22f0a-c9cd-449a-9137-c76e5055ca37",
+  "hrid" : "inst000000000016",
   "source": "FOLIO",
   "title": "Poverty reduction strategies in Africa edited by Toyin Falola and Mike Odugbo Odey",
   "series": [

--- a/sample-data/instances/interesting-times.json
+++ b/sample-data/instances/interesting-times.json
@@ -1,5 +1,6 @@
 {
   "id": "a89eccf0-57a6-495e-898d-32b9b2210f2f",
+  "hrid" : "inst000000000017",
   "source": "FOLIO",
   "title": "Interesting Times",
   "contributors": [

--- a/sample-data/instances/journey-through-europe.json
+++ b/sample-data/instances/journey-through-europe.json
@@ -1,5 +1,6 @@
 {
   "id": "1b74ab75-9f41-4837-8662-a1d99118008d",
+  "hrid" : "inst000000000018",
   "source": "FOLIO",
   "title": "A journey through Europe Bildtontraeger high-speed lines European Commission, Directorate-General for Mobility and Transport",
   "alternativeTitles": [],

--- a/sample-data/instances/millimeter-wave-networks.json
+++ b/sample-data/instances/millimeter-wave-networks.json
@@ -1,5 +1,6 @@
 {
   "id": "6b4ae089-e1ee-431f-af83-e1133f8e3da0",
+  "hrid" : "inst000000000019",
   "source": "FOLIO",
   "title": "MobiCom'17 5 mmNets'17, October 16, 2017, Snowbird, UT, USA / general chairs: Haitham Hassanieh (University of Illinois at Urbana Champaign, USA), Xinyu Zhang (University of California San Diego, USA)",
   "alternativeTitles": [

--- a/sample-data/instances/neurotic-heroine.json
+++ b/sample-data/instances/neurotic-heroine.json
@@ -1,5 +1,6 @@
 {
   "id": "62ca5b43-0f11-40af-a6b4-1a9ee2db33cb",
+  "hrid" : "inst000000000020",
   "source": "FOLIO",
   "title": "The Neurotic Heroine in Tennessee Williams microform C.N. Stavrou",
   "alternativeTitles": [],

--- a/sample-data/instances/nod.json
+++ b/sample-data/instances/nod.json
@@ -1,5 +1,6 @@
 {
   "id": "6506b79b-7702-48b2-9774-a1c538fdd34e",
+  "hrid" : "inst000000000021",
   "source": "FOLIO",
   "title": "Nod",
   "contributors": [

--- a/sample-data/instances/semantic-web-primer.json
+++ b/sample-data/instances/semantic-web-primer.json
@@ -1,5 +1,6 @@
 {
   "id": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39",
+  "hrid" : "inst000000000022",
   "source": "FOLIO",
   "title": "A semantic web primer",
   "indexTitle": "Semantic web primer",

--- a/sample-data/instances/signature-of-complex-system.json
+++ b/sample-data/instances/signature-of-complex-system.json
@@ -1,5 +1,6 @@
 {
   "id": "54cc0262-76df-4cac-acca-b10e9bc5c79a",
+  "hrid" : "inst000000000023",
   "source": "FOLIO",
   "title": "On the signature of complex system a decomposed approach Gaofeng Da, Ping Shing Chan, Maochao Xu",
   "alternativeTitles": [],

--- a/sample-data/instances/temeraire.json
+++ b/sample-data/instances/temeraire.json
@@ -1,5 +1,6 @@
 {
   "id": "cf23adf0-61ba-4887-bf82-956c4aae2260",
+  "hrid" : "inst000000000024",
   "source": "FOLIO",
   "title": "Temeraire",
   "contributors": [

--- a/sample-data/instances/transparent-water.json
+++ b/sample-data/instances/transparent-water.json
@@ -1,5 +1,6 @@
 {
   "id": "e54b1f4d-7d05-4b1a-9368-3c36b75d8ac6",
+  "hrid" : "inst000000000025",
   "source": "FOLIO",
   "title": "Transparent water",
   "identifiers": [

--- a/sample-data/instances/umsetzung-multipart.json
+++ b/sample-data/instances/umsetzung-multipart.json
@@ -1,5 +1,6 @@
 {
   "id": "a317b304-528c-424f-961c-39174933b454",
+  "hrid" : "inst000000000026",
   "source": "FOLIO",
   "title": "Umsetzung der DIN EN ISO 9001:2015 Harald Augustin (Hrsg.)",
   "series": [

--- a/sample-data/instances/umsetzung-v1.json
+++ b/sample-data/instances/umsetzung-v1.json
@@ -1,5 +1,6 @@
 {
   "id": "e6bc03c6-c137-4221-b679-a7c5c31f986c",
+  "hrid" : "inst000000000027",
   "source": "FOLIO",
   "title": "Organisations- und Prozessentwicklung Harald Augustin (Hrsg.)",
   "series": [

--- a/sample-data/instances/umsetzung-v2.json
+++ b/sample-data/instances/umsetzung-v2.json
@@ -1,5 +1,6 @@
 {
   "id": "549fad9e-7f8e-4d8e-9a71-00d251817866",
+  "hrid" : "inst000000000028",
   "source": "FOLIO",
   "title": "Agile Organisation, Risiko- und Change Management Harald Augustin (Hrsg.)",
   "series": [

--- a/sample-data/instances/water-resources-of-east-feliciana-parish.json
+++ b/sample-data/instances/water-resources-of-east-feliciana-parish.json
@@ -1,5 +1,6 @@
 {
   "id": "bbd4a5e1-c9f3-44b9-bfdf-d184e04f0ba0",
+  "hrid" : "inst000000000029",
   "source": "FOLIO",
   "title": "Water resources of East Feliciana Parish, Louisiana",
   "contributors": [

--- a/sample-data/items/aba-4-1.json
+++ b/sample-data/items/aba-4-1.json
@@ -1,5 +1,6 @@
 {
   "id" : "bc90a3c9-26c9-4519-96bc-d9d44995afef",
+  "hrid" : "item000000000001",
   "status" : {
     "name" : "Available"
   },

--- a/sample-data/items/aba-4-2.json
+++ b/sample-data/items/aba-4-2.json
@@ -1,5 +1,6 @@
 {
   "id" : "eedd13c4-7d40-4b1e-8f77-b0b9d19a896b",
+  "hrid" : "item000000000002",
   "status" : {
     "name" : "Available"
   },

--- a/sample-data/items/aba-4-3.json
+++ b/sample-data/items/aba-4-3.json
@@ -1,5 +1,6 @@
 {
   "id" : "f8b6d973-60d4-41ce-a57b-a3884471a6d6",
+  "hrid" : "item000000000003",
   "status" : {
     "name" : "Available"
   },

--- a/sample-data/items/aba-4-4.json
+++ b/sample-data/items/aba-4-4.json
@@ -1,5 +1,6 @@
 {
   "id" : "645549b1-2a73-4251-b8bb-39598f773a93",
+  "hrid" : "item000000000004",
   "status" : {
     "name" : "Available"
   },

--- a/sample-data/items/aba-4-5.json
+++ b/sample-data/items/aba-4-5.json
@@ -1,5 +1,6 @@
 {
   "id" : "9428231b-dd31-4f70-8406-fe22fbdeabc2",
+  "hrid" : "item000000000005",
   "status" : {
     "name" : "Available"
   },

--- a/sample-data/items/aba-4-6.json
+++ b/sample-data/items/aba-4-6.json
@@ -1,5 +1,6 @@
 {
   "id" : "9ea1fd0b-0259-4edb-95a3-eb2f9a063e20",
+  "hrid" : "item000000000006",
   "status" : {
     "name" : "Available"
   },

--- a/sample-data/items/american-journal-of-medicine.json
+++ b/sample-data/items/american-journal-of-medicine.json
@@ -1,5 +1,6 @@
 {
   "id" : "1714f71f-b845-444b-a79e-a577487a6f7d",
+  "hrid" : "item000000000007",
   "status" : {
     "name" : "Available"
   },

--- a/sample-data/items/bridget-jones-baby-item.json
+++ b/sample-data/items/bridget-jones-baby-item.json
@@ -1,5 +1,6 @@
 {
   "id": "1b6d3338-186e-4e35-9e75-1b886b0da53e",
+  "hrid" : "item000000000008",
   "holdingsRecordId": "65cb2bf0-d4c2-4886-8ad0-b76f1ba75d61",
   "barcode": "453987605438",
   "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",

--- a/sample-data/items/bridget-jones-baby-item_2.json
+++ b/sample-data/items/bridget-jones-baby-item_2.json
@@ -1,5 +1,6 @@
 {
   "id": "4428a37c-8bae-4f0d-865d-970d83d5ad55",
+  "hrid" : "item000000000009",
   "holdingsRecordId": "65cb2bf0-d4c2-4886-8ad0-b76f1ba75d61",
   "barcode": "4539876054382",
   "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",

--- a/sample-data/items/bridget-jones-baby-item_3.json
+++ b/sample-data/items/bridget-jones-baby-item_3.json
@@ -1,5 +1,6 @@
 {
   "id": "d6f7c1ba-a237-465e-94ed-f37e91bc64bd",
+  "hrid" : "item000000000010",
   "holdingsRecordId": "fb7b70f1-b898-4924-a991-0e4b6312bb5f",
   "barcode": "4539876054383",
   "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",

--- a/sample-data/items/girl-on-the-train-item.json
+++ b/sample-data/items/girl-on-the-train-item.json
@@ -1,5 +1,6 @@
 {
   "id": "459afaba-5b39-468d-9072-eb1685e0ddf4",
+  "hrid" : "item000000000011",
   "holdingsRecordId": "65032151-39a5-4cef-8810-5350eb316300",
   "barcode": "765475420716",
   "materialTypeId": "5ee11d91-f7e8-481d-b079-65d708582ccc",

--- a/sample-data/items/interesting-times-item.json
+++ b/sample-data/items/interesting-times-item.json
@@ -1,5 +1,6 @@
 {
   "id": "bb5a6689-c008-4c96-8f8f-b666850ee12d",
+  "hrid" : "item000000000012",
   "holdingsRecordId": "67cd0046-e4f1-4e4f-9024-adf0b0039d09",
   "barcode": "326547658598",
   "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",

--- a/sample-data/items/nod-item.json
+++ b/sample-data/items/nod-item.json
@@ -1,5 +1,6 @@
 {
   "id": "23f2c8e1-bd5d-4f27-9398-a688c998808a",
+  "hrid" : "item000000000013",
   "holdingsRecordId": "68872d8a-bf16-420b-829f-206da38f6c10",
   "barcode": "697685458679",
   "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",

--- a/sample-data/items/semantic-web-primer-10101.json
+++ b/sample-data/items/semantic-web-primer-10101.json
@@ -1,5 +1,6 @@
 {
   "id" : "7212ba6a-8dcf-45a1-be9a-ffaa847c4423",
+  "hrid" : "item000000000014",
   "status" : {
     "name" : "Available"
   },

--- a/sample-data/items/semantic-web-primer-90000.json
+++ b/sample-data/items/semantic-web-primer-90000.json
@@ -1,5 +1,6 @@
 {
   "id" : "100d10bf-2f06-4aa0-be15-0b95b2d9f9e3",
+  "hrid" : "item000000000015",
   "status" : {
     "name" : "Available"
   },

--- a/sample-data/items/temeraire-item.json
+++ b/sample-data/items/temeraire-item.json
@@ -1,5 +1,6 @@
 {
   "id": "0b96a642-5e7f-452d-9cae-9cee66c9a892",
+  "hrid" : "item000000000017",
   "holdingsRecordId": "e6d7e91a-4dbc-4a70-9b38-e000d2fbdc79",
   "barcode": "645398607547",
   "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",

--- a/sample-data/items/temeraire2-item.json
+++ b/sample-data/items/temeraire2-item.json
@@ -1,5 +1,6 @@
 {
   "id": "23fdb0bc-ab58-442a-b326-577a96204487",
+  "hrid" : "item000000000016",
   "holdingsRecordId": "e6d7e91a-4dbc-4a70-9b38-e000d2fbdc79",
   "barcode": "653285216743",
   "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",


### PR DESCRIPTION
This pull request includes manually updated sample records.

I wanted to also change the way the tests treated sample records and add one to demonstrate the current issue. However I wanted to get this change completed as quickly as possible, so deferred these changes.

I ran Okapi manually and loaded the sample records successfully. I tried invoking the install endpoint a second time and it didn't seem to fail, I don't know if that is sufficient for testing this.

@adamdickmeiss I don't really understand how to recreate the issue, so I'd appreciate you trying and checking if this resolves the issue (at least for the moment) or help me understand how to replicate the issue locally.