### PR TITLE
MODINVSTOR-458: Calculate effective call number components for item batch create

### DIFF
--- a/src/main/java/org/folio/rest/exceptions/NotFoundException.java
+++ b/src/main/java/org/folio/rest/exceptions/NotFoundException.java
@@ -1,7 +1,0 @@
-package org.folio.rest.exceptions;
-
-public class NotFoundException extends RuntimeException {
-  public NotFoundException(String message) {
-    super(message);
-  }
-}

--- a/src/main/java/org/folio/rest/exceptions/ValidationException.java
+++ b/src/main/java/org/folio/rest/exceptions/ValidationException.java
@@ -1,0 +1,16 @@
+package org.folio.rest.exceptions;
+
+import org.folio.rest.jaxrs.model.Errors;
+
+public class ValidationException extends RuntimeException {
+  private final Errors errors;
+
+  public ValidationException(Errors errors) {
+    super("Validation exception: " + errors);
+    this.errors = errors;
+  }
+
+  public Errors getErrors() {
+    return errors;
+  }
+}

--- a/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
@@ -1,7 +1,26 @@
 package org.folio.rest.impl;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.folio.rest.jaxrs.resource.ItemStorageBatchSynchronous.PostItemStorageBatchSynchronousResponse.respond422WithApplicationJson;
 import static org.folio.rest.jaxrs.resource.ItemStorageBatchSynchronous.PostItemStorageBatchSynchronousResponse.respond500WithTextPlain;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.exceptions.ValidationException;
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.jaxrs.model.ItemsPost;
+import org.folio.rest.jaxrs.resource.ItemStorageBatchSynchronous;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.support.HridManager;
+import org.folio.rest.tools.utils.TenantTool;
+import org.folio.services.ItemEffectiveCallNumberComponentsService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
@@ -10,21 +29,9 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 
-import org.folio.rest.annotations.Validate;
-import org.folio.rest.jaxrs.model.Item;
-import org.folio.rest.jaxrs.model.ItemsPost;
-import org.folio.rest.jaxrs.resource.ItemStorageBatchSynchronous;
-import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.support.HridManager;
-import org.folio.rest.tools.utils.TenantTool;
-
-import javax.ws.rs.core.Response;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
-
 public class ItemBatchSyncAPI implements ItemStorageBatchSynchronous {
+  private static final Logger log = LoggerFactory.getLogger(ItemBatchSyncAPI.class);
+
   @Validate
   @Override
   public void postItemStorageBatchSynchronous(ItemsPost entity, Map<String, String> okapiHeaders,
@@ -32,6 +39,9 @@ public class ItemBatchSyncAPI implements ItemStorageBatchSynchronous {
     final List<Item> items = entity.getItems();
     final PostgresClient postgresClient = PostgresClient.getInstance(
           vertxContext.owner(), TenantTool.tenantId(okapiHeaders));
+    final ItemEffectiveCallNumberComponentsService effectiveCallNumberService =
+      new ItemEffectiveCallNumberComponentsService(postgresClient);
+
     // Currently, there is no method on CompositeFuture to accept List<Future<String>>
     @SuppressWarnings("rawtypes")
     final List<Future> futures = new ArrayList<>();
@@ -41,15 +51,27 @@ public class ItemBatchSyncAPI implements ItemStorageBatchSynchronous {
       futures.add(setHrid(item, hridManager));
     }
 
-    CompositeFuture.all(futures).setHandler(ar -> {
-      if (ar.succeeded()) {
+    CompositeFuture.all(futures)
+      .compose(result -> effectiveCallNumberService.populateEffectiveCallNumberComponents(items))
+      .map(result -> {
         StorageHelper.postSync(ItemStorageAPI.ITEM_TABLE, entity.getItems(),
-            okapiHeaders, asyncResultHandler, vertxContext,
-            PostItemStorageBatchSynchronousResponse::respond201);
-      } else {
-        asyncResultHandler.handle(
-            Future.succeededFuture(respond500WithTextPlain(ar.cause().getMessage())));
-      }
+          okapiHeaders, asyncResultHandler, vertxContext,
+          PostItemStorageBatchSynchronousResponse::respond201);
+        return result;
+      }).otherwise(error -> {
+        log.warn("Error occurred during batch item create", error);
+
+        if (error instanceof ValidationException) {
+          final ValidationException validationError = (ValidationException) error;
+
+          asyncResultHandler.handle(Future.succeededFuture(
+            respond422WithApplicationJson(validationError.getErrors())));
+        } else {
+          asyncResultHandler.handle(Future.succeededFuture(
+            respond500WithTextPlain(error.getMessage())));
+        }
+
+        return null;
     });
   }
 

--- a/src/main/java/org/folio/rest/support/EndpointFailureHandler.java
+++ b/src/main/java/org/folio/rest/support/EndpointFailureHandler.java
@@ -1,0 +1,42 @@
+package org.folio.rest.support;
+
+import java.util.function.Function;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.exceptions.ValidationException;
+import org.folio.rest.jaxrs.model.Errors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+
+public final class EndpointFailureHandler {
+  private static final Logger log = LoggerFactory.getLogger(EndpointFailureHandler.class);
+
+  private EndpointFailureHandler() {}
+
+  public static <T> Function<Throwable, T> handleFailure(
+    Handler<AsyncResult<Response>> asyncResultHandler,
+    Function<Errors, Response> validationHandler,
+    Function<String, Response> serverErrorHandler) {
+
+    return error -> {
+      log.warn("Error occurred", error);
+
+      if (error instanceof ValidationException) {
+        final ValidationException validationError = (ValidationException) error;
+
+        asyncResultHandler.handle(Future.succeededFuture(
+          validationHandler.apply(validationError.getErrors())));
+      } else {
+        asyncResultHandler.handle(Future.succeededFuture(
+          serverErrorHandler.apply(error.getMessage())));
+      }
+
+      return null;
+    };
+  }
+}

--- a/src/main/java/org/folio/services/ItemEffectiveCallNumberComponentsService.java
+++ b/src/main/java/org/folio/services/ItemEffectiveCallNumberComponentsService.java
@@ -1,0 +1,113 @@
+package org.folio.services;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static org.apache.commons.lang3.StringUtils.isNoneBlank;
+import static org.folio.rest.impl.HoldingsStorageAPI.HOLDINGS_RECORD_TABLE;
+import static org.folio.rest.support.EffectiveCallNumberComponentsUtil.buildComponents;
+import static org.folio.rest.tools.utils.ValidationHelper.createValidationErrorMessage;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.folio.rest.exceptions.ValidationException;
+import org.folio.rest.jaxrs.model.HoldingsRecord;
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+
+public class ItemEffectiveCallNumberComponentsService {
+  private final PostgresClient postgresClient;
+
+  public ItemEffectiveCallNumberComponentsService(Context context, Map<String, String> headers) {
+    this.postgresClient = PgUtil.postgresClient(context, headers);
+  }
+
+  public ItemEffectiveCallNumberComponentsService(PostgresClient postgresClient) {
+    this.postgresClient = postgresClient;
+  }
+
+  public Future<List<Item>> populateEffectiveCallNumberComponents(List<Item> items) {
+    return getHoldingsRecordsForItems(items)
+      .map(holdingsRecordMap -> {
+        items.forEach(item -> {
+          final HoldingsRecord holdingsRecord = holdingsRecordMap.get(item.getHoldingsRecordId());
+          item.setEffectiveCallNumberComponents(buildComponents(holdingsRecord, item));
+        });
+        return items;
+      });
+  }
+
+  public Future<Item> populateEffectiveCallNumberComponents(Item item) {
+    return getHoldingsRecordForItem(item)
+      .map(holdingsRecord -> buildComponents(holdingsRecord, item))
+      .map(item::withEffectiveCallNumberComponents);
+  }
+
+  private Future<HoldingsRecord> getHoldingsRecordForItem(Item item) {
+    if (shouldNotRetrieveHoldingsRecord(item)) {
+      return succeededFuture(null);
+    }
+
+    final Promise<HoldingsRecord> promise = Promise.promise();
+    postgresClient.getById(HOLDINGS_RECORD_TABLE, item.getHoldingsRecordId(),
+      HoldingsRecord.class, promise);
+
+    return promise.future()
+      .compose(holdingsRecord -> {
+        if (holdingsRecord != null) {
+          return succeededFuture(holdingsRecord);
+        }
+
+        return failedFuture(
+          holdingsRecordNotFoundException(item.getHoldingsRecordId()));
+      });
+  }
+
+  private Future<Map<String, HoldingsRecord>> getHoldingsRecordsForItems(List<Item> items) {
+    final Promise<Map<String, HoldingsRecord>> promise = Promise.promise();
+    final List<String> holdingsIds = items.stream()
+      .filter(this::shouldRetrieveHoldingsRecord)
+      .map(Item::getHoldingsRecordId)
+      .distinct()
+      .collect(Collectors.toList());
+
+    postgresClient.getById(HOLDINGS_RECORD_TABLE, new JsonArray(holdingsIds),
+      HoldingsRecord.class, promise);
+
+    return promise.future()
+      .compose(holdingsRecordMap -> {
+        if (holdingsRecordMap.keySet().containsAll(holdingsIds)) {
+          return succeededFuture(holdingsRecordMap);
+        }
+
+        final String notFoundId = holdingsIds.stream()
+          .filter(id -> !holdingsRecordMap.containsKey(id))
+          .findFirst().orElse(null);
+
+        return failedFuture(holdingsRecordNotFoundException(notFoundId));
+      });
+  }
+
+  private boolean shouldNotRetrieveHoldingsRecord(Item item) {
+    return isNoneBlank(item.getItemLevelCallNumber(),
+      item.getItemLevelCallNumberPrefix(),
+      item.getItemLevelCallNumberSuffix(),
+      item.getItemLevelCallNumberTypeId());
+  }
+
+  private boolean shouldRetrieveHoldingsRecord(Item item) {
+    return !shouldNotRetrieveHoldingsRecord(item);
+  }
+
+  private ValidationException holdingsRecordNotFoundException(String id) {
+    return new ValidationException(createValidationErrorMessage("holdingsRecordId",
+      id, "Holdings record does not exist"));
+  }
+}

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -854,12 +854,13 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
   private JsonArray threeItems() {
     try {
-      UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
-      JsonArray jsonArray = new JsonArray()
+      UUID holdingsRecordId = createInstanceAndHoldingWithBuilder(mainLibraryLocationId,
+        holdingRequestBuilder -> holdingRequestBuilder.withCallNumber("hrCallNumber"));
+
+      return new JsonArray()
           .add(nod(holdingsRecordId))
           .add(smallAngryPlanet(holdingsRecordId))
           .add(interestingTimes(UUID.randomUUID(), holdingsRecordId));
-      return jsonArray;
     } catch (MalformedURLException | ExecutionException | InterruptedException | TimeoutException e) {
       throw new RuntimeException(e);
     }
@@ -2039,6 +2040,22 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
       nonExistentHoldingsRecordId.toString()));
   }
 
+  @Test
+  public void cannotBatchCreateItemsWithNonExistentHoldingsRecordId() throws Exception {
+    final String nonExistentHoldingsRecordId = UUID.randomUUID().toString();
+    final JsonArray items = threeItems();
+
+    items.getJsonObject(2)
+      .put("holdingsRecordId", nonExistentHoldingsRecordId);
+
+    final Response response = itemsStorageSyncClient
+      .attemptToCreate(new JsonObject().put("items", items));
+
+    assertThat(response, hasValidationError(
+      "Holdings record does not exist", "holdingsRecordId",
+      nonExistentHoldingsRecordId));
+  }
+
   @SuppressWarnings("unused")
   private Set<String> getAllowedItemStatuses() throws IOException {
     final String itemJson = new String(readAllBytes(get("ramls/item.json")),
@@ -2154,6 +2171,8 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   private void assertExists(Response response, JsonObject expectedItem) {
     assertThat(response, statusCodeIs(HttpStatus.HTTP_OK));
     assertThat(response.getBody(), containsString(expectedItem.getString("holdingsRecordId")));
+    assertThat(response.getJson().getJsonObject("effectiveCallNumberComponents"),
+      notNullValue());
   }
 
   private void assertHRIDRange(Response response, String minHRID, String maxHRID) {

--- a/src/test/java/org/folio/rest/api/TestBase.java
+++ b/src/test/java/org/folio/rest/api/TestBase.java
@@ -3,7 +3,7 @@ package org.folio.rest.api;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -38,6 +38,7 @@ public abstract class TestBase {
   static ResourceClient precedingSucceedingTitleClient;
   static ResourceClient instanceRelationshipsClient;
   static ResourceClient instancesStorageSyncClient;
+  static ResourceClient itemsStorageSyncClient;
   static ResourceClient instancesStorageBatchInstancesClient;
 
   @BeforeClass
@@ -59,6 +60,7 @@ public abstract class TestBase {
     instanceRelationshipsClient = ResourceClient.forInstanceRelationships(client);
     precedingSucceedingTitleClient = ResourceClient.forPrecedingSucceedingTitles(client);
     instancesStorageSyncClient = ResourceClient.forInstancesStorageSync(client);
+    itemsStorageSyncClient = ResourceClient.forItemsStorageSync(client);
     instancesStorageBatchInstancesClient = ResourceClient
       .forInstancesStorageBatchInstances(client);
   }

--- a/src/test/java/org/folio/rest/support/http/ResourceClient.java
+++ b/src/test/java/org/folio/rest/support/http/ResourceClient.java
@@ -97,6 +97,11 @@ public class ResourceClient {
       "Instances batch sync", "instances");
   }
 
+  public static ResourceClient forItemsStorageSync(HttpClient client) {
+    return new ResourceClient(client, InterfaceUrls::itemsStorageSyncUrl,
+      "Items batch sync", "items");
+  }
+
   public static ResourceClient forInstancesStorageBatchInstances(HttpClient client) {
     return new ResourceClient(client, InterfaceUrls::instancesStorageBatchInstancesUrl,
       "Instances batch (Deprecated)", "instances");

--- a/src/test/java/org/folio/rest/support/matchers/ItemMatchers.java
+++ b/src/test/java/org/folio/rest/support/matchers/ItemMatchers.java
@@ -1,0 +1,88 @@
+package org.folio.rest.support.matchers;
+
+import java.util.Objects;
+import java.util.function.Function;
+
+import org.folio.rest.jaxrs.model.EffectiveCallNumberComponents;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+import io.vertx.core.json.JsonObject;
+
+public final class ItemMatchers {
+  private static final String EFFECTIVE_CALL_NUMBER_COMPONENTS = "effectiveCallNumberComponents";
+
+  private ItemMatchers() {
+  }
+
+  public static Matcher<JsonObject> effectiveCallNumberComponents(
+    Matcher<EffectiveCallNumberComponents> matcher) {
+
+    return new TypeSafeMatcher<JsonObject>() {
+      @Override
+      protected boolean matchesSafely(JsonObject jsonObject) {
+        if (!jsonObject.containsKey(EFFECTIVE_CALL_NUMBER_COMPONENTS)) {
+          return false;
+        }
+
+        final EffectiveCallNumberComponents components = jsonObject
+          .getJsonObject(EFFECTIVE_CALL_NUMBER_COMPONENTS)
+          .mapTo(EffectiveCallNumberComponents.class);
+
+        return matcher.matches(components);
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("Has effective call number components matches ")
+          .appendDescriptionOf(matcher);
+      }
+
+      @Override
+      protected void describeMismatchSafely(JsonObject item, Description mismatchDescription) {
+        super.describeMismatchSafely(item.getJsonObject(EFFECTIVE_CALL_NUMBER_COMPONENTS),
+          mismatchDescription);
+      }
+    };
+  }
+
+  private static <T> Matcher<EffectiveCallNumberComponents> hasEffectiveCallNumberElement(
+    Function<EffectiveCallNumberComponents, T> property, T expectedValue) {
+
+    return new TypeSafeMatcher<EffectiveCallNumberComponents>() {
+      @Override
+      protected boolean matchesSafely(EffectiveCallNumberComponents components) {
+        final T actualValue = property.apply(components);
+        return Objects.equals(actualValue, expectedValue);
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("Has effective call number component value ")
+          .appendValue(expectedValue);
+      }
+    };
+  }
+
+  public static Matcher<EffectiveCallNumberComponents> hasCallNumber(String callNumber) {
+    return hasEffectiveCallNumberElement(EffectiveCallNumberComponents::getCallNumber,
+      callNumber);
+  }
+
+  public static Matcher<EffectiveCallNumberComponents> hasSuffix(String suffix) {
+    return hasEffectiveCallNumberElement(EffectiveCallNumberComponents::getSuffix,
+      suffix);
+  }
+
+  public static Matcher<EffectiveCallNumberComponents> hasPrefix(String prefix) {
+    return hasEffectiveCallNumberElement(EffectiveCallNumberComponents::getPrefix,
+      prefix);
+  }
+
+  public static Matcher<EffectiveCallNumberComponents> hasTypeId(String typeId) {
+    return hasEffectiveCallNumberElement(EffectiveCallNumberComponents::getTypeId,
+      typeId);
+  }
+}
+


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-458 - EffecticeCallNumberComponents is not set for items in "/item-storage/batch/synchronous" API.

### Changes:
* Add logic to calculate effective call number components for batch item create.
* Move effective call number logic to separate service class.