### PR TITLE
MODINVSTOR-433: Add 'Claimed returned' to allowed item statuses list.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "item-storage",
-      "version": "8.0",
+      "version": "8.1",
       "handlers": [
         {
           "methods": ["GET"],
@@ -35,7 +35,7 @@
     },
     {
       "id": "item-storage-batch-sync",
-      "version": "0.2",
+      "version": "0.3",
       "handlers": [
         {
           "methods": ["POST"],

--- a/ramls/item-storage.raml
+++ b/ramls/item-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Item Storage
-version: v8.0
+version: v8.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item-sync.raml
+++ b/ramls/item-sync.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Storage Item Batch Sync API
-version: v0.2
+version: v0.3
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -231,7 +231,8 @@
             "On order",
             "Paged",
             "Declared lost",
-            "Order closed"
+            "Order closed",
+            "Claim returned"
           ]
         },
         "date": {

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -232,7 +232,7 @@
             "Paged",
             "Declared lost",
             "Order closed",
-            "Claim returned"
+            "Claimed returned"
           ]
         },
         "date": {

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -2,6 +2,8 @@ package org.folio.rest.api;
 
 import static java.net.HttpURLConnection.HTTP_INTERNAL_ERROR;
 import static java.net.HttpURLConnection.HTTP_OK;
+import static java.nio.file.Files.readAllBytes;
+import static java.nio.file.Paths.get;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.HttpStatus.HTTP_CREATED;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
@@ -40,15 +42,18 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
@@ -1921,27 +1926,37 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   @Parameters(method = "getAllowedItemStatuses")
-  public void canCreateItemWithAllAllowedStatuses(Status.Name status) throws Exception {
+  public void canCreateItemWithAllAllowedStatuses(String status) throws Exception {
     final UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
 
     final ItemRequestBuilder itemToCreate = new ItemRequestBuilder()
       .forHolding(holdingsRecordId)
       .withMaterialType(journalMaterialTypeId)
       .withPermanentLoanType(canCirculateLoanTypeId)
-      .withStatus(status.value());
+      .withStatus(status);
 
     final IndividualResource createdItem = itemsClient.create(itemToCreate);
-    assertThat(createdItem.getJson().getJsonObject("status").getString("name"),
-      is(status.value()));
+    assertThat(createdItem.getJson().getJsonObject("status")
+      .getString("name"), is(status));
 
     JsonObject itemInStorage = itemsClient.getById(createdItem.getId()).getJson();
-    assertThat(itemInStorage.getJsonObject("status").getString("name"),
-      is(status.value()));
+    assertThat(itemInStorage.getJsonObject("status").getString("name"), is(status));
   }
 
   @SuppressWarnings("unused")
-  private Status.Name[] getAllowedItemStatuses() {
-    return Status.Name.values();
+  private Set<String> getAllowedItemStatuses() throws IOException {
+    final String itemJson = new String(readAllBytes(get("ramls/item.json")),
+      StandardCharsets.UTF_8);
+
+    final JsonObject itemSchema = new JsonObject(itemJson);
+
+    JsonArray allowedStatuses = itemSchema.getJsonObject("properties")
+      .getJsonObject("status").getJsonObject("properties")
+      .getJsonObject("name").getJsonArray("enum");
+
+    return allowedStatuses.stream()
+      .map(element -> (String) element)
+      .collect(Collectors.toSet());
   }
 
   private Response getById(UUID id) throws InterruptedException,


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-433: Backend: Claim returned: mark an item claim returned.

* Add `Claimed returned` to allowed item statuses list.
* Update `item-storage` and `item-sync` API versions.