### PR TITLE
MODOAIPMH-105: soft delete for items, holdings and instances

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -313,7 +313,7 @@
     },
     {
       "tableName": "instance",
-      "fromModuleVersion": "17.1.0",
+      "fromModuleVersion": "19.2.0",
       "withMetadata": true,
       "foreignKeys": [
         {
@@ -564,7 +564,7 @@
     },
     {
       "tableName": "holdings_record",
-      "fromModuleVersion": "19.0.0",
+      "fromModuleVersion": "19.2.0",
       "withMetadata": true,
       "foreignKeys": [
         {
@@ -637,7 +637,7 @@
     {
       "tableName": "item",
       "withMetadata": true,
-      "fromModuleVersion": "19.0.0",
+      "fromModuleVersion": "19.2.0",
       "foreignKeys": [
         {
           "fieldName": "holdingsRecordId",
@@ -849,6 +849,11 @@
     {
       "run": "after",
       "snippetPath": "removeOldPrecedingSucceedingTitles.sql",
+      "fromModuleVersion": "19.2.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "softdelete/softDeleteForHoldingsInstancesItems.sql",
       "fromModuleVersion": "19.2.0"
     }
   ]

--- a/src/main/resources/templates/db_scripts/softdelete/softDeleteForHoldingsInstancesItems.sql
+++ b/src/main/resources/templates/db_scripts/softdelete/softDeleteForHoldingsInstancesItems.sql
@@ -1,5 +1,5 @@
--- ADD deleted_date field to the tables
--- create indexes on deleted date
+-- add deleted_date field to the tables
+-- create indexees on deleted date
 -- rename instance, holdings and item tables
 -- create views with the name of the corresponding tables
 
@@ -7,9 +7,9 @@ ALTER TABLE ${myuniversity}_${mymodule}.instance ADD "deleted_date" TIMESTAMP;
 ALTER TABLE ${myuniversity}_${mymodule}.item ADD "deleted_date" TIMESTAMP;
 ALTER TABLE ${myuniversity}_${mymodule}.holdings_record ADD "deleted_date" TIMESTAMP;
 --
-create index instance_deleted_date__index on ${myuniversity}_${mymodule}.instance (deleted_date);
-create index item_deleted_date__index on ${myuniversity}_${mymodule}.item (deleted_date);
-create index holdings_record_deleted_date__index on ${myuniversity}_${mymodule}.holdings_record (deleted_date);
+CREATE INDEX instance_deleted_date__index ON ${myuniversity}_${mymodule}.instance (deleted_date);
+CREATE INDEX item_deleted_date__index ON ${myuniversity}_${mymodule}.item (deleted_date);
+CREATE INDEX holdings_record_deleted_date__index ON ${myuniversity}_${mymodule}.holdings_record (deleted_date);
 --
 ALTER TABLE ${myuniversity}_${mymodule}.instance RENAME TO instance_log;
 ALTER TABLE ${myuniversity}_${mymodule}.item RENAME TO item_log;

--- a/src/main/resources/templates/db_scripts/softdelete/softDeleteForHoldingsInstancesItems.sql
+++ b/src/main/resources/templates/db_scripts/softdelete/softDeleteForHoldingsInstancesItems.sql
@@ -1,18 +1,20 @@
--- add deleted_date field to the tables
+-- ADD deleted_date field to the tables
+-- create indexes on deleted date
 -- rename instance, holdings and item tables
--- create index on deleted date (?)
--- Create views ith the name of the corresponding tables to filter rows with no deleted date
+-- create views with the name of the corresponding tables
 
-alter table ${myuniversity}_${mymodule}.instance add "deleted_date" timestamp;
-alter table ${myuniversity}_${mymodule}.item add "deleted_date" timestamp;
-alter table ${myuniversity}_${mymodule}.holdings_record add "deleted_date" timestamp;
+ALTER TABLE ${myuniversity}_${mymodule}.instance ADD "deleted_date" TIMESTAMP;
+ALTER TABLE ${myuniversity}_${mymodule}.item ADD "deleted_date" TIMESTAMP;
+ALTER TABLE ${myuniversity}_${mymodule}.holdings_record ADD "deleted_date" TIMESTAMP;
 --
---create index instance_log__index on ${myuniversity}_${mymodule}.instance (deleted_date);
+create index instance_deleted_date__index on ${myuniversity}_${mymodule}.instance (deleted_date);
+create index item_deleted_date__index on ${myuniversity}_${mymodule}.item (deleted_date);
+create index holdings_record_deleted_date__index on ${myuniversity}_${mymodule}.holdings_record (deleted_date);
 --
-alter table ${myuniversity}_${mymodule}.instance rename to instance_log;
-alter table ${myuniversity}_${mymodule}.item rename to item_log;
-alter table ${myuniversity}_${mymodule}.holdings_record rename to holdings_record_log;
+ALTER TABLE ${myuniversity}_${mymodule}.instance RENAME TO instance_log;
+ALTER TABLE ${myuniversity}_${mymodule}.item RENAME TO item_log;
+ALTER TABLE ${myuniversity}_${mymodule}.holdings_record RENAME TO holdings_record_log;
 --
-CREATE OR REPLACE VIEW instance AS SELECT * from instance_log where deleted_date IS NULL;
-CREATE OR REPLACE VIEW holdings_record AS SELECT * from holdings_record_log where deleted_date IS NULL;
-CREATE OR REPLACE VIEW item AS SELECT * from item_log where deleted_date IS NULL;
+CREATE OR REPLACE VIEW instance AS SELECT * FROM instance_log WHERE deleted_date IS NULL;
+CREATE OR REPLACE VIEW holdings_record AS SELECT * FROM holdings_record_log WHERE deleted_date IS NULL;
+CREATE OR REPLACE VIEW item AS SELECT * FROM item_log WHERE deleted_date IS NULL;

--- a/src/main/resources/templates/db_scripts/softdelete/softDeleteForHoldingsInstancesItems.sql
+++ b/src/main/resources/templates/db_scripts/softdelete/softDeleteForHoldingsInstancesItems.sql
@@ -1,15 +1,10 @@
 -- add deleted_date field to the tables
--- create indexees on deleted date
 -- rename instance, holdings and item tables
 -- create views with the name of the corresponding tables
 
 ALTER TABLE ${myuniversity}_${mymodule}.instance ADD "deleted_date" TIMESTAMP;
 ALTER TABLE ${myuniversity}_${mymodule}.item ADD "deleted_date" TIMESTAMP;
 ALTER TABLE ${myuniversity}_${mymodule}.holdings_record ADD "deleted_date" TIMESTAMP;
---
-CREATE INDEX instance_deleted_date__index ON ${myuniversity}_${mymodule}.instance (deleted_date);
-CREATE INDEX item_deleted_date__index ON ${myuniversity}_${mymodule}.item (deleted_date);
-CREATE INDEX holdings_record_deleted_date__index ON ${myuniversity}_${mymodule}.holdings_record (deleted_date);
 --
 ALTER TABLE ${myuniversity}_${mymodule}.instance RENAME TO instance_log;
 ALTER TABLE ${myuniversity}_${mymodule}.item RENAME TO item_log;

--- a/src/main/resources/templates/db_scripts/softdelete/softDeleteForHoldingsInstancesItems.sql
+++ b/src/main/resources/templates/db_scripts/softdelete/softDeleteForHoldingsInstancesItems.sql
@@ -1,0 +1,18 @@
+-- add deleted_date field to the tables
+-- rename instance, holdings and item tables
+-- create index on deleted date (?)
+-- Create views ith the name of the corresponding tables to filter rows with no deleted date
+
+alter table ${myuniversity}_${mymodule}.instance add "deleted_date" timestamp;
+alter table ${myuniversity}_${mymodule}.item add "deleted_date" timestamp;
+alter table ${myuniversity}_${mymodule}.holdings_record add "deleted_date" timestamp;
+--
+--create index instance_log__index on ${myuniversity}_${mymodule}.instance (deleted_date);
+--
+alter table ${myuniversity}_${mymodule}.instance rename to instance_log;
+alter table ${myuniversity}_${mymodule}.item rename to item_log;
+alter table ${myuniversity}_${mymodule}.holdings_record rename to holdings_record_log;
+--
+CREATE OR REPLACE VIEW instance AS SELECT * from instance_log where deleted_date IS NULL;
+CREATE OR REPLACE VIEW holdings_record AS SELECT * from holdings_record_log where deleted_date IS NULL;
+CREATE OR REPLACE VIEW item AS SELECT * from item_log where deleted_date IS NULL;

--- a/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
@@ -338,14 +338,14 @@ public class ItemEffectiveLocationTest extends TestBaseWithInventoryUtil {
   }
 
   private void disableTriggers() {
-    runSql("DROP TRIGGER IF EXISTS update_effective_location_for_items ON test_tenant_mod_inventory_storage.holdings_record");
-    runSql("DROP TRIGGER IF EXISTS update_effective_location           ON test_tenant_mod_inventory_storage.item");
+    runSql("DROP TRIGGER IF EXISTS update_effective_location_for_items ON test_tenant_mod_inventory_storage.holdings_record_log");
+    runSql("DROP TRIGGER IF EXISTS update_effective_location           ON test_tenant_mod_inventory_storage.item_log");
   }
 
   private void enableTriggers() {
-    runSql("create trigger update_effective_location_for_items after update on test_tenant_mod_inventory_storage.holdings_record "
+    runSql("create trigger update_effective_location_for_items after update on test_tenant_mod_inventory_storage.holdings_record_log "
         + "for each row execute procedure test_tenant_mod_inventory_storage.update_effective_location_on_holding_update()");
-    runSql("create trigger update_effective_location before insert or update on test_tenant_mod_inventory_storage.item "
+    runSql("create trigger update_effective_location before insert or update on test_tenant_mod_inventory_storage.item_log "
         + "for each row execute procedure test_tenant_mod_inventory_storage.update_effective_location_on_item_update()");
   }
 

--- a/src/test/java/org/folio/rest/api/PrecedingSucceedingTitleTest.java
+++ b/src/test/java/org/folio/rest/api/PrecedingSucceedingTitleTest.java
@@ -199,7 +199,7 @@ public class PrecedingSucceedingTitleTest extends TestBase {
 
     assertThat(response.getStatusCode(), is(HttpResponseStatus.UNPROCESSABLE_ENTITY.code()));
     assertErrors(response, "Cannot set preceding_succeeding_title.precedinginstanceid = " +
-      "14b65645-2e49-4a85-8dc1-43d444710570 because it does not exist in instance.id.");
+      "14b65645-2e49-4a85-8dc1-43d444710570 because it does not exist in instance_log.id.");
   }
 
   @Test
@@ -219,7 +219,7 @@ public class PrecedingSucceedingTitleTest extends TestBase {
 
     assertThat(response.getStatusCode(), is(HttpResponseStatus.UNPROCESSABLE_ENTITY.code()));
     assertErrors(response, "Cannot set preceding_succeeding_title.succeedinginstanceid = " +
-      "14b65645-2e49-4a85-8dc1-43d444710570 because it does not exist in instance.id.");
+      "14b65645-2e49-4a85-8dc1-43d444710570 because it does not exist in instance_log.id.");
   }
 
   @Test


### PR DESCRIPTION
# Purpose

Implement soft delete support for instances, holdings and items. 

# Approach 

Introduce views with the name of the tables that will filter records that have the deleted date populated. Rename instances, holdings and items tables with suffix _log, add a column to store the deleted date. Instead of actually deleting the row in the corresponding /delete API, the deleted_date column will be populated for that row(MODOAIPMH-113 to address that). This is the least intrusive way as almost no changes to the existing code are needed; additionally, the soft deleted records are transparently hidden from API clients.
