### PR TITLE
MODINVSTOR-449: Set default value for instance.discoverySuppress=false

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -88,7 +88,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "7.3",
+      "version": "7.4",
       "handlers": [
         {
           "methods": ["GET"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -88,7 +88,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "7.2",
+      "version": "7.3",
       "handlers": [
         {
           "methods": ["GET"],
@@ -155,7 +155,7 @@
     },
     {
       "id": "instance-storage-batch",
-      "version": "0.2",
+      "version": "0.3",
       "handlers": [
         {
           "methods": ["POST"],
@@ -166,7 +166,7 @@
     },
     {
       "id": "instance-storage-batch-sync",
-      "version": "0.1",
+      "version": "0.2",
       "handlers": [
         {
           "methods": ["POST"],

--- a/ramls/instance-storage-batch.raml
+++ b/ramls/instance-storage-batch.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Deprecated Inventory Storage Instance Batch API
-version: v0.2
+version: v0.3
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/instance-storage.raml
+++ b/ramls/instance-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Instance Storage
-version: v7.3
+version: v7.4
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/instance-storage.raml
+++ b/ramls/instance-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Instance Storage
-version: v7.2
+version: v7.3
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/instance-sync.raml
+++ b/ramls/instance-sync.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Storage Instance Batch Sync API
-version: v0.1
+version: v0.2
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -296,7 +296,8 @@
     },
     "discoverySuppress": {
       "type": "boolean",
-      "description": "Records the fact that the record should not be displayed in a discovery system"
+      "description": "Records the fact that the record should not be displayed in a discovery system",
+      "default": false
     },
     "statisticalCodeIds": {
       "type": "array",

--- a/src/main/resources/templates/db_scripts/populateDiscoverySuppressIfNotSet.sql
+++ b/src/main/resources/templates/db_scripts/populateDiscoverySuppressIfNotSet.sql
@@ -1,0 +1,3 @@
+UPDATE ${myuniversity}_${mymodule}.instance
+SET	jsonb = JSONB_SET(instance.jsonb, '{discoverySuppress}', TO_JSONB(false))
+WHERE jsonb->>'discoverySuppress' IS NULL;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -747,6 +747,11 @@
       "run": "after",
       "snippetPath": "renameModesOfIssuance.sql",
       "fromModuleVersion": "19.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "populateDiscoverySuppressIfNotSet.sql",
+      "fromModuleVersion": "19.0.0"
     }
   ]
 }

--- a/src/test/java/org/folio/rest/api/InstanceDiscoverySuppressMigrationScriptTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceDiscoverySuppressMigrationScriptTest.java
@@ -1,0 +1,106 @@
+package org.folio.rest.api;
+
+import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import java.net.MalformedURLException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeoutException;
+
+import org.folio.rest.jaxrs.model.Instance;
+import org.folio.rest.support.IndividualResource;
+import org.junit.Before;
+import org.junit.Test;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class InstanceDiscoverySuppressMigrationScriptTest extends MigrationTestBase {
+  private static final String DISCOVERY_SUPPRESS = "discoverySuppress";
+  private static final String MIGRATION_SCRIPT
+    = loadScript("populateDiscoverySuppressIfNotSet.sql");
+
+  @Before
+  public void beforeEach() {
+    StorageTestSuite.deleteAll(instancesStorageUrl(""));
+  }
+
+  @Test
+  public void canSetDiscoverySuppressIfNotPresent() throws Exception {
+    List<IndividualResource> allInstances = createInstances(3);
+
+    for (IndividualResource instance : allInstances) {
+      assertThat(unsetJsonbProperty("instance", instance.getId(),
+        DISCOVERY_SUPPRESS).getUpdated(), is(1));
+    }
+
+    executeMultipleSqlStatements(MIGRATION_SCRIPT);
+
+    verifyNotSuppressed(allInstances);
+  }
+
+  @Test
+  public void discoverySuppressedInstancesAreNotUpdated() throws Exception {
+    List<IndividualResource> notSuppressedInstances = createInstances(2);
+    List<IndividualResource> suppressedInstances = new ArrayList<>(2);
+
+    suppressedInstances.add(
+      instancesClient.create(smallAngryPlanetSuppressedFromDiscovery()));
+    suppressedInstances.add(
+      instancesClient.create(smallAngryPlanetSuppressedFromDiscovery()));
+
+    for (IndividualResource instance : notSuppressedInstances) {
+      assertThat(unsetJsonbProperty("instance", instance.getId(),
+        DISCOVERY_SUPPRESS).getUpdated(), is(1));
+    }
+
+    executeMultipleSqlStatements(MIGRATION_SCRIPT);
+
+    verifyNotSuppressed(notSuppressedInstances);
+    verifySuppressed(suppressedInstances);
+  }
+
+  private List<IndividualResource> createInstances(int count) throws Exception {
+    final List<IndividualResource> allInstances = new ArrayList<>();
+
+    for (int i = 0; i < count; i++) {
+      allInstances.add(instancesClient.create(smallAngryPlanet()));
+    }
+    return allInstances;
+  }
+
+  private JsonObject smallAngryPlanet() {
+    return createInstanceRequest(UUID.randomUUID(), "TEST",
+      "Long Way to a Small Angry Planet", new JsonArray(), new JsonArray(),
+      UUID_INSTANCE_TYPE, new JsonArray());
+  }
+
+  private JsonObject smallAngryPlanetSuppressedFromDiscovery() {
+    return smallAngryPlanet()
+      .put(DISCOVERY_SUPPRESS, true);
+  }
+
+  private void verifyNotSuppressed(List<IndividualResource> instances)
+    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+
+    for (IndividualResource instance : instances) {
+      Instance instanceInStorage = instancesClient.getById(instance.getId()).getJson()
+        .mapTo(Instance.class);
+      assertThat(instanceInStorage.getDiscoverySuppress(), is(false));
+    }
+  }
+
+  private void verifySuppressed(List<IndividualResource> instances)
+    throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
+
+    for (IndividualResource instance : instances) {
+      Instance instanceInStorage = instancesClient.getById(instance.getId()).getJson()
+        .mapTo(Instance.class);
+      assertThat(instanceInStorage.getDiscoverySuppress(), is(true));
+    }
+  }
+}

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -74,7 +74,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   private static final String TAG_VALUE = "test-tag";
   private static final String STATUS_UPDATED_DATE_PROPERTY = "statusUpdatedDate";
   private static final Logger log = LoggerFactory.getLogger(InstanceStorageTest.class);
-
+  private static final String DISCOVERY_SUPPRESS = "discoverySuppress";
 
   private Set<String> natureOfContentIdsToRemoveAfterTest = new HashSet<>();
 
@@ -110,11 +110,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canCreateAnInstance()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+  public void canCreateAnInstance() throws InterruptedException,
+    ExecutionException, TimeoutException {
 
     UUID id = UUID.randomUUID();
     NatureOfContentTerm journalContentType = createNatureOfContentTerm("journal_test");
@@ -147,6 +144,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(identifiers, hasItem(identifierMatches(UUID_ISBN.toString(), "9781473619777")));
     assertThat(instance.getJsonArray("natureOfContentTermIds"),
       containsInAnyOrder(natureOfContentIds));
+    assertThat(instance.getBoolean(DISCOVERY_SUPPRESS), is(false));
 
     Response getResponse = getById(id);
 
@@ -169,6 +167,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       containsInAnyOrder(natureOfContentIds));
     assertThat(
       instanceFromGet.getString(STATUS_UPDATED_DATE_PROPERTY), nullValue());
+    assertThat(instanceFromGet.getBoolean(DISCOVERY_SUPPRESS), is(false));
   }
 
   @Test
@@ -355,6 +354,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(itemFromGet.getString("title"), is("A Long Way to a Small Angry Planet"));
     assertThat(itemFromGet.getString(STATUS_UPDATED_DATE_PROPERTY),
       is(replacement.getString(STATUS_UPDATED_DATE_PROPERTY)));
+    assertThat(itemFromGet.getBoolean(DISCOVERY_SUPPRESS), is(false));
   }
 
   @Test
@@ -1506,10 +1506,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void canCreateACollectionOfInstances()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+    throws InterruptedException, ExecutionException, TimeoutException {
 
     JsonArray instancesArray = new JsonArray();
     int numberOfInstances = 1000;
@@ -1538,14 +1535,13 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     JsonArray instances = instancesResponse.getJsonArray(INSTANCES_KEY);
     assertThat(instances.size(), is(numberOfInstances));
     assertThat(instances.getJsonObject(1).getJsonObject(METADATA_KEY), notNullValue());
+
+    assertNotSuppressedFromDiscovery(instances);
   }
 
   @Test
   public void canCreateInstancesEvenIfSomeFailed()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+    throws InterruptedException, ExecutionException, TimeoutException {
 
     JsonObject correctInstance = smallAngryPlanet(null);
     JsonObject errorInstance = smallAngryPlanet(null).put("modeOfIssuanceId", UUID.randomUUID().toString());
@@ -1574,6 +1570,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     JsonArray instances = instancesResponse.getJsonArray(INSTANCES_KEY);
     assertThat(instances.size(), is(2));
+
+    assertNotSuppressedFromDiscovery(instances);
   }
 
   @Test
@@ -1736,6 +1734,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertExists(uprooted);
     assertExists(smallAngryPlanet);
     assertExists(temeraire);
+
+    assertNotSuppressedFromDiscovery(instancesArray);
   }
 
   @Test
@@ -2297,6 +2297,74 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     log.info("Finished cannotCreateACollectionOfInstancesWithHRIDFailure");
   }
 
