### PR TITLE
MODINVSTOR-471: Duplicate class name IllPolicy, use javaType

### DIFF
--- a/ramls/holdingsrecord.json
+++ b/ramls/holdingsrecord.json
@@ -132,8 +132,8 @@
     },
     "illPolicy": {
       "type": "object",
-      "id": "holdingsIllPolicy",
       "description": "expanded ILL Policy object corresponding to illPolicyId",
+      "javaType": "org.folio.rest.jaxrs.model.IllPolicyVirtual",
       "folio:$ref": "illpolicy.json",
       "readonly": true,
       "folio:isVirtual": true,


### PR DESCRIPTION
This also reverts commit f36857657196144a4fa77d341cf6dcabffeaaa25
"Speculatively add an `id` to the `illPolicy` virtual field"