### PR TITLE
[BREAKING] MODINVSTOR-416, MODINVSTOR-392, MODINVSTOR-332: item storage 8.0

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "item-storage",
-      "version": "7.8",
+      "version": "8.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -35,7 +35,7 @@
     },
     {
       "id": "item-storage-batch-sync",
-      "version": "0.1",
+      "version": "0.2",
       "handlers": [
         {
           "methods": ["POST"],

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>18.3.0-SNAPSHOT</version>
+  <version>19.0.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/ramls/item-storage.raml
+++ b/ramls/item-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Item Storage
-version: v7.8
+version: v8.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item-sync.raml
+++ b/ramls/item-sync.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Storage Item Batch Sync API
-version: v0.1
+version: v0.2
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -210,7 +210,18 @@
       "properties": {
         "name": {
           "description": "Name of the status e.g. Available, Checked out, In transit",
-          "type": "string"
+          "type": "string",
+          "enum": [
+            "Available",
+            "Awaiting pickup",
+            "Checked out",
+            "In process",
+            "In transit",
+            "Missing",
+            "On order",
+            "Paged",
+            "Withdrawn"
+          ]
         },
         "date": {
           "description": "Date and time when the status was last changed",

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -227,7 +227,6 @@
             "Missing",
             "On order",
             "Paged",
-            "Withdrawn",
             "Declared lost",
             "Received",
             "Order closed"

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -214,6 +214,7 @@
           "enum": [
             "Available",
             "Awaiting pickup",
+            "Awaiting delivery",
             "Checked out",
             "In process",
             "In transit",

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -228,7 +228,6 @@
             "On order",
             "Paged",
             "Declared lost",
-            "Received",
             "Order closed"
           ]
         },

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -97,13 +97,9 @@
       "type": "string",
       "description": "Item identifier number, e.g. imported from the union catalogue (read only)."
     },
-    "copyNumbers": {
-      "type": "array",
-      "description": "Copy number is the piece identifier. The copy number reflects if the library has one (or more) copies of a single-volume monograph; one (or more) copies of a multi-volume, (e.g. Copy 1, or C.7.)",
-      "items": {
-        "type": "string"
-      },
-      "uniqueItems": true
+    "copyNumber": {
+      "type": "string",
+      "description": "Copy number is the piece identifier. The copy number reflects if the library has a copy of a single-volume monograph; one copy of a multi-volume, (e.g. Copy 1, or C.7.)"
     },
     "numberOfPieces": {
       "type": "string",
@@ -201,7 +197,7 @@
           },
           "staffOnly": {
             "type": "boolean",
-            "default": "Flag to restrict display of this note",
+            "description": "Flag to restrict display of this note",
             "default": false
           }
         },
@@ -218,7 +214,9 @@
         },
         "date": {
           "description": "Date and time when the status was last changed",
-          "type": "string"
+          "type": "string",
+          "format": "date-time",
+          "readonly": true
         }
       },
       "additionalProperties": false

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -112,6 +112,7 @@
       "description": "Number of pieces. Used when an item is checked out or returned to verify that all parts are present (e.g. 7 CDs in a set)."
     },
     "descriptionOfPieces": {
+      "description": "Description of item pieces.",
       "type": "string"
     },
     "numberOfMissingPieces": {
@@ -127,9 +128,11 @@
       "description": "Date when the piece(s) went missing."
     },
     "itemDamagedStatusId": {
+      "description": "Item dame status id identifier.",
       "type": "string"
     },
     "itemDamagedStatusDate": {
+      "description": "Date and time when the item was damaged.",
       "type": "string"
     },
     "notes": {
@@ -269,6 +272,7 @@
     },
     "electronicAccess": {
       "type": "array",
+      "description": "References for accessing the item by URL.",
       "items": {
         "type": "object",
         "properties": {
@@ -329,6 +333,7 @@
     },
     "holdingsRecord2": {
       "type": "object",
+      "description": "Item associated holdings record object.",
       "folio:$ref": "holdingsrecord.json",
       "readonly": true,
       "folio:isVirtual": true,

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -231,6 +231,7 @@
           "readonly": true
         }
       },
+      "required": ["name"],
       "additionalProperties": false
     },
     "materialTypeId": {
@@ -356,6 +357,7 @@
   "required": [
     "materialTypeId",
     "permanentLoanTypeId",
-    "holdingsRecordId"
+    "holdingsRecordId",
+    "status"
   ]
 }

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -220,7 +220,8 @@
             "Missing",
             "On order",
             "Paged",
-            "Withdrawn"
+            "Withdrawn",
+            "Declared lost"
           ]
         },
         "date": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -228,7 +228,9 @@
             "On order",
             "Paged",
             "Withdrawn",