+  @Test
+  public void canPostSynchronousBatchWithDiscoverySuppressedInstances() throws Exception {
+    final JsonArray instancesArray = new JsonArray();
+    final UUID smallAngryPlanetId = UUID.randomUUID();
+    final UUID uprootedId = UUID.randomUUID();
+
+    instancesArray.add(uprooted(uprootedId));
+    instancesArray.add(smallAngryPlanet(smallAngryPlanetId)
+      .put(DISCOVERY_SUPPRESS, true));
+
+    final JsonObject instanceCollection = new JsonObject().put(INSTANCES_KEY,
+      instancesArray);
+
+    final CompletableFuture<Response> createCompleted = new CompletableFuture<>();
+    client.post(instancesStorageSyncUrl(""), instanceCollection, TENANT_ID,
+      ResponseHandler.empty(createCompleted));
+
+    assertThat(createCompleted.get(30, SECONDS), statusCodeIs(HttpStatus.HTTP_CREATED));
+
+    assertSuppressedFromDiscovery(smallAngryPlanetId.toString());
+    assertNotSuppressedFromDiscovery(uprootedId.toString());
+  }
+
+  @Test
+  public void canPostInstanceStorageBatchWithDiscoverySuppressedInstances() throws Exception {
+    final JsonArray instancesArray = new JsonArray();
+    final UUID smallAngryPlanetId = UUID.randomUUID();
+    final UUID uprootedId = UUID.randomUUID();
+
+    instancesArray.add(uprooted(uprootedId));
+    instancesArray.add(smallAngryPlanet(smallAngryPlanetId)
+      .put(DISCOVERY_SUPPRESS, true));
+
+    final JsonObject instanceCollection = new JsonObject()
+      .put(INSTANCES_KEY, instancesArray)
+      .put(TOTAL_RECORDS_KEY, 2);
+
+    final CompletableFuture<Response> createCompleted = new CompletableFuture<>();
+    client.post(instancesStorageBatchInstancesUrl(StringUtils.EMPTY),
+      instanceCollection, TENANT_ID, json(createCompleted));
+
+    final Response response = createCompleted.get(5, SECONDS);
+
+    assertThat(response.getStatusCode(), is(201));
+    assertSuppressedFromDiscovery(smallAngryPlanetId.toString());
+    assertNotSuppressedFromDiscovery(uprootedId.toString());
+  }
+
+  @Test
+  public void canPostDiscoverySuppressedInstance() throws Exception {
+    IndividualResource instance = createInstance(smallAngryPlanet(UUID.randomUUID())
+      .put(DISCOVERY_SUPPRESS, true));
+
+    assertThat(instance.getJson().getBoolean(DISCOVERY_SUPPRESS), is(false));
+    assertSuppressedFromDiscovery(instance.getId().toString());
+  }
+
+  @Test
+  public void canMakeInstanceDiscoverySuppressed() throws Exception {
+    IndividualResource instance = createInstance(smallAngryPlanet(UUID.randomUUID()));
+    assertThat(instance.getJson().getBoolean(DISCOVERY_SUPPRESS), is(false));
+
+    updateInstance(getById(instance.getId()).getJson().copy()
+      .put(DISCOVERY_SUPPRESS, true));
+
+    assertSuppressedFromDiscovery(instance.getId().toString());
+  }
+
   private void setInstanceSequence(long sequenceNumber) {
     final Vertx vertx = StorageTestSuite.getVertx();
     final PostgresClient postgresClient =
@@ -2338,11 +2406,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       response.getStatusCode(), is(201));
     }
 
