### PR TITLE
MODINVSTOR-435: Add indexes for callNumber and accessionNumber.

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -582,6 +582,14 @@
           "fieldName": "hrid",
           "tOps": "ADD"
         }
+      ],
+      "index": [
+        {
+          "fieldName": "callNumber",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
+        }
       ]
     },
     {
@@ -641,6 +649,12 @@
         }
       ],
       "index": [
+        {
+          "fieldName": "accessionNumber",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
+        },
         {
           "fieldName": "barcode",
           "tOps": "ADD",


### PR DESCRIPTION
Accents are not removed because they are relevant for libraries that use them.