-            "Declared lost"
+            "Declared lost",
+            "Received",
+            "Order closed"
           ]
         },
         "date": {

--- a/sample-data/items/aba-4-1.json
+++ b/sample-data/items/aba-4-1.json
@@ -10,7 +10,6 @@
   "barcode" : "A14811392695",
   "enumeration" : "v.73:no.1-6",
   "chronology" : "1987:Jan.-June",
-  "copyNumbers" : [ ],
   "notes" : [ ],
   "circulationNotes" : [ ],
   "yearCaption" : [ ],

--- a/sample-data/items/aba-4-2.json
+++ b/sample-data/items/aba-4-2.json
@@ -10,7 +10,6 @@
   "barcode" : "A1429864347",
   "enumeration" : "v.72:no.6-7,10-12",
   "chronology" : "1986:July-Aug.,Oct.-Dec.",
-  "copyNumbers" : [ ],
   "notes" : [ ],
   "circulationNotes" : [ ],
   "yearCaption" : [ ],

--- a/sample-data/items/aba-4-3.json
+++ b/sample-data/items/aba-4-3.json
@@ -10,7 +10,6 @@
   "barcode" : "A14811392645",
   "enumeration" : "v.72:no.1-6",
   "chronology" : "1986:Jan.-June",
-  "copyNumbers" : [ ],
   "notes" : [ ],
   "circulationNotes" : [ ],
   "yearCaption" : [ ],

--- a/sample-data/items/aba-4-4.json
+++ b/sample-data/items/aba-4-4.json
@@ -10,7 +10,6 @@
   "barcode" : "A14813848587",
   "enumeration" : "v.71:no.6-2",
   "chronology" : "1985:July-Dec.",
-  "copyNumbers" : [ ],
   "notes" : [ ],
   "circulationNotes" : [ ],
   "yearCaption" : [ ],

--- a/sample-data/items/aba-4-5.json
+++ b/sample-data/items/aba-4-5.json
@@ -10,7 +10,6 @@
   "barcode" : "A14837334314",
   "enumeration" : "v.70:no.7-12",
   "chronology" : "1984:July-Dec.",
-  "copyNumbers" : [ ],
   "notes" : [ ],
   "circulationNotes" : [ ],
   "yearCaption" : [ ],

--- a/sample-data/items/aba-4-6.json
+++ b/sample-data/items/aba-4-6.json
@@ -10,7 +10,7 @@
   "barcode" : "A14837334306",
   "enumeration" : "v.70:no.1-6",
   "chronology" : "1984:Jan.-June",
-  "copyNumbers" : [ "1" ],
+  "copyNumber" : "1",
   "notes" : [ ],
   "circulationNotes" : [ ],
   "yearCaption" : [ ],

--- a/sample-data/items/american-journal-of-medicine.json
+++ b/sample-data/items/american-journal-of-medicine.json
@@ -7,7 +7,7 @@
   "holdingsRecordId" : "133a7916-f05e-4df4-8f7f-09eb2a7076d1",
   "barcode" : "000111222333444",
   "enumeration" : "v. 30 1961",
-  "copyNumbers" : [ "c.1" ],
+  "copyNumber" : "c.1",
   "notes" : [ ],
   "materialTypeId" : "1a54b431-2e4f-452d-9cae-9cee66c9a892",
   "permanentLoanTypeId" : "2e48e713-17f3-4c13-a9f8-23845bb210a4",

--- a/sample-data/items/bridget-jones-baby-item.json
+++ b/sample-data/items/bridget-jones-baby-item.json
@@ -9,7 +9,7 @@
   "status": {
     "name": "Checked out"
   },
-  "copyNumbers": ["Copy 1"],
+  "copyNumber": "Copy 1",
   "numberOfPieces": "1",
   "notes": [
     {

--- a/sample-data/items/bridget-jones-baby-item_2.json
+++ b/sample-data/items/bridget-jones-baby-item_2.json
@@ -9,7 +9,7 @@
   "status": {
     "name": "Available"
   },
-  "copyNumbers": ["Copy 2"],
+  "copyNumber": "Copy 2",
   "numberOfPieces": "1",
   "notes": [
     {

--- a/sample-data/items/bridget-jones-baby-item_3.json
+++ b/sample-data/items/bridget-jones-baby-item_3.json
@@ -9,6 +9,6 @@
   "status": {
     "name": "Available"
   },
-  "copyNumbers": ["Copy 3"],
+  "copyNumber": "Copy 3",
   "numberOfPieces": "1"
 }

--- a/sample-data/items/semantic-web-primer-10101.json
+++ b/sample-data/items/semantic-web-primer-10101.json
@@ -10,7 +10,7 @@
   "itemLevelCallNumber" : "TK5105.88815 . A58 2004 FT MEADE",
   "enumeration" : "",
   "chronology" : "",
-  "copyNumbers" : [ "Copy 2" ],
+  "copyNumber" : "Copy 2",
   "notes" : [ ],
   "circulationNotes" : [ ],
   "electronicAccess" : [ {

--- a/sample-data/items/semantic-web-primer-90000.json
+++ b/sample-data/items/semantic-web-primer-90000.json
@@ -10,7 +10,6 @@
   "itemLevelCallNumber" : "TK5105.88815 . A58 2004 FT MEADE",
   "enumeration" : "",
   "chronology" : "",
-  "copyNumbers" : [ ],
   "notes" : [ ],
   "circulationNotes" : [ ],
   "electronicAccess" : [ {

--- a/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
@@ -20,7 +20,6 @@ import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.jaxrs.model.Items;
-import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.jaxrs.resource.ItemStorage;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
@@ -44,7 +43,6 @@ public class ItemStorageAPI implements ItemStorage {
   static final String HOLDINGS_RECORD_TABLE = "holdings_record";
 
   private static final Logger log = LoggerFactory.getLogger(ItemStorageAPI.class);
-  private static final Status.Name DEFAULT_STATUS_NAME = Status.Name.AVAILABLE;
 
   @Validate
   @Override
@@ -67,10 +65,6 @@ public class ItemStorageAPI implements ItemStorage {
       String lang, Item entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
-
-    if (entity.getStatus() == null) {
-      entity.setStatus(new Status().withName(DEFAULT_STATUS_NAME));
-    }
 
     final Future<String> hridFuture;
     if (isBlank(entity.getHrid())) {

--- a/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
@@ -44,7 +44,7 @@ public class ItemStorageAPI implements ItemStorage {
   static final String HOLDINGS_RECORD_TABLE = "holdings_record";
 
   private static final Logger log = LoggerFactory.getLogger(ItemStorageAPI.class);
-  private static final String DEFAULT_STATUS_NAME = "Available";
+  private static final Status.Name DEFAULT_STATUS_NAME = Status.Name.AVAILABLE;
 
   @Validate
   @Override
@@ -156,7 +156,7 @@ public class ItemStorageAPI implements ItemStorage {
               respond500WithTextPlain(response.result().getEntity())));
         } else {
           final Item existingItem = (Item) response.result().getEntity();
-          if (Objects.equals(entity.getHrid(), existingItem.getHrid())) { 
+          if (Objects.equals(entity.getHrid(), existingItem.getHrid())) {
             setEffectiveCallNumber(okapiHeaders, vertxContext, entity).thenAccept(
                 item -> PgUtil.put(ITEM_TABLE, item, itemId, okapiHeaders, vertxContext,
                   PutItemStorageItemsByItemIdResponse.class, asyncResultHandler));

--- a/src/main/resources/templates/db_scripts/migrateItemCopyNumberToSingleValue.sql
+++ b/src/main/resources/templates/db_scripts/migrateItemCopyNumberToSingleValue.sql
@@ -1,0 +1,12 @@
+START TRANSACTION;
+-- Make the array of copy numbers as a single value, take the first value from the array
+UPDATE ${myuniversity}_${mymodule}.item AS it
+  SET jsonb = jsonb_set(it.jsonb, '{copyNumber}', it.jsonb#>'{copyNumbers, 0}')
+WHERE it.jsonb->'copyNumbers' IS NOT NULL AND jsonb_array_length(it.jsonb->'copyNumbers') > 0;
+
+-- Remove the copyNumbers property even if it has zero length.
+UPDATE ${myuniversity}_${mymodule}.item AS it
+  SET jsonb = it.jsonb - 'copyNumbers'
+WHERE it.jsonb->'copyNumbers' IS NOT NULL;
+
+END TRANSACTION;

--- a/src/main/resources/templates/db_scripts/migrateItemCopyNumberToSingleValue.sql
+++ b/src/main/resources/templates/db_scripts/migrateItemCopyNumberToSingleValue.sql
@@ -2,7 +2,7 @@ START TRANSACTION;
 -- Make the array of copy numbers as a single value, take the first value from the array
 UPDATE ${myuniversity}_${mymodule}.item AS it
   SET jsonb = jsonb_set(it.jsonb, '{copyNumber}', it.jsonb#>'{copyNumbers, 0}')
-WHERE it.jsonb->'copyNumbers' IS NOT NULL AND jsonb_array_length(it.jsonb->'copyNumbers') > 0;
+WHERE it.jsonb->>'copyNumbers' IS NOT NULL AND jsonb_array_length(it.jsonb->'copyNumbers') > 0;
 
 -- Remove the copyNumbers property even if it has zero length.
 UPDATE ${myuniversity}_${mymodule}.item AS it

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -727,7 +727,7 @@
     {
       "run": "after",
       "snippetPath": "migrateItemCopyNumberToSingleValue.sql",
-      "fromModuleVersion": "18.2.0"
+      "fromModuleVersion": "19.0.0"
     }
   ]
 }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -723,6 +723,11 @@
       "run": "after",
       "snippetPath": "alterHridSequences.sql",
       "fromModuleVersion": "18.2.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "migrateItemCopyNumberToSingleValue.sql",
+      "fromModuleVersion": "18.2.0"
     }
   ]
 }

--- a/src/main/resources/templates/db_scripts/updateItemStatusDate.sql
+++ b/src/main/resources/templates/db_scripts/updateItemStatusDate.sql
@@ -16,7 +16,6 @@ AS $$
     ELSE
       NEW.jsonb = NEW.jsonb #- '{status, date}';
 	  END IF;
-
 	  RETURN NEW;
   END;
   $$ LANGUAGE 'plpgsql';

--- a/src/main/resources/templates/db_scripts/updateItemStatusDate.sql
+++ b/src/main/resources/templates/db_scripts/updateItemStatusDate.sql
@@ -11,8 +11,13 @@ AS $$
 	    -- Date time in "YYYY-MM-DD"T"HH24:MI:SS.ms'Z'" format at UTC (00:00) time zone
       NEW.jsonb = jsonb_set(NEW.jsonb, '{status,date}',
        to_jsonb(to_char(CURRENT_TIMESTAMP(3) AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.ms"Z"')), true);
+    ELSIF (OLD.jsonb->'status'->'date' IS NOT NULL) THEN
+      NEW.jsonb = jsonb_set(NEW.jsonb, '{status,date}', OLD.jsonb->'status'->'date', true);
+    ELSE
+      NEW.jsonb = NEW.jsonb #- '{status, date}';
 	  END IF;
-	RETURN NEW;
+
+	  RETURN NEW;
   END;
   $$ LANGUAGE 'plpgsql';
 

--- a/src/test/java/org/folio/rest/api/HridSettingsIncreaseMaxValueMigrationTest.java
+++ b/src/test/java/org/folio/rest/api/HridSettingsIncreaseMaxValueMigrationTest.java
@@ -1,6 +1,5 @@
 package org.folio.rest.api;
 
-import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.folio.rest.api.StorageTestSuite.getVertx;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -12,14 +11,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.folio.rest.persist.PostgresClient;
-import org.folio.util.ResourceUtil;
 import org.junit.Test;
 
 import io.vertx.core.json.JsonArray;
 
-public class HridSettingsIncreaseMaxValueMigrationTest extends TestBase {
+public class HridSettingsIncreaseMaxValueMigrationTest extends MigrationTestBase {
   private static final String CREATE_SEQUENCE_SQL = loadCreateSequenceSqlFile();
-  private static final String ALTER_SEQUENCE_SQL = loadAlterSequenceSqlFile();
+  private static final String ALTER_SEQUENCE_SQL = loadScript("alterHridSequences.sql");
   private static final String INSTANCES_SEQ = "hrid_instances_seq";
   private static final String HOLDINGS_SEQ = "hrid_holdings_seq";
   private static final String ITEMS_SEQ = "hrid_items_seq";
@@ -104,17 +102,9 @@ public class HridSettingsIncreaseMaxValueMigrationTest extends TestBase {
   }
 
   private static String loadCreateSequenceSqlFile() {
-    return ResourceUtil.asString("/templates/db_scripts/hridSettings.sql")
-      .replace("${myuniversity}_${mymodule}", getSchemaName())
-      .replace("${table.tableName}", "hrid_settings");
-  }
-
-  private static String loadAlterSequenceSqlFile() {
-    return ResourceUtil.asString("/templates/db_scripts/alterHridSequences.sql")
-      .replace("${myuniversity}_${mymodule}", getSchemaName());
-  }
-
-  private static String getSchemaName() {
-    return String.format("%s_mod_inventory_storage", TENANT_ID);
+    return loadScript("hridSettings.sql",
+      MigrationTestBase::replaceSchema,
+      resource -> resource.replace("${table.tableName}", "hrid_settings")
+    );
   }
 }

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -1633,8 +1633,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     JsonObject updatedInstance = updateInstance(replacement).getJson();
 
     assertThat(updatedInstance.getString(STATUS_UPDATED_DATE_PROPERTY), hasIsoFormat());
+
     assertThat(updatedInstance
-        .getString(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(2)));
+        .getInstant(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(2)));
   }
 
   /**
@@ -1671,9 +1672,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(updatedInstanceWithOthStatus.getString(STATUS_UPDATED_DATE_PROPERTY), hasIsoFormat());
 
     assertThat(updatedInstanceWithCatStatus
-        .getString(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(2)));
+        .getInstant(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(2)));
     assertThat(updatedInstanceWithOthStatus
-        .getString(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(1)));
+        .getInstant(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(1)));
   }
 
   /**
@@ -1708,7 +1709,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(updatedInstanceWithCatStatus.getString(STATUS_UPDATED_DATE_PROPERTY),
       is(updatedAnotherInstanceWithCatStatus.getString(STATUS_UPDATED_DATE_PROPERTY)));
     assertThat(updatedInstanceWithCatStatus
-      .getString(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(2)));
+      .getInstant(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(2)));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/ItemCopyNumberMigrationScriptTest.java
+++ b/src/test/java/org/folio/rest/api/ItemCopyNumberMigrationScriptTest.java
@@ -96,7 +96,7 @@ public class ItemCopyNumberMigrationScriptTest extends MigrationTestBase {
 
     JsonObject itemToCreate = new JsonObject()
       .put("id", UUID.randomUUID().toString())
-      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
+      .put("status", new JsonObject().put("name", "Available"))
       .put("holdingsRecordId", holdingsRecordId.toString())
       .put("barcode", new Random().nextLong())
       .put("materialTypeId", journalMaterialTypeID)

--- a/src/test/java/org/folio/rest/api/ItemCopyNumberMigrationScriptTest.java
+++ b/src/test/java/org/folio/rest/api/ItemCopyNumberMigrationScriptTest.java
@@ -14,7 +14,6 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
-import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.support.IndividualResource;
 import org.junit.Before;
 import org.junit.Test;

--- a/src/test/java/org/folio/rest/api/ItemCopyNumberMigrationScriptTest.java
+++ b/src/test/java/org/folio/rest/api/ItemCopyNumberMigrationScriptTest.java
@@ -1,0 +1,155 @@
+package org.folio.rest.api;
+
+
+import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertFalse;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+
+import org.folio.rest.support.IndividualResource;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.vertx.core.json.JsonObject;
+
+public class ItemCopyNumberMigrationScriptTest extends MigrationTestBase {
+  private static final String MIGRATION_SCRIPT = loadScript("migrateItemCopyNumberToSingleValue.sql");
+
+  @Before
+  public void beforeEach() {
+    StorageTestSuite.deleteAll(itemsStorageUrl(""));
+    StorageTestSuite.deleteAll(holdingsStorageUrl(""));
+    StorageTestSuite.deleteAll(instancesStorageUrl(""));
+  }
+
+  @Test
+  public void canMigrateCopyNumbersToSingleValue() throws Exception {
+    List<IndividualResource> threeItems = createItems(3);
+    UUID[] ids = threeItems.stream().map(IndividualResource::getId).toArray(UUID[]::new);
+
+    setCopyNumbersArray(ids);
+
+    executeMultipleSqlStatements(MIGRATION_SCRIPT);
+
+    assertCopyNumber(ids[0], "cp0");
+    assertCopyNumber(ids[1], "cp1");
+    assertCopyNumber(ids[2], "cp2");
+  }
+
+  @Test
+  public void emptyCopyNumberArrayIsRemoved() throws Exception {
+    List<IndividualResource> fourItems = createItems(4);
+    UUID[] itemIdsWithoutCopyNumbers = {fourItems.get(0).getId(), fourItems.get(2).getId()};
+    UUID[] itemIdsWithCopyNumbers = {fourItems.get(1).getId(), fourItems.get(3).getId()};
+
+    emptyCopyNumberArray(itemIdsWithoutCopyNumbers[0]);
+    emptyCopyNumberArray(itemIdsWithoutCopyNumbers[1]);
+
+    setCopyNumbersArray(itemIdsWithCopyNumbers);
+
+    executeMultipleSqlStatements(MIGRATION_SCRIPT);
+
+    assertCopyNumber(itemIdsWithCopyNumbers[0], "cp0");
+    assertCopyNumber(itemIdsWithCopyNumbers[1], "cp1");
+    assertNoCopyNumber(itemIdsWithoutCopyNumbers[0]);
+    assertNoCopyNumber(itemIdsWithoutCopyNumbers[1]);
+  }
+
+  @Test
+  public void shouldTakeFirstElementFromCopyNumbersArray() throws Exception {
+    List<IndividualResource> sixItems = createItems(6);
+
+    UUID[] itemIdsWithoutCopyNumbers = {sixItems.get(0).getId(), sixItems.get(5).getId()};
+    UUID[] itemIdsWithCopyNumbers = {sixItems.get(1).getId(), sixItems.get(3).getId()};
+    UUID[] itemIdsWithTwoComponentCopyNumbers = {sixItems.get(2).getId(), sixItems.get(4).getId()};
+
+    emptyCopyNumberArray(itemIdsWithoutCopyNumbers[0]);
+    emptyCopyNumberArray(itemIdsWithoutCopyNumbers[1]);
+
+    copyNumberArrayWithTwoValues(itemIdsWithTwoComponentCopyNumbers[0], "cp6");
+    copyNumberArrayWithTwoValues(itemIdsWithTwoComponentCopyNumbers[1], "cp7");
+
+    setCopyNumbersArray(itemIdsWithCopyNumbers);
+
+    executeMultipleSqlStatements(MIGRATION_SCRIPT);
+
+    assertCopyNumber(itemIdsWithCopyNumbers[0], "cp0");
+    assertCopyNumber(itemIdsWithCopyNumbers[1], "cp1");
+    assertCopyNumber(itemIdsWithTwoComponentCopyNumbers[0], "cp6");
+    assertCopyNumber(itemIdsWithTwoComponentCopyNumbers[1], "cp7");
+
+    assertNoCopyNumber(itemIdsWithoutCopyNumbers[0]);
+    assertNoCopyNumber(itemIdsWithoutCopyNumbers[1]);
+  }
+
+  private IndividualResource createItem() throws Exception {
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
+
+    JsonObject itemToCreate = new JsonObject()
+      .put("id", UUID.randomUUID().toString())
+      .put("holdingsRecordId", holdingsRecordId.toString())
+      .put("barcode", new Random().nextLong())
+      .put("materialTypeId", journalMaterialTypeID)
+      .put("permanentLoanTypeId", canCirculateLoanTypeID);
+
+    return itemsClient.create(itemToCreate);
+  }
+
+  private List<IndividualResource> createItems(int count) throws Exception {
+    final List<IndividualResource> allItems = new ArrayList<>();
+
+    for (int i = 0; i < count; i++) {
+      allItems.add(createItem());
+    }
+    return allItems;
+  }
+
+  private void setCopyNumbersArray(UUID... ids) throws Exception {
+    for (int currentIdIndex = 0; currentIdIndex < ids.length; currentIdIndex++) {
+      final UUID id = ids[currentIdIndex];
+      final String copyNumber = "cp" + currentIdIndex;
+
+      updateJsonbProperty("item", id, "copyNumbers",
+        String.format("ARRAY['%s']", copyNumber)
+      );
+    }
+  }
+
+  private void emptyCopyNumberArray(UUID id) throws Exception {
+    updateJsonbProperty("item", id, "copyNumbers",
+      "ARRAY[]::TEXT[]"
+    );
+  }
+
+  private void copyNumberArrayWithTwoValues(UUID id, String copyNumber) throws Exception {
+    final String copyNumberToSet = String.format("'%1$s', '%1$sCopy2'", copyNumber);
+
+    updateJsonbProperty("item", id, "copyNumbers",
+      String.format("ARRAY[%s]", copyNumberToSet)
+    );
+  }
+
+  private void assertCopyNumber(UUID itemId, String expectedCopyNumber) throws Exception {
+    JsonObject item = itemsClient.getById(itemId).getJson();
+
+    assertThat(expectedCopyNumber, notNullValue());
+    assertThat(item.getString("copyNumber"), is(expectedCopyNumber));
+    assertFalse(item.containsKey("copyNumbers"));
+  }
+
+  private void assertNoCopyNumber(UUID itemId) throws Exception {
+    JsonObject item = itemsClient.getById(itemId).getJson();
+
+    assertThat(item, notNullValue());
+    assertFalse(item.containsKey("copyNumbers"));
+    assertFalse(item.containsKey("copyNumber"));
+  }
+}

--- a/src/test/java/org/folio/rest/api/ItemCopyNumberMigrationScriptTest.java
+++ b/src/test/java/org/folio/rest/api/ItemCopyNumberMigrationScriptTest.java
@@ -14,6 +14,7 @@ import java.util.List;
 import java.util.Random;
 import java.util.UUID;
 
+import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.support.IndividualResource;
 import org.junit.Before;
 import org.junit.Test;
@@ -95,6 +96,7 @@ public class ItemCopyNumberMigrationScriptTest extends MigrationTestBase {
 
     JsonObject itemToCreate = new JsonObject()
       .put("id", UUID.randomUUID().toString())
+      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
       .put("holdingsRecordId", holdingsRecordId.toString())
       .put("barcode", new Random().nextLong())
       .put("materialTypeId", journalMaterialTypeID)

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -198,6 +198,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject itemToCreate = new JsonObject()
       .put("id", id.toString())
+      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
       .put("holdingsRecordId", holdingsRecordId.toString())
       .put("materialTypeId", journalMaterialTypeID)
       .put("permanentLoanTypeId", canCirculateLoanTypeID)
@@ -231,6 +232,27 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(tags.size(), is(1));
     assertThat(tags, hasItem(TAG_VALUE));
+  }
+
+  @Test
+  public void canReplaceItemWithNewProperties() throws Exception {
+    final UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
+    final UUID id = UUID.randomUUID();
+    final String expectedCopyNumber = "copy1";
+
+    JsonObject itemToCreate = smallAngryPlanet(id, holdingsRecordId);
+    createItem(itemToCreate);
+
+    JsonObject createdItem = getById(id).getJson();
+    assertThat(createdItem.getString("copyNumber"), nullValue());
+
+    JsonObject updatedItem = createdItem.copy()
+      .put("copyNumber", expectedCopyNumber);
+
+    itemsClient.replace(id, updatedItem);
+
+    JsonObject updatedItemResponse = itemsClient.getById(id).getJson();
+    assertThat(updatedItemResponse.getString("copyNumber"), is(expectedCopyNumber));
   }
 
   @Test
@@ -403,6 +425,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     final JsonObject itemToCreate = new JsonObject()
       .put("id", id.toString())
+      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
       .put("holdingsRecordId", holdingsRecordId.toString())
       .put("materialTypeId", journalMaterialTypeID)
       .put("permanentLoanTypeId", canCirculateLoanTypeID)
@@ -437,6 +460,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject itemToCreate = new JsonObject();
     String itemId = UUID.randomUUID().toString();
     itemToCreate.put("id", itemId);
+    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
@@ -466,6 +490,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject itemToCreate = new JsonObject();
     String itemId = UUID.randomUUID().toString();
     itemToCreate.put("id", itemId);
+    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
@@ -604,6 +629,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject itemToCreate = new JsonObject();
     String itemId = UUID.randomUUID().toString();
     itemToCreate.put("id", itemId);
+    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
@@ -634,6 +660,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     String itemId = UUID.randomUUID().toString();
     itemToCreate.put("id", itemId);
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
+    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
     itemToCreate.put("itemLevelCallNumberPrefix", "testItemCallNumberPrefix");
@@ -770,6 +797,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject itemToCreate = new JsonObject();
     String itemId = UUID.randomUUID().toString();
     itemToCreate.put("id", itemId);
+    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
@@ -799,6 +827,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject itemToCreate = new JsonObject();
     String itemId = UUID.randomUUID().toString();
     itemToCreate.put("id", itemId);
+    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
@@ -831,6 +860,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     final String itemId = UUID.randomUUID().toString();
 
     itemToCreate.put("id", itemId);
+    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
@@ -863,6 +893,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject itemToCreate = new JsonObject()
       .put("id", id)
+      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
       .put("holdingsRecordId", holdingsRecordId.toString())
       .put("materialTypeId", journalMaterialTypeID)
       .put("permanentLoanTypeId", canCirculateLoanTypeID)
@@ -893,6 +924,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject itemToCreate = new JsonObject()
       .put("id", id)
+      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
       .put("holdingsRecordId", holdingsRecordId.toString())
       .put("materialTypeId", journalMaterialTypeID)
       .put("permanentLoanTypeId", canCirculateLoanTypeID)
@@ -952,6 +984,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     UUID id = UUID.randomUUID();
     itemToCreate.put("id", id.toString());
+    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
 
@@ -980,6 +1013,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
     JsonObject itemToCreate = new JsonObject();
     itemToCreate.put("id", UUID.randomUUID().toString());
+    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", UUID.randomUUID().toString());
@@ -1005,10 +1039,11 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     final UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
 
     final JsonObject itemToCreate = new JsonObject()
-        .put("id", UUID.randomUUID().toString())
-        .put("holdingsRecordId", holdingsRecordId.toString())
-        .put("permanentLoanTypeId", canCirculateLoanTypeID)
-        .put("materialTypeId", journalMaterialTypeID);
+      .put("id", UUID.randomUUID().toString())
+      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
+      .put("holdingsRecordId", holdingsRecordId.toString())
+      .put("permanentLoanTypeId", canCirculateLoanTypeID)
+      .put("materialTypeId", journalMaterialTypeID);
 
     setItemSequence(1);
 
@@ -1057,10 +1092,11 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     final UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
 
     final JsonObject itemToCreate = new JsonObject()
-        .put("id", UUID.randomUUID().toString())
-        .put("holdingsRecordId", holdingsRecordId.toString())
-        .put("permanentLoanTypeId", canCirculateLoanTypeID)
-        .put("materialTypeId", journalMaterialTypeID);
+      .put("id", UUID.randomUUID().toString())
+      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
+      .put("holdingsRecordId", holdingsRecordId.toString())
+      .put("permanentLoanTypeId", canCirculateLoanTypeID)
+      .put("materialTypeId", journalMaterialTypeID);
 
     setItemSequence(99_999_999_999L);
 
@@ -1095,6 +1131,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject itemToCreate = new JsonObject();
     String itemId = UUID.randomUUID().toString();
     itemToCreate.put("id", itemId);
+    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
@@ -1122,10 +1159,11 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     final UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
     final String itemId = UUID.randomUUID().toString();
     final JsonObject itemToCreate = new JsonObject()
-        .put("id", itemId)
-        .put("holdingsRecordId", holdingsRecordId.toString())
-        .put("permanentLoanTypeId", canCirculateLoanTypeID)
-        .put("materialTypeId", bookMaterialTypeID);
+      .put("id", itemId)
+      .put("holdingsRecordId", holdingsRecordId.toString())
+      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
+      .put("permanentLoanTypeId", canCirculateLoanTypeID)
+      .put("materialTypeId", bookMaterialTypeID);
 
     setItemSequence(1);
 
@@ -1156,10 +1194,11 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     final UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
     final String itemId = UUID.randomUUID().toString();
     final JsonObject itemToCreate = new JsonObject()
-        .put("id", itemId)
-        .put("holdingsRecordId", holdingsRecordId.toString())
-        .put("permanentLoanTypeId", canCirculateLoanTypeID)
-        .put("materialTypeId", bookMaterialTypeID);
+      .put("id", itemId)
+      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
+      .put("holdingsRecordId", holdingsRecordId.toString())
+      .put("permanentLoanTypeId", canCirculateLoanTypeID)
+      .put("materialTypeId", bookMaterialTypeID);
 
     setItemSequence(1);
 
@@ -1801,27 +1840,6 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canUpdateItemWithCopyNumber() throws Exception {
-    final UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
-    final UUID id = UUID.randomUUID();
-    final String expectedCopyNumber = "copy1";
-
-    JsonObject itemToCreate = smallAngryPlanet(id, holdingsRecordId);
-    createItem(itemToCreate);
-
-    JsonObject createdItem = getById(id).getJson();
-    assertThat(createdItem.getString("copyNumber"), nullValue());
-
-    JsonObject updatedItem = createdItem.copy()
-      .put("copyNumber", expectedCopyNumber);
-
-    itemsClient.replace(id, updatedItem);
-
-    JsonObject updatedItemResponse = itemsClient.getById(id).getJson();
-    assertThat(updatedItemResponse.getString("copyNumber"), is(expectedCopyNumber));
-  }
-
-  @Test
   public void canDeleteAnItem() throws InterruptedException,
     MalformedURLException, TimeoutException, ExecutionException {
 
@@ -2326,13 +2344,44 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canRemoveItemStatus() throws Exception {
+  public void cannotRemoveItemStatus() throws Exception {
     UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
-
     UUID id = UUID.randomUUID();
+
     JsonObject itemToCreate = smallAngryPlanet(id, holdingsRecordId)
-      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
-      .put("hrid", "testHRID");
+      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+
+    createItem(itemToCreate);
+
+    JsonObject createdItem = getById(id).getJson();
+    assertThat(createdItem.getJsonObject("status").getString("name"),
+      is(Status.Name.AVAILABLE.value())
+    );
+
+    JsonObject replacement = itemToCreate.copy();
+    replacement.remove("status");
+
+    CompletableFuture<JsonErrorResponse> updateCompleted = new CompletableFuture<>();
+    client.put(itemsStorageUrl("/" + id), replacement,
+      TENANT_ID, ResponseHandler.jsonErrors(updateCompleted));
+
+    JsonErrorResponse updateResponse = updateCompleted.get(5, TimeUnit.SECONDS);
+    assertThat(updateResponse.getStatusCode(), is(422));
+    assertThat(updateResponse.getErrors().size(), is(1));
+
+    JsonObject error = updateResponse.getErrors().get(0);
+    assertThat(error.getString("message"), is("may not be null"));
+    assertThat(error.getJsonArray("parameters").getJsonObject(0).getString("key"),
+      is("status"));
+  }
+
+  @Test
+  public void cannotRemoveItemStatusName() throws Exception {
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
+    UUID id = UUID.randomUUID();
+
+    JsonObject itemToCreate = smallAngryPlanet(id, holdingsRecordId)
+      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
 
     createItem(itemToCreate);
 
@@ -2344,10 +2393,18 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject replacement = itemToCreate.copy();
     replacement.getJsonObject("status").remove("name");
 
-    itemsClient.replace(id, replacement);
+    CompletableFuture<JsonErrorResponse> updateCompleted = new CompletableFuture<>();
+    client.put(itemsStorageUrl("/" + id), replacement,
+      TENANT_ID, ResponseHandler.jsonErrors(updateCompleted));
 
-    JsonObject updatedItem = getById(id).getJson();
-    assertThat(updatedItem.getJsonObject("status").getString("name"), nullValue());
+    JsonErrorResponse updateResponse = updateCompleted.get(5, TimeUnit.SECONDS);
+    assertThat(updateResponse.getStatusCode(), is(422));
+    assertThat(updateResponse.getErrors().size(), is(1));
+
+    JsonObject error = updateResponse.getErrors().get(0);
+    assertThat(error.getString("message"), is("may not be null"));
+    assertThat(error.getJsonArray("parameters").getJsonObject(0).getString("key"),
+      is("status.name"));
   }
 
   private Response getById(UUID id) throws InterruptedException,

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -2300,6 +2300,31 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     );
   }
 
+  @Test
+  public void canRemoveItemStatus() throws Exception {
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
+
+    UUID id = UUID.randomUUID();
+    JsonObject itemToCreate = smallAngryPlanet(id, holdingsRecordId)
+      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
+      .put("hrid", "testHRID");
+
+    createItem(itemToCreate);
+
+    JsonObject createdItem = getById(id).getJson();
+    assertThat(createdItem.getJsonObject("status").getString("name"),
+      is(Status.Name.AVAILABLE.value())
+    );
+
+    JsonObject replacement = itemToCreate.copy();
+    replacement.getJsonObject("status").remove("name");
+
+    itemsClient.replace(id, replacement);
+
+    JsonObject updatedItem = getById(id).getJson();
+    assertThat(updatedItem.getJsonObject("status").getString("name"), nullValue());
+  }
+
   private Response getById(UUID id) throws InterruptedException,
     ExecutionException, TimeoutException {
 

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -61,7 +61,6 @@ import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.jaxrs.model.Items;
 import org.folio.rest.jaxrs.model.LastCheckIn;
-import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.AdditionalHttpStatusCodes;
 import org.folio.rest.support.IndividualResource;
@@ -1609,7 +1608,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject replacement = itemToCreate.copy();
 
     replacement
-      .put("status", new JsonObject().put("name", Status.Name.CHECKED_OUT.value()));
+      .put("status", new JsonObject().put("name", "Checked out"));
 
     CompletableFuture<Response> replaceCompleted = new CompletableFuture<>();
 
@@ -1629,7 +1628,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(item.getId(), is(id.toString()));
 
     assertThat(item.getStatus().getName(),
-      is(Status.Name.CHECKED_OUT));
+      is("Checked out"));
 
     assertThat(item.getStatus().getDate().toInstant(), withinSecondsBeforeNow(seconds(2)));
   }
@@ -1650,7 +1649,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject replacement = itemToCreate.copy();
 
     replacement
-      .put("status", new JsonObject().put("name", Status.Name.CHECKED_OUT.value()));
+      .put("status", new JsonObject().put("name", "Checked out"));
 
     CompletableFuture<Response> replaceCompleted = new CompletableFuture<>();
 
@@ -1671,7 +1670,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(item.getId(), is(id.toString()));
 
     assertThat(item.getStatus().getName(),
-      is(Status.Name.CHECKED_OUT));
+      is("Checked out"));
 
     assertThat(item.getStatus().getDate(),
       notNullValue());
@@ -1701,7 +1700,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(resultItem.getId(), is(id.toString()));
 
     assertThat(resultItem.getStatus().getName(),
-      is(Status.Name.AVAILABLE));
+      is("Available"));
 
     Instant itemStatusDate = resultItem.getStatus().getDate().toInstant();
 
@@ -1718,14 +1717,14 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     createItem(itemToCreate);
 
     JsonObject itemWithUpdatedStatus = getById(id).getJson().copy()
-      .put("status", new JsonObject().put("name", Status.Name.CHECKED_OUT.value()));
+      .put("status", new JsonObject().put("name", "Checked out"));
 
     itemsClient.replace(id, itemWithUpdatedStatus);
 
     Response updatedItemResponse = itemsClient.getById(id);
     JsonObject updatedStatus = updatedItemResponse.getJson().getJsonObject("status");
 
-    assertThat(updatedStatus.getString("name"), is(Status.Name.CHECKED_OUT.value()));
+    assertThat(updatedStatus.getString("name"), is("Checked out"));
     assertThat(updatedStatus.getString("date"), withinSecondsBeforeNowAsString(seconds(2)));
 
     JsonObject itemWithUpdatedStatusDate = updatedItemResponse.getJson().copy();
@@ -1774,14 +1773,14 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     createItem(itemToCreate);
 
     JsonObject itemWithUpdatedStatus = getById(id).getJson().copy()
-      .put("status", new JsonObject().put("name", Status.Name.CHECKED_OUT.value()));
+      .put("status", new JsonObject().put("name", "Checked out"));
 
     itemsClient.replace(id, itemWithUpdatedStatus);
 
     Response updatedItemResponse = itemsClient.getById(id);
     JsonObject updatedStatus = updatedItemResponse.getJson().getJsonObject("status");
 
-    assertThat(updatedStatus.getString("name"), is(Status.Name.CHECKED_OUT.value()));
+    assertThat(updatedStatus.getString("name"), is("Checked out"));
     assertThat(updatedStatus.getString("date"), withinSecondsBeforeNowAsString(seconds(2)));
 
     JsonObject itemWithUpdatedCallNumber = updatedItemResponse.getJson().copy()

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -59,6 +59,7 @@ import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.jaxrs.model.Items;
 import org.folio.rest.jaxrs.model.LastCheckIn;
+import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.AdditionalHttpStatusCodes;
 import org.folio.rest.support.IndividualResource;
@@ -118,7 +119,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     itemToCreate.put("id", id.toString());
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("barcode", "565578437802");
-    itemToCreate.put("status", new JsonObject().put("name", "Available"));
+    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
     itemToCreate.put("materialTypeId", journalMaterialTypeID);
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("temporaryLocationId", annexLibraryLocationId.toString());
@@ -167,7 +168,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(itemFromGet.getString("holdingsRecordId"), is(holdingsRecordId.toString()));
     assertThat(itemFromGet.getString("barcode"), is("565578437802"));
     assertThat(itemFromGet.getJsonObject("status").getString("name"),
-      is("Available"));
+      is(Status.Name.AVAILABLE.value()));
     assertThat(itemFromGet.getString("materialTypeId"),
       is(journalMaterialTypeID));
     assertThat(itemFromGet.getString("permanentLoanTypeId"),
@@ -222,7 +223,8 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject itemFromGet = getResponse.getJson();
 
     assertThat(itemFromGet.getString("id"), is(id.toString()));
-    assertThat(itemFromGet.getJsonObject("status").getString("name"), is("Available"));
+    assertThat(itemFromGet.getJsonObject("status").getString("name"),
+      is(Status.Name.AVAILABLE.value()));
 
     List<String> tags = itemFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
 
@@ -1566,7 +1568,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject replacement = itemToCreate.copy();
 
     replacement
-      .put("status", new JsonObject().put("name", "Checked out"));
+      .put("status", new JsonObject().put("name", Status.Name.CHECKED_OUT.value()));
 
     CompletableFuture<Response> replaceCompleted = new CompletableFuture<>();
 
@@ -1586,7 +1588,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(item.getId(), is(id.toString()));
 
     assertThat(item.getStatus().getName(),
-      is("Checked out"));
+      is(Status.Name.CHECKED_OUT));
 
     assertThat(item.getStatus().getDate().toInstant(), withinSecondsBeforeNow(seconds(2)));
   }
@@ -1607,7 +1609,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject replacement = itemToCreate.copy();
 
     replacement
-      .put("status", new JsonObject().put("name", "Checked out"));
+      .put("status", new JsonObject().put("name", Status.Name.CHECKED_OUT.value()));
 
     CompletableFuture<Response> replaceCompleted = new CompletableFuture<>();
 
@@ -1628,7 +1630,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(item.getId(), is(id.toString()));
 
     assertThat(item.getStatus().getName(),
-      is("Checked out"));
+      is(Status.Name.CHECKED_OUT));
 
     assertThat(item.getStatus().getDate(),
       notNullValue());
@@ -1658,7 +1660,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(resultItem.getId(), is(id.toString()));
 
     assertThat(resultItem.getStatus().getName(),
-      is("Available"));
+      is(Status.Name.AVAILABLE));
 
     Instant itemStatusDate = resultItem.getStatus().getDate().toInstant();
 
@@ -1675,14 +1677,14 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     createItem(itemToCreate);
 
     JsonObject itemWithUpdatedStatus = getById(id).getJson().copy()
-      .put("status", new JsonObject().put("name", "Checked out"));
+      .put("status", new JsonObject().put("name", Status.Name.CHECKED_OUT.value()));
 
     itemsClient.replace(id, itemWithUpdatedStatus);
 
     Response updatedItemResponse = itemsClient.getById(id);
     JsonObject updatedStatus = updatedItemResponse.getJson().getJsonObject("status");
 
-    assertThat(updatedStatus.getString("name"), is("Checked out"));
+    assertThat(updatedStatus.getString("name"), is(Status.Name.CHECKED_OUT.value()));
     assertThat(updatedStatus.getString("date"), withinSecondsBeforeNowAsString(seconds(2)));
 
     JsonObject itemWithUpdatedStatusDate = updatedItemResponse.getJson().copy();
@@ -1706,14 +1708,14 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     createItem(itemToCreate);
 
     JsonObject itemWithUpdatedStatus = getById(id).getJson().copy()
-      .put("status", new JsonObject().put("name", "Checked out"));
+      .put("status", new JsonObject().put("name", Status.Name.CHECKED_OUT.value()));
 
     itemsClient.replace(id, itemWithUpdatedStatus);
 
     Response updatedItemResponse = itemsClient.getById(id);
     JsonObject updatedStatus = updatedItemResponse.getJson().getJsonObject("status");
 
-    assertThat(updatedStatus.getString("name"), is("Checked out"));
+    assertThat(updatedStatus.getString("name"), is(Status.Name.CHECKED_OUT.value()));
     assertThat(updatedStatus.getString("date"), withinSecondsBeforeNowAsString(seconds(2)));
 
     JsonObject itemWithUpdatedCallNumber = updatedItemResponse.getJson().copy()

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -121,7 +121,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     itemToCreate.put("id", id.toString());
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("barcode", "565578437802");
-    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+    itemToCreate.put("status", new JsonObject().put("name", "Available"));
     itemToCreate.put("materialTypeId", journalMaterialTypeID);
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("temporaryLocationId", annexLibraryLocationId.toString());
@@ -170,7 +170,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(itemFromGet.getString("holdingsRecordId"), is(holdingsRecordId.toString()));
     assertThat(itemFromGet.getString("barcode"), is("565578437802"));
     assertThat(itemFromGet.getJsonObject("status").getString("name"),
-      is(Status.Name.AVAILABLE.value()));
+      is("Available"));
     assertThat(itemFromGet.getString("materialTypeId"),
       is(journalMaterialTypeID));
     assertThat(itemFromGet.getString("permanentLoanTypeId"),
@@ -199,7 +199,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject itemToCreate = new JsonObject()
       .put("id", id.toString())
-      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
+      .put("status", new JsonObject().put("name", "Available"))
       .put("holdingsRecordId", holdingsRecordId.toString())
       .put("materialTypeId", journalMaterialTypeID)
       .put("permanentLoanTypeId", canCirculateLoanTypeID)
@@ -227,7 +227,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(itemFromGet.getString("id"), is(id.toString()));
     assertThat(itemFromGet.getJsonObject("status").getString("name"),
-      is(Status.Name.AVAILABLE.value()));
+      is("Available"));
 
     List<String> tags = itemFromGet.getJsonObject("tags").getJsonArray("tagList").getList();
 
@@ -426,7 +426,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     final JsonObject itemToCreate = new JsonObject()
       .put("id", id.toString())
-      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
+      .put("status", new JsonObject().put("name", "Available"))
       .put("holdingsRecordId", holdingsRecordId.toString())
       .put("materialTypeId", journalMaterialTypeID)
       .put("permanentLoanTypeId", canCirculateLoanTypeID)
@@ -461,7 +461,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject itemToCreate = new JsonObject();
     String itemId = UUID.randomUUID().toString();
     itemToCreate.put("id", itemId);
-    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+    itemToCreate.put("status", new JsonObject().put("name", "Available"));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
@@ -491,7 +491,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject itemToCreate = new JsonObject();
     String itemId = UUID.randomUUID().toString();
     itemToCreate.put("id", itemId);
-    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+    itemToCreate.put("status", new JsonObject().put("name", "Available"));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
@@ -630,7 +630,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject itemToCreate = new JsonObject();
     String itemId = UUID.randomUUID().toString();
     itemToCreate.put("id", itemId);
-    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+    itemToCreate.put("status", new JsonObject().put("name", "Available"));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
@@ -661,7 +661,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     String itemId = UUID.randomUUID().toString();
     itemToCreate.put("id", itemId);
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
-    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+    itemToCreate.put("status", new JsonObject().put("name", "Available"));
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
     itemToCreate.put("itemLevelCallNumberPrefix", "testItemCallNumberPrefix");
@@ -798,7 +798,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject itemToCreate = new JsonObject();
     String itemId = UUID.randomUUID().toString();
     itemToCreate.put("id", itemId);
-    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+    itemToCreate.put("status", new JsonObject().put("name", "Available"));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
@@ -828,7 +828,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject itemToCreate = new JsonObject();
     String itemId = UUID.randomUUID().toString();
     itemToCreate.put("id", itemId);
-    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+    itemToCreate.put("status", new JsonObject().put("name", "Available"));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
@@ -861,7 +861,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     final String itemId = UUID.randomUUID().toString();
 
     itemToCreate.put("id", itemId);
-    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+    itemToCreate.put("status", new JsonObject().put("name", "Available"));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
@@ -894,7 +894,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject itemToCreate = new JsonObject()
       .put("id", id)
-      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
+      .put("status", new JsonObject().put("name", "Available"))
       .put("holdingsRecordId", holdingsRecordId.toString())
       .put("materialTypeId", journalMaterialTypeID)
       .put("permanentLoanTypeId", canCirculateLoanTypeID)
@@ -925,7 +925,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject itemToCreate = new JsonObject()
       .put("id", id)
-      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
+      .put("status", new JsonObject().put("name", "Available"))
       .put("holdingsRecordId", holdingsRecordId.toString())
       .put("materialTypeId", journalMaterialTypeID)
       .put("permanentLoanTypeId", canCirculateLoanTypeID)
@@ -985,7 +985,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     UUID id = UUID.randomUUID();
     itemToCreate.put("id", id.toString());
-    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+    itemToCreate.put("status", new JsonObject().put("name", "Available"));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
 
@@ -1014,7 +1014,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
     JsonObject itemToCreate = new JsonObject();
     itemToCreate.put("id", UUID.randomUUID().toString());
-    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+    itemToCreate.put("status", new JsonObject().put("name", "Available"));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", UUID.randomUUID().toString());
@@ -1041,7 +1041,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     final JsonObject itemToCreate = new JsonObject()
       .put("id", UUID.randomUUID().toString())
-      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
+      .put("status", new JsonObject().put("name", "Available"))
       .put("holdingsRecordId", holdingsRecordId.toString())
       .put("permanentLoanTypeId", canCirculateLoanTypeID)
       .put("materialTypeId", journalMaterialTypeID);
@@ -1094,7 +1094,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     final JsonObject itemToCreate = new JsonObject()
       .put("id", UUID.randomUUID().toString())
-      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
+      .put("status", new JsonObject().put("name", "Available"))
       .put("holdingsRecordId", holdingsRecordId.toString())
       .put("permanentLoanTypeId", canCirculateLoanTypeID)
       .put("materialTypeId", journalMaterialTypeID);
@@ -1132,7 +1132,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject itemToCreate = new JsonObject();
     String itemId = UUID.randomUUID().toString();
     itemToCreate.put("id", itemId);
-    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+    itemToCreate.put("status", new JsonObject().put("name", "Available"));
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     itemToCreate.put("materialTypeId", bookMaterialTypeID);
@@ -1162,7 +1162,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     final JsonObject itemToCreate = new JsonObject()
       .put("id", itemId)
       .put("holdingsRecordId", holdingsRecordId.toString())
-      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
+      .put("status", new JsonObject().put("name", "Available"))
       .put("permanentLoanTypeId", canCirculateLoanTypeID)
       .put("materialTypeId", bookMaterialTypeID);
 
@@ -1196,7 +1196,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     final String itemId = UUID.randomUUID().toString();
     final JsonObject itemToCreate = new JsonObject()
       .put("id", itemId)
-      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()))
+      .put("status", new JsonObject().put("name", "Available"))
       .put("holdingsRecordId", holdingsRecordId.toString())
       .put("permanentLoanTypeId", canCirculateLoanTypeID)
       .put("materialTypeId", bookMaterialTypeID);
@@ -1751,7 +1751,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject createdItem = getById(id).getJson();
     JsonObject initialStatus = createdItem.getJsonObject("status");
 
-    assertThat(initialStatus.getString("name"), is(Status.Name.AVAILABLE.value()));
+    assertThat(initialStatus.getString("name"), is("Available"));
     assertThat(initialStatus.getString("date"), nullValue());
 
     itemsClient.replace(id,
@@ -1762,7 +1762,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     Response updatedItemResponse = itemsClient.getById(id);
     JsonObject updatedStatus = updatedItemResponse.getJson().getJsonObject("status");
 
-    assertThat(updatedStatus.getString("name"), is(Status.Name.AVAILABLE.value()));
+    assertThat(updatedStatus.getString("name"), is("Available"));
     assertThat(updatedStatus.getString("date"), nullValue());
   }
 
@@ -2350,13 +2350,13 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     UUID id = UUID.randomUUID();
 
     JsonObject itemToCreate = smallAngryPlanet(id, holdingsRecordId)
-      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+      .put("status", new JsonObject().put("name", "Available"));
 
     createItem(itemToCreate);
 
     JsonObject createdItem = getById(id).getJson();
     assertThat(createdItem.getJsonObject("status").getString("name"),
-      is(Status.Name.AVAILABLE.value())
+      is("Available")
     );
 
     JsonObject replacement = itemToCreate.copy();
@@ -2382,13 +2382,13 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     UUID id = UUID.randomUUID();
 
     JsonObject itemToCreate = smallAngryPlanet(id, holdingsRecordId)
-      .put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+      .put("status", new JsonObject().put("name", "Available"));
 
     createItem(itemToCreate);
 
     JsonObject createdItem = getById(id).getJson();
     assertThat(createdItem.getJsonObject("status").getString("name"),
-      is(Status.Name.AVAILABLE.value())
+      is("Available")
     );
 
     JsonObject replacement = itemToCreate.copy();

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -1702,6 +1702,31 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  public void cannotSetStatusDate() throws Exception {
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
+    UUID id = UUID.randomUUID();
+    JsonObject itemToCreate = smallAngryPlanet(id, holdingsRecordId);
+    createItem(itemToCreate);
+
+    JsonObject createdItem = getById(id).getJson();
+    JsonObject initialStatus = createdItem.getJsonObject("status");
+
+    assertThat(initialStatus.getString("name"), is(Status.Name.AVAILABLE.value()));
+    assertThat(initialStatus.getString("date"), nullValue());
+
+    itemsClient.replace(id,
+      createdItem.copy()
+        .put("status", initialStatus.put("date", DateTime.now().toString()))
+    );
+
+    Response updatedItemResponse = itemsClient.getById(id);
+    JsonObject updatedStatus = updatedItemResponse.getJson().getJsonObject("status");
+
+    assertThat(updatedStatus.getString("name"), is(Status.Name.AVAILABLE.value()));
+    assertThat(updatedStatus.getString("date"), nullValue());
+  }
+
+  @Test
   public void statusUpdatedDateRemainsAfterUpdate() throws Exception {
     UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
     UUID id = UUID.randomUUID();

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -1627,8 +1627,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(item.getId(), is(id.toString()));
 
-    assertThat(item.getStatus().getName(),
-      is("Checked out"));
+    assertThat(item.getStatus().getName().value(), is("Checked out"));
 
     assertThat(item.getStatus().getDate().toInstant(), withinSecondsBeforeNow(seconds(2)));
   }
@@ -1669,8 +1668,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(item.getId(), is(id.toString()));
 
-    assertThat(item.getStatus().getName(),
-      is("Checked out"));
+    assertThat(item.getStatus().getName().value(), is("Checked out"));
 
     assertThat(item.getStatus().getDate(),
       notNullValue());
@@ -1699,8 +1697,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(resultItem.getId(), is(id.toString()));
 
-    assertThat(resultItem.getStatus().getName(),
-      is("Available"));
+    assertThat(resultItem.getStatus().getName().value(), is("Available"));
 
     Instant itemStatusDate = resultItem.getStatus().getDate().toInstant();
 

--- a/src/test/java/org/folio/rest/api/LoanTypeTest.java
+++ b/src/test/java/org/folio/rest/api/LoanTypeTest.java
@@ -20,7 +20,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.support.AdditionalHttpStatusCodes;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;

--- a/src/test/java/org/folio/rest/api/LoanTypeTest.java
+++ b/src/test/java/org/folio/rest/api/LoanTypeTest.java
@@ -335,7 +335,7 @@ public class LoanTypeTest extends TestBaseWithInventoryUtil {
   private static String createItem(UUID holdingsRecordId, String permanentLoanTypeId, String temporaryLoanTypeId) {
     JsonObject item = new JsonObject();
 
-    item.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+    item.put("status", new JsonObject().put("name", "Available"));
     item.put("holdingsRecordId", holdingsRecordId.toString());
     item.put("barcode", "12345");
     item.put("materialTypeId", materialTypeID);

--- a/src/test/java/org/folio/rest/api/LoanTypeTest.java
+++ b/src/test/java/org/folio/rest/api/LoanTypeTest.java
@@ -20,6 +20,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.support.AdditionalHttpStatusCodes;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
@@ -334,6 +335,7 @@ public class LoanTypeTest extends TestBaseWithInventoryUtil {
   private static String createItem(UUID holdingsRecordId, String permanentLoanTypeId, String temporaryLoanTypeId) {
     JsonObject item = new JsonObject();
 
+    item.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
     item.put("holdingsRecordId", holdingsRecordId.toString());
     item.put("barcode", "12345");
     item.put("materialTypeId", materialTypeID);

--- a/src/test/java/org/folio/rest/api/LocationsTest.java
+++ b/src/test/java/org/folio/rest/api/LocationsTest.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.support.AdditionalHttpStatusCodes;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
@@ -344,6 +345,8 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
 
   private JsonObject createItemRequest(String holdingsRecordId, String temporaryLocationId) {
     JsonObject item = new JsonObject();
+
+    item.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
     item.put("holdingsRecordId", holdingsRecordId);
     item.put("barcode", "12345");
     item.put("permanentLoanTypeId", canCirculateLoanTypeID);

--- a/src/test/java/org/folio/rest/api/LocationsTest.java
+++ b/src/test/java/org/folio/rest/api/LocationsTest.java
@@ -346,7 +346,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
   private JsonObject createItemRequest(String holdingsRecordId, String temporaryLocationId) {
     JsonObject item = new JsonObject();
 
-    item.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+    item.put("status", new JsonObject().put("name", "Available"));
     item.put("holdingsRecordId", holdingsRecordId);
     item.put("barcode", "12345");
     item.put("permanentLoanTypeId", canCirculateLoanTypeID);

--- a/src/test/java/org/folio/rest/api/LocationsTest.java
+++ b/src/test/java/org/folio/rest/api/LocationsTest.java
@@ -24,7 +24,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
-import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.support.AdditionalHttpStatusCodes;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;

--- a/src/test/java/org/folio/rest/api/MaterialTypeTest.java
+++ b/src/test/java/org/folio/rest/api/MaterialTypeTest.java
@@ -7,6 +7,8 @@ import io.vertx.core.http.HttpClientRequest;
 import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
+
+import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.support.*;
 import org.folio.rest.support.client.LoanTypesClient;
 import org.junit.Assert;
@@ -357,6 +359,7 @@ public class MaterialTypeTest extends TestBaseWithInventoryUtil {
     JsonObject item = new JsonObject();
 
     item.put("barcode", "12345");
+    item.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
     item.put("holdingsRecordId", holdingsRecordId);
     item.put("materialTypeId", materialTypeId);
     item.put("permanentLoanTypeId", canCirculateLoanTypeID);

--- a/src/test/java/org/folio/rest/api/MaterialTypeTest.java
+++ b/src/test/java/org/folio/rest/api/MaterialTypeTest.java
@@ -359,7 +359,7 @@ public class MaterialTypeTest extends TestBaseWithInventoryUtil {
     JsonObject item = new JsonObject();
 
     item.put("barcode", "12345");
-    item.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+    item.put("status", new JsonObject().put("name", "Available"));
     item.put("holdingsRecordId", holdingsRecordId);
     item.put("materialTypeId", materialTypeId);
     item.put("permanentLoanTypeId", canCirculateLoanTypeID);

--- a/src/test/java/org/folio/rest/api/MaterialTypeTest.java
+++ b/src/test/java/org/folio/rest/api/MaterialTypeTest.java
@@ -8,7 +8,6 @@ import io.vertx.core.http.HttpClientResponse;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 
-import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.support.*;
 import org.folio.rest.support.client.LoanTypesClient;
 import org.junit.Assert;

--- a/src/test/java/org/folio/rest/api/MigrationTestBase.java
+++ b/src/test/java/org/folio/rest/api/MigrationTestBase.java
@@ -1,0 +1,99 @@
+package org.folio.rest.api;
+
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
+
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+import java.util.function.UnaryOperator;
+
+import org.folio.rest.persist.PostgresClient;
+import org.folio.util.ResourceUtil;
+
+import io.vertx.core.Vertx;
+
+abstract class MigrationTestBase extends TestBaseWithInventoryUtil {
+  static String loadScript(String scriptName) {
+    return loadScript(scriptName, MigrationTestBase::replaceSchema);
+  }
+
+  @SafeVarargs
+  static String loadScript(String scriptName, UnaryOperator<String>... replacementFunctions) {
+    String resource = ResourceUtil.asString("/templates/db_scripts/" + scriptName);
+
+    for (UnaryOperator<String> replacementFunction : replacementFunctions) {
+      resource = replacementFunction.apply(resource);
+    }
+
+    return resource;
+  }
+
+  static String getSchemaName() {
+    return String.format("%s_mod_inventory_storage", TENANT_ID);
+  }
+
+  static String replaceSchema(String resource) {
+    return resource.replace("${myuniversity}_${mymodule}", getSchemaName());
+  }
+
+  /**
+   * Executes multiply SQL statements separated by a line separator (either CRLF|CR|LF).
+   *
+   * @param allStatements - Statements to execute (separated by a line separator).
+   * @throws InterruptedException
+   * @throws ExecutionException
+   * @throws TimeoutException
+   */
+  void executeMultipleSqlStatements(String allStatements)
+    throws InterruptedException, ExecutionException, TimeoutException {
+
+    final CompletableFuture<Void> result = new CompletableFuture<>();
+    final Vertx vertx = StorageTestSuite.getVertx();
+
+    PostgresClient.getInstance(vertx).runSQLFile(allStatements, true, handler -> {
+      if (handler.failed()) {
+        result.completeExceptionally(handler.cause());
+      } else if (!handler.result().isEmpty()) {
+        result.completeExceptionally(new RuntimeException("Failing SQL: " + handler.result().toString()));
+      } else {
+        result.complete(null);
+      }
+    });
+
+    result.get(5, SECONDS);
+  }
+
+  void executeSql(String sql)
+    throws InterruptedException, ExecutionException, TimeoutException {
+
+    final CompletableFuture<Void> result = new CompletableFuture<>();
+    final Vertx vertx = StorageTestSuite.getVertx();
+
+    PostgresClient.getInstance(vertx).execute(sql, updateResult -> {
+      if (updateResult.failed()) {
+        result.completeExceptionally(updateResult.cause());
+      } else {
+        result.complete(null);
+      }
+    });
+
+    result.get(5, SECONDS);
+  }
+
+  void updateJsonbProperty(
+    String tableName, UUID id, String postgresPropertyPath, String postgresPropertyValue)
+    throws InterruptedException, ExecutionException, TimeoutException {
+
+    executeSql(String.format(
+      "UPDATE %s.%s as tbl SET jsonb = jsonb_set(tbl.jsonb, '{%s}', to_jsonb(%s)) WHERE id::text = '%s'",
+      getSchemaName(),
+      tableName,
+      postgresPropertyPath,
+      postgresPropertyValue,
+      id.toString()
+    ));
+  }
+}

--- a/src/test/java/org/folio/rest/api/TestBase.java
+++ b/src/test/java/org/folio/rest/api/TestBase.java
@@ -79,48 +79,4 @@ public abstract class TestBase {
       throw new RuntimeException(e);
     }
   }
-
-  /**
-   * Executes multiply SQL statements separated by a line separator (either CRLF|CR|LF).
-   *
-   * @param allStatements - Statements to execute (separated by a line separator).
-   * @throws InterruptedException
-   * @throws ExecutionException
-   * @throws TimeoutException
-   */
-  void executeMultipleSqlStatements(String allStatements)
-    throws InterruptedException, ExecutionException, TimeoutException {
-
-    final CompletableFuture<Void> result = new CompletableFuture<>();
-    final Vertx vertx = StorageTestSuite.getVertx();
-
-    PostgresClient.getInstance(vertx).runSQLFile(allStatements, true, handler -> {
-      if (handler.failed()) {
-        result.completeExceptionally(handler.cause());
-      } else if (!handler.result().isEmpty()) {
-        result.completeExceptionally(new RuntimeException("Failing SQL: " + handler.result().toString()));
-      } else {
-        result.complete(null);
-      }
-    });
-
-    result.get(5, SECONDS);
-  }
-
-  void executeSql(String sql)
-    throws InterruptedException, ExecutionException, TimeoutException {
-
-    final CompletableFuture<Void> result = new CompletableFuture<>();
-    final Vertx vertx = StorageTestSuite.getVertx();
-
-    PostgresClient.getInstance(vertx).execute(sql, updateResult -> {
-      if (updateResult.failed()) {
-        result.completeExceptionally(updateResult.cause());
-      } else {
-        result.complete(null);
-      }
-    });
-
-    result.get(5, SECONDS);
-  }
 }

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -218,7 +218,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     itemToCreate.put("id", UUID.randomUUID().toString());
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("barcode", Long.toString(new Random().nextLong()));
-    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
+    itemToCreate.put("status", new JsonObject().put("name", "Available"));
     itemToCreate.put("materialTypeId", journalMaterialTypeID);
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     if (tempLocation != null) {

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
@@ -217,7 +218,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     itemToCreate.put("id", UUID.randomUUID().toString());
     itemToCreate.put("holdingsRecordId", holdingsRecordId.toString());
     itemToCreate.put("barcode", Long.toString(new Random().nextLong()));
-    itemToCreate.put("status", new JsonObject().put("name", "Available"));
+    itemToCreate.put("status", new JsonObject().put("name", Status.Name.AVAILABLE.value()));
     itemToCreate.put("materialTypeId", journalMaterialTypeID);
     itemToCreate.put("permanentLoanTypeId", canCirculateLoanTypeID);
     if (tempLocation != null) {

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.folio.rest.jaxrs.model.Item;
-import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;

--- a/src/test/java/org/folio/rest/support/matchers/ResponseMatcher.java
+++ b/src/test/java/org/folio/rest/support/matchers/ResponseMatcher.java
@@ -2,14 +2,15 @@ package org.folio.rest.support.matchers;
 
 import java.util.Objects;
 
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.support.Response;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
 import io.vertx.core.json.DecodeException;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 
 public class ResponseMatcher {
 
@@ -24,19 +25,16 @@ public class ResponseMatcher {
         }
 
         try {
-          JsonArray errors = response.getJson().getJsonArray("errors");
-          if (errors != null && errors.size() == 1) {
-            JsonObject error = errors.getJsonObject(0);
-            JsonArray parameters = error.getJsonArray("parameters");
+          Errors errors = response.getJson().mapTo(Errors.class);
+          if (errors.getErrors().size() == 1) {
+            final Error error = errors.getErrors().get(0);
 
-            if (parameters != null && parameters.size() == 1) {
-              String message = error.getString("message");
-              String key = parameters.getJsonObject(0).getString("key");
-              String value = parameters.getJsonObject(0).getString("value");
+            if (error.getParameters() != null && error.getParameters().size() == 1) {
+              final Parameter parameter = error.getParameters().get(0);
 
-              return Objects.equals(expectedMessage, message)
-                && Objects.equals(expectedKey, key)
-                && Objects.equals(expectedValue, value);
+              return Objects.equals(expectedMessage, error.getMessage())
+                && Objects.equals(expectedKey, parameter.getKey())
+                && Objects.equals(expectedValue, parameter.getValue());
             }
           }
 

--- a/src/test/java/org/folio/rest/support/matchers/ResponseMatcher.java
+++ b/src/test/java/org/folio/rest/support/matchers/ResponseMatcher.java
@@ -1,0 +1,58 @@
+package org.folio.rest.support.matchers;
+
+import java.util.Objects;
+
+import org.folio.rest.support.Response;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import io.vertx.core.json.DecodeException;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class ResponseMatcher {
+
+  public static Matcher<Response> hasValidationError(
+    String expectedMessage, String expectedKey, String expectedValue) {
+
+    return new TypeSafeMatcher<Response>() {
+      @Override
+      protected boolean matchesSafely(Response response) {
+        if (response.getStatusCode() != 422) {
+          return false;
+        }
+
+        try {
+          JsonArray errors = response.getJson().getJsonArray("errors");
+          if (errors != null && errors.size() == 1) {
+            JsonObject error = errors.getJsonObject(0);
+            JsonArray parameters = error.getJsonArray("parameters");
+
+            if (parameters != null && parameters.size() == 1) {
+              String message = error.getString("message");
+              String key = parameters.getJsonObject(0).getString("key");
+              String value = parameters.getJsonObject(0).getString("value");
+
+              return Objects.equals(expectedMessage, message)
+                && Objects.equals(expectedKey, key)
+                && Objects.equals(expectedValue, value);
+            }
+          }
+
+          return false;
+        } catch (DecodeException ex) {
+          return false;
+        }
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description
+          .appendText("Response has 422 status and 'message' - ").appendValue(expectedMessage)
+          .appendText(", 'key' - ").appendValue(expectedKey)
+          .appendText(" and 'value' - ").appendValue(expectedValue);
+      }
+    };
+  }
+}


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-332: Item: Change array copyNumbers to simple property copyNumber (breaking)
https://issues.folio.org/browse/MODINVSTOR-283: Restrict item states
https://issues.folio.org/browse/MODINVSTOR-392: Make item.status.date read only field.
https://issues.folio.org/browse/MODINVSTOR-425: Make item.status required.

Item-storage 8.0 breaking changes.