-  private void createInstance(JsonObject instanceToCreate)
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+  private IndividualResource createInstance(JsonObject instanceToCreate)
+    throws InterruptedException, ExecutionException, TimeoutException {
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
@@ -2353,6 +2418,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(String.format("Create instance failed: %s", response.getBody()),
       response.getStatusCode(), is(201));
+
+    return new IndividualResource(response);
   }
 
   private IndividualResource updateInstance(JsonObject instance)
@@ -2480,5 +2547,20 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     natureOfContentIdsToRemoveAfterTest.add(natureOfContentTerm.getId());
     return response.getJson().mapTo(NatureOfContentTerm.class);
+  }
+
+  private void assertNotSuppressedFromDiscovery(JsonArray array) {
+    array.stream()
+      .map(obj -> (JsonObject) obj)
+      .map(instance -> instance.getString("id"))
+      .forEach(this::assertNotSuppressedFromDiscovery);
+  }
+
+  private void assertSuppressedFromDiscovery(String id) {
+    assertThat(getById(id).getJson().getBoolean(DISCOVERY_SUPPRESS), is(true));
+  }
+
+  private void assertNotSuppressedFromDiscovery(String id) {
+    assertThat(getById(id).getJson().getBoolean(DISCOVERY_SUPPRESS), is(false));
   }
 }

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -2350,7 +2350,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     IndividualResource instance = createInstance(smallAngryPlanet(UUID.randomUUID())
       .put(DISCOVERY_SUPPRESS, true));
 
