### PR TITLE
Release 18.2.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 18.2.3 2020-01-10
+
+* Upgrades to RAML Module Builder 29.2.2 to upgrade indexes on module upgrade ([MODINVSTOR-430](https://issues.folio.org/browse/MODINVSTOR-430), [RMB-550](https://issues.folio.org/browse/RMB-550))
+
 ## 18.2.2 2020-01-09
 
 * Upgrades to RAML Module Builder 29.2.1 (MODINVSTOR-429, RMB-549)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>18.2.3</version>
+  <version>18.2.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -107,7 +107,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>v18.2.3</tag>
+    <tag>v18.2.0</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>29.2.1</raml-module-builder-version>
+    <raml-module-builder-version>29.2.2</raml-module-builder-version>
     <argLine />
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>18.2.3-SNAPSHOT</version>
+  <version>18.2.3</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -107,7 +107,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>v18.2.0</tag>
+    <tag>v18.2.3</tag>
   </scm>
 
   <build>


### PR DESCRIPTION
Update RAML Module Builder (RMB) from 29.2.1 to 29.2.2 to get this fix:

[MODINVSTOR-430](https://issues.folio.org/browse/MODINVSTOR-430)
[RMB-550](https://issues.folio.org/browse/RMB-550) Index recreation on module upgrade.

All indexes will be recreated on module upgrade, this may take long. This is needed for
[RMB-498](https://issues.folio.org/browse/RMB-498) and other index changes linked in
[MODINVSTOR-424](https://issues.folio.org/browse/MODINVSTOR-424) when an existing installation is upgraded.
