### PR TITLE
RMB 29.2.2: Upgrade indexes on module upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>29.2.1</raml-module-builder-version>
+    <raml-module-builder-version>29.2.2</raml-module-builder-version>
     <argLine />
   </properties>
 


### PR DESCRIPTION
Update RAML Module Builder (RMB) from 29.2.1 to 29.2.2 to get this fix:

[RMB-550](https://issues.folio.org/browse/RMB-550) Index recreation on module upgrade.

All indexes will be recreated on module upgrade, this may take long. This is needed for
[RMB-498](https://issues.folio.org/browse/RMB-498) and other index changes linked in
[MODINVSTOR-424](https://issues.folio.org/browse/MODINVSTOR-424) when an existing installation is upgraded.