-    assertThat(instance.getJson().getBoolean(DISCOVERY_SUPPRESS), is(false));
+    assertThat(instance.getJson().getBoolean(DISCOVERY_SUPPRESS), is(true));
     assertSuppressedFromDiscovery(instance.getId().toString());
   }
 

--- a/src/test/java/org/folio/rest/api/TestBase.java
+++ b/src/test/java/org/folio/rest/api/TestBase.java
@@ -12,7 +12,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.HttpClient;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
@@ -37,6 +36,8 @@ public abstract class TestBase {
   static ResourceClient callNumberTypesClient;
   static ResourceClient modesOfIssuanceClient;
   static ResourceClient precedingSucceedingTitleClient;
+  static ResourceClient instancesStorageSyncClient;
+  static ResourceClient instancesStorageBatchInstancesClient;
 
   @BeforeClass
   public static void testBaseBeforeClass() throws Exception {
@@ -55,6 +56,9 @@ public abstract class TestBase {
     callNumberTypesClient = ResourceClient.forCallNumberTypes(client);
     modesOfIssuanceClient = ResourceClient.forModesOfIssuance(client);
     precedingSucceedingTitleClient = ResourceClient.forPrecedingSucceedingTitles(client);
+    instancesStorageSyncClient = ResourceClient.forInstancesStorageSync(client);
+    instancesStorageBatchInstancesClient = ResourceClient
+      .forInstancesStorageBatchInstances(client);
   }
 
   @AfterClass


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-449: Create migration script to ensure that suppress from discovery is always yes or no.

### Changes:
* Set default value to `false` for `instance.discoverySuppress` property;
* Update API versions for `instance-storage/batch/sync`;
* Add migration script to set `discoverySuppress=false` if value for property is not set;
