### PR TITLE
MODINVSTOR-453 Set default value to false for staffSuppress property

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -88,7 +88,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "7.4",
+      "version": "7.5",
       "handlers": [
         {
           "methods": ["GET"],
@@ -182,7 +182,7 @@
     },
     {
       "id": "instance-storage-batch",
-      "version": "0.3",
+      "version": "0.4",
       "handlers": [
         {
           "methods": ["POST"],
@@ -193,7 +193,7 @@
     },
     {
       "id": "instance-storage-batch-sync",
-      "version": "0.2",
+      "version": "0.3",
       "handlers": [
         {
           "methods": ["POST"],

--- a/ramls/instance-storage-batch.raml
+++ b/ramls/instance-storage-batch.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Deprecated Inventory Storage Instance Batch API
-version: v0.3
+version: v0.4
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/instance-storage.raml
+++ b/ramls/instance-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Instance Storage
-version: v7.4
+version: v7.5
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/instance-sync.raml
+++ b/ramls/instance-sync.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Storage Instance Batch Sync API
-version: v0.2
+version: v0.3
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -292,7 +292,8 @@
     },
     "staffSuppress": {
       "type": "boolean",
-      "description": "Records the fact that the record should not be displayed for others than catalogers"
+      "description": "Records the fact that the record should not be displayed for others than catalogers",
+      "default": false
     },
     "discoverySuppress": {
       "type": "boolean",

--- a/src/main/resources/templates/db_scripts/populateStaffSuppressIfNotSet.sql
+++ b/src/main/resources/templates/db_scripts/populateStaffSuppressIfNotSet.sql
@@ -1,0 +1,3 @@
+UPDATE ${myuniversity}_${mymodule}.instance
+SET	jsonb = JSONB_SET(instance.jsonb, '{staffSuppress}', TO_JSONB(false))
+WHERE jsonb->>'staffSuppress' IS NULL;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -801,6 +801,11 @@
       "run": "after",
       "snippetPath": "populateDiscoverySuppressIfNotSet.sql",
       "fromModuleVersion": "19.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "populateStaffSuppressIfNotSet.sql",
+      "fromModuleVersion": "19.1.0"
     }
   ]
 }

--- a/src/test/java/org/folio/rest/api/InstanceDefaultValueMigrationScriptTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceDefaultValueMigrationScriptTest.java
@@ -1,0 +1,104 @@
+package org.folio.rest.api;
+
+import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import org.folio.rest.jaxrs.model.Instance;
+import org.folio.rest.support.IndividualResource;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
+public abstract class InstanceDefaultValueMigrationScriptTest
+  extends MigrationTestBase {
+
+  @Before
+  public void beforeEach() {
+    StorageTestSuite.deleteAll(instancesStorageUrl(""));
+  }
+
+  @Test
+  public void canSetDefaultValueIfNotPresent() throws Exception {
+    List<IndividualResource> allInstances = createInstances(3);
+
+    for (IndividualResource instance : allInstances) {
+      assertThat(unsetJsonbProperty("instance", instance.getId(),
+        getFieldName()).getUpdated(), is(1));
+    }
+
+    executeMultipleSqlStatements(getMigrationScript());
+
+    verifyDefaultValue(allInstances);
+  }
+
+  @Test
+  public void instancesWithFieldsAreNotUpdated() throws Exception {
+    List<IndividualResource> instancesWithDefaultValue = createInstances(2);
+    List<IndividualResource> instancesWithField = new ArrayList<>(2);
+
+    instancesWithField.add(
+      instancesClient.create(smallAngryWithField()));
+    instancesWithField.add(
+      instancesClient.create(smallAngryWithField()));
+
+    for (IndividualResource instance : instancesWithDefaultValue) {
+      assertThat(unsetJsonbProperty("instance", instance.getId(),
+        getFieldName()).getUpdated(), is(1));
+    }
+
+    executeMultipleSqlStatements(getMigrationScript());
+
+    verifyDefaultValue(instancesWithDefaultValue);
+    verifyFieldValue(instancesWithField);
+  }
+
+  private List<IndividualResource> createInstances(int count) throws Exception {
+    final List<IndividualResource> allInstances = new ArrayList<>();
+
+    for (int i = 0; i < count; i++) {
+      allInstances.add(instancesClient.create(smallAngryPlanet()));
+    }
+    return allInstances;
+  }
+
+  private JsonObject smallAngryPlanet() {
+    return createInstanceRequest(UUID.randomUUID(), "TEST",
+      "Long Way to a Small Angry Planet", new JsonArray(), new JsonArray(),
+      UUID_INSTANCE_TYPE, new JsonArray());
+  }
+
+  private JsonObject smallAngryWithField() {
+    return smallAngryPlanet()
+      .put(getFieldName(), true);
+  }
+
+  private void verifyDefaultValue(List<IndividualResource> instances) throws Exception {
+
+    for (IndividualResource instance : instances) {
+      Instance instanceInStorage = instancesClient.getById(instance.getId()).getJson()
+        .mapTo(Instance.class);
+      assertThat(getFieldValue(instanceInStorage), is(false));
+    }
+  }
+
+  private void verifyFieldValue(List<IndividualResource> instances) throws Exception {
+
+    for (IndividualResource instance : instances) {
+      Instance instanceInStorage = instancesClient.getById(instance.getId()).getJson()
+        .mapTo(Instance.class);
+      assertThat(getFieldValue(instanceInStorage), is(true));
+    }
+  }
+
+  protected abstract Boolean getFieldValue(Instance instanceInStorage);
+
+  protected abstract String getFieldName();
+
+  protected abstract String getMigrationScript();
+}

--- a/src/test/java/org/folio/rest/api/InstanceStaffSuppressMigrationScriptTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStaffSuppressMigrationScriptTest.java
@@ -2,21 +2,20 @@ package org.folio.rest.api;
 
 import org.folio.rest.jaxrs.model.Instance;
 
-public class InstanceDiscoverySuppressMigrationScriptTest
+public class InstanceStaffSuppressMigrationScriptTest
   extends InstanceDefaultValueMigrationScriptTest {
-
-  private static final String DISCOVERY_SUPPRESS = "discoverySuppress";
+  private static final String STAFF_SUPPRESS = "staffSuppress";
   private static final String MIGRATION_SCRIPT
-    = loadScript("populateDiscoverySuppressIfNotSet.sql");
+    = loadScript("populateStaffSuppressIfNotSet.sql");
 
   @Override
   public Boolean getFieldValue(Instance instanceInStorage) {
-    return instanceInStorage.getDiscoverySuppress();
+    return instanceInStorage.getStaffSuppress();
   }
 
   @Override
   public String getFieldName() {
-    return DISCOVERY_SUPPRESS;
+    return STAFF_SUPPRESS;
   }
 
   @Override

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -61,7 +61,9 @@ import static org.junit.Assert.assertThat;
   ItemEffectiveCallNumberComponentsTest.class,
   ItemEffectiveCallNumberDataUpgradeTest.class,
   ModesOfIssuanceMigrationScriptTest.class,
-  PrecedingSucceedingTitleTest.class
+  PrecedingSucceedingTitleTest.class,
+  InstanceDiscoverySuppressMigrationScriptTest.class,
+  InstanceStaffSuppressMigrationScriptTest.class
 })
 public class StorageTestSuite {
   public static final String TENANT_ID = "test_tenant";

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -1,5 +1,6 @@
 package org.folio.rest.api;
 
+import static org.folio.rest.api.ItemDamagedStatusAPITest.TEST_TENANT;
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instanceStatusesUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
@@ -83,6 +84,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     ExecutionException,
     TimeoutException {
 
+    StorageTestSuite.deleteAll(TEST_TENANT, "preceding_succeeding_title");
     StorageTestSuite.deleteAll(itemsStorageUrl(""));
     StorageTestSuite.deleteAll(holdingsStorageUrl(""));
     StorageTestSuite.deleteAll(instancesStorageUrl(""));


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-453: 
Set default value to false for staffSuppress property

Changes:
Set default value to false for instance.staffSuppress property;
Update API versions for instance-storage/batch/sync;
Add migration script to set staffSuppress=false if value for property is not set;