### PR TITLE
MODINVSTOR-451 Remove old data after the whole Preceding/Succeeding titles migration

### DIFF
--- a/reference-data/instance-relationship-types/preceding-succeeding.json
+++ b/reference-data/instance-relationship-types/preceding-succeeding.json
@@ -1,4 +1,0 @@
-{
-  "id": "cde80cc2-0c8b-4672-82d4-721e51dcb990",
-  "name": "preceding-succeeding"
-}

--- a/sample-data/import.sh
+++ b/sample-data/import.sh
@@ -5,6 +5,7 @@ item_storage_address=http://localhost:9130/item-storage/items
 instance_storage_address=http://localhost:9130/instance-storage/instances
 instance_relationship_storage_address=http://localhost:9130/instance-storage/instance-relationships
 holdings_storage_address=http://localhost:9130/holdings-storage/holdings
+preceding_succeeding_title_storage_address=http://localhost:9130/preceding-succeeding-titles
 
 for f in ./instances/*.json; do
     curl -w '\n' -X POST -D - \
@@ -36,4 +37,12 @@ for f in ./instance-relationships/*.json; do
          -H "X-Okapi-Tenant: ${tenant}" \
          -d @$f \
          "${instance_relationship_storage_address}"
+done
+
+for f in ./preceding-succeeding-titles/*.json; do
+    curl -v -w '\n' -X POST -D - \
+         -H "Content-type: application/json" \
+         -H "X-Okapi-Tenant: ${tenant}" \
+         -d @$f \
+         "${preceding_succeeding_title_storage_address}"
 done

--- a/sample-data/instance-relationships/american-bar-association-preceding-title.json
+++ b/sample-data/instance-relationships/american-bar-association-preceding-title.json
@@ -1,6 +1,0 @@
-{
-  "id": "1e772f36-20ac-4429-955b-8cd6c7dd644a",
-  "superInstanceId": "69640328-788e-43fc-9c3c-af39e243f3b7",
-  "subInstanceId":   "00f10ab9-d845-4334-92d2-ff55862bf4f9",
-  "instanceRelationshipTypeId": "cde80cc2-0c8b-4672-82d4-721e51dcb990"
-}

--- a/sample-data/preceding-succeeding-titles/american-bar-association-connected-preceding-title.json
+++ b/sample-data/preceding-succeeding-titles/american-bar-association-connected-preceding-title.json
@@ -1,0 +1,5 @@
+{
+  "id": "1e772f36-20ac-4429-955b-8cd6c7dd644a",
+  "precedingInstanceId": "69640328-788e-43fc-9c3c-af39e243f3b7",
+  "succeedingInstanceId":   "00f10ab9-d845-4334-92d2-ff55862bf4f9"
+}

--- a/sample-data/preceding-succeeding-titles/american-bar-association-unconnected-preceding-title.json
+++ b/sample-data/preceding-succeeding-titles/american-bar-association-unconnected-preceding-title.json
@@ -1,0 +1,12 @@
+{
+  "id": "6d986a7f-da45-4513-8a34-0a257f776eac",
+  "succeedingInstanceId":   "00f10ab9-d845-4334-92d2-ff55862bf4f9",
+  "title": "A semantic web primer",
+  "hrid": "inst000000000022",
+  "identifiers": [
+    {
+      "identifierTypeId": "8261054f-be78-422d-bd51-4ed9f33c3422",
+      "value": "0262012103"
+    }
+  ]
+}

--- a/src/main/resources/templates/db_scripts/removeOldPrecedingSucceedingTitles.sql
+++ b/src/main/resources/templates/db_scripts/removeOldPrecedingSucceedingTitles.sql
@@ -1,0 +1,9 @@
+START TRANSACTION;
+
+DELETE FROM ${myuniversity}_${mymodule}.instance_relationship
+WHERE instanceRelationshipTypeId ='cde80cc2-0c8b-4672-82d4-721e51dcb990';
+
+DELETE FROM ${myuniversity}_${mymodule}.instance_relationship_type
+WHERE id ='cde80cc2-0c8b-4672-82d4-721e51dcb990';
+
+END TRANSACTION;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -801,6 +801,11 @@
       "run": "after",
       "snippetPath": "populateDiscoverySuppressIfNotSet.sql",
       "fromModuleVersion": "19.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "removeOldPrecedingSucceedingTitles.sql",
+      "fromModuleVersion": "19.2.0"
     }
   ]
 }

--- a/src/test/java/org/folio/rest/api/PrecedingSucceedingTitleMigrationScriptTest.java
+++ b/src/test/java/org/folio/rest/api/PrecedingSucceedingTitleMigrationScriptTest.java
@@ -7,9 +7,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import io.vertx.core.json.JsonObject;
 import org.folio.rest.api.entities.InstanceRelationship;
 import org.folio.rest.support.IndividualResource;
+import org.folio.rest.support.Response;
 import org.junit.Before;
 import org.junit.Test;
 
+import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.util.List;
 import java.util.UUID;
@@ -18,30 +20,45 @@ import java.util.concurrent.TimeoutException;
 
 public class PrecedingSucceedingTitleMigrationScriptTest extends MigrationTestBase {
   private static final String PRECEDING_SUCCEEDING_TITLE_TABLE = "preceding_succeeding_title";
+  private static final String INSTANCE_RELATIONSHIP_TABLE = "instance_relationship";
+  private static final String INSTANCE_RELATIONSHIP_TYPE_TABLE = "instance_relationship_type";
   private static final String MIGRATION_SCRIPT = loadScript("migratePrecedingSucceedingTitles.sql");
-  private final static String PRECEDING_SUCCEEDING_INSTANCE_RELATIONSHIP_TYPE_ID = "cde80cc2-0c8b-4672-82d4-721e51dcb990";
+  private static final String REMOVE_OLD_PRECEDING_SUCCEEDING_TITLES_SCRIPT =
+    loadScript("removeOldPrecedingSucceedingTitles.sql");
+  private final static String PRECEDING_SUCCEEDING_RELATIONSHIP_TYPE_ID = "cde80cc2-0c8b-4672-82d4-721e51dcb990";
   private final static String BOUND_WITH_INSTANCE_RELATIONSHIP_TYPE_ID = "758f13db-ffb4-440e-bb10-8a364aa6cb4a";
+  private IndividualResource instanceRelationship1;
+  private IndividualResource instanceRelationship2;
 
   @Before
-  public void beforeEach() {
-    StorageTestSuite.deleteAll(TEST_TENANT, PRECEDING_SUCCEEDING_TITLE_TABLE);
-  }
+  public void beforeEach() throws Exception {
 
-  @Test
-  public void canMigratePrecedingSucceedingTitles() throws Exception {
+    StorageTestSuite.deleteAll(TEST_TENANT, INSTANCE_RELATIONSHIP_TABLE);
+    StorageTestSuite.deleteAll(TEST_TENANT, INSTANCE_RELATIONSHIP_TYPE_TABLE);
+    StorageTestSuite.deleteAll(TEST_TENANT, PRECEDING_SUCCEEDING_TITLE_TABLE);
+
     final UUID instance1Id = UUID.randomUUID();
     final UUID instance2Id = UUID.randomUUID();
     final UUID instance3Id = UUID.randomUUID();
+
+    createInstanceRelationType(PRECEDING_SUCCEEDING_RELATIONSHIP_TYPE_ID,
+      "preceding-succeeding");
+    createInstanceRelationType(BOUND_WITH_INSTANCE_RELATIONSHIP_TYPE_ID,
+      "bound-with");
 
     instancesClient.create(instance(instance1Id));
     instancesClient.create(instance(instance2Id));
     instancesClient.create(instance(instance3Id));
 
-    IndividualResource instanceRelationship1 = createInstanceRelationship(instance1Id, instance2Id,
-      PRECEDING_SUCCEEDING_INSTANCE_RELATIONSHIP_TYPE_ID);
-    IndividualResource instanceRelationship2 = createInstanceRelationship(instance2Id, instance3Id,
-      PRECEDING_SUCCEEDING_INSTANCE_RELATIONSHIP_TYPE_ID);
+    instanceRelationship1 = createInstanceRelationship(instance1Id, instance2Id,
+      PRECEDING_SUCCEEDING_RELATIONSHIP_TYPE_ID);
+    instanceRelationship2 = createInstanceRelationship(instance2Id, instance3Id,
+      PRECEDING_SUCCEEDING_RELATIONSHIP_TYPE_ID);
     createInstanceRelationship(instance1Id, instance3Id, BOUND_WITH_INSTANCE_RELATIONSHIP_TYPE_ID);
+  }
+
+  @Test
+  public void canMigratePrecedingSucceedingTitles() throws Exception {
 
     executeMultipleSqlStatements(MIGRATION_SCRIPT);
 
@@ -51,6 +68,26 @@ public class PrecedingSucceedingTitleMigrationScriptTest extends MigrationTestBa
 
     assertPrecedingSucceedingTitle(precedingSucceedingTitles.get(0), instanceRelationship1);
     assertPrecedingSucceedingTitle(precedingSucceedingTitles.get(1), instanceRelationship2);
+  }
+
+  @Test
+  public void canRemoveOldPrecedingSucceedingTitles() throws Exception {
+
+    executeMultipleSqlStatements(REMOVE_OLD_PRECEDING_SUCCEEDING_TITLES_SCRIPT);
+
+    Response response = instanceRelationshipTypesClient
+      .getById(UUID.fromString(PRECEDING_SUCCEEDING_RELATIONSHIP_TYPE_ID));
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
+
+    List<JsonObject> instanceRelationships = instanceRelationshipsClient
+      .getByQuery("?query=instance_relationship_type=" + PRECEDING_SUCCEEDING_RELATIONSHIP_TYPE_ID);
+    assertThat(instanceRelationships.size(), is(0));
+  }
+
+  private void createInstanceRelationType(String id, String name) throws Exception {
+    instanceRelationshipTypesClient.create(new JsonObject()
+      .put("id", id)
+      .put("name", name));
   }
 
   private IndividualResource createInstanceRelationship(UUID instance1Id, UUID instance2Id,

--- a/src/test/java/org/folio/rest/api/ReferenceTablesTest.java
+++ b/src/test/java/org/folio/rest/api/ReferenceTablesTest.java
@@ -710,7 +710,7 @@ public class ReferenceTablesTest extends TestBase {
   public void instanceRelationshipTypesLoaded() throws Exception {
     Response searchResponse = getReferenceRecords(instanceRelationshipTypesUrl(""));
     validateNumberOfReferenceRecords("instance-relationship types",
-      searchResponse, 4, 200);
+      searchResponse, 3, 200);
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/SampleDataTest.java
+++ b/src/test/java/org/folio/rest/api/SampleDataTest.java
@@ -69,7 +69,7 @@ public class SampleDataTest extends TestBase {
 
   @Test
   public void instanceRelationshipsCount() {
-    assertCount(instanceRelationshipsUrl("?limit=100"), "instanceRelationships", 6);
+    assertCount(instanceRelationshipsUrl("?limit=100"), "instanceRelationships", 5);
   }
 
   private JsonObject get(URL url) {

--- a/src/test/java/org/folio/rest/api/TestBase.java
+++ b/src/test/java/org/folio/rest/api/TestBase.java
@@ -37,6 +37,7 @@ public abstract class TestBase {
   static ResourceClient modesOfIssuanceClient;
   static ResourceClient precedingSucceedingTitleClient;
   static ResourceClient instanceRelationshipsClient;
+  static ResourceClient instanceRelationshipTypesClient;
   static ResourceClient instancesStorageSyncClient;
   static ResourceClient instancesStorageBatchInstancesClient;
 
@@ -57,6 +58,7 @@ public abstract class TestBase {
     callNumberTypesClient = ResourceClient.forCallNumberTypes(client);
     modesOfIssuanceClient = ResourceClient.forModesOfIssuance(client);
     instanceRelationshipsClient = ResourceClient.forInstanceRelationships(client);
+    instanceRelationshipTypesClient = ResourceClient.forInstanceRelationshipTypes(client);
     precedingSucceedingTitleClient = ResourceClient.forPrecedingSucceedingTitles(client);
     instancesStorageSyncClient = ResourceClient.forInstancesStorageSync(client);
     instancesStorageBatchInstancesClient = ResourceClient

--- a/src/test/java/org/folio/rest/support/http/ResourceClient.java
+++ b/src/test/java/org/folio/rest/support/http/ResourceClient.java
@@ -67,6 +67,11 @@ public class ResourceClient {
       "instance relationships", "instanceRelationships");
   }
 
+  public static ResourceClient forInstanceRelationshipTypes(HttpClient client) {
+    return new ResourceClient(client, InterfaceUrls::instanceRelationshipTypesUrl,
+      "instance relationship types", "instanceRelationshipTypes");
+  }
+
   public static ResourceClient forPrecedingSucceedingTitles(HttpClient client) {
     return new ResourceClient(client, InterfaceUrls::precedingSucceedingTitleUrl,
       "preceding succeeding titles", "precedingSucceedingTitles");


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-451

**Purpose:** 

Remove old data after the whole Preceding/Succeeding titles migration:

**Approach:**

Remove preceding/succeeding data from:

- reference and sample data
- instance_relationship and instance_relationship_type tables