### PR TITLE
MODINVSTOR-460: smart index recreation on module upgrade, RMB v29.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>29.3.1</raml-module-builder-version>
+    <raml-module-builder-version>29.3.2</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids</generate_routing_context>
     <argLine />
   </properties>


### PR DESCRIPTION
This works for upgrading from mod-inventory-storage versions that
contain RMB >= v29.3.2 (Fameflower onwards upgrade path).