### PR TITLE
MODINVSTOR-473: Add indexes for *suppress properties

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -412,6 +412,18 @@
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": true
+        },
+        {
+          "fieldName": "staffSuppress",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
+        },
+        {
+          "fieldName": "discoverySuppress",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
         }
       ],
       "fullTextIndex": [
@@ -608,6 +620,12 @@
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": false
+        },
+        {
+          "fieldName": "discoverySuppress",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
         }
       ]
     },
@@ -696,6 +714,12 @@
         {
           "fieldName": "fullCallNumber",
           "multiFieldNames": "effectiveCallNumberComponents.prefix, effectiveCallNumberComponents.callNumber, effectiveCallNumberComponents.suffix",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
+        },
+        {
+          "fieldName": "discoverySuppress",
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": false

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -35,6 +35,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static java.net.HttpURLConnection.HTTP_OK;
@@ -63,7 +64,7 @@ import static org.hamcrest.Matchers.*;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.joda.time.Seconds.seconds;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.fail;
 
 @RunWith(VertxUnitRunner.class)
@@ -75,6 +76,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   private static final String STATUS_UPDATED_DATE_PROPERTY = "statusUpdatedDate";
   private static final Logger log = LoggerFactory.getLogger(InstanceStorageTest.class);
   private static final String DISCOVERY_SUPPRESS = "discoverySuppress";
+  private static final String STAFF_SUPPRESS = "staffSuppress";
 
   private Set<String> natureOfContentIdsToRemoveAfterTest = new HashSet<>();
 
@@ -2382,6 +2384,50 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       .put(DISCOVERY_SUPPRESS, true));
 
     assertSuppressedFromDiscovery(instance.getId().toString());
+  }
+
+  @Test
+  public void canSearchByDiscoverySuppressProperty() throws Exception {
+    final IndividualResource suppressedInstance = createInstance(smallAngryPlanet(UUID.randomUUID())
+      .put(DISCOVERY_SUPPRESS, true));
+    final IndividualResource notSuppressedInstance = createInstance(
+      smallAngryPlanet(UUID.randomUUID()));
+
+    final List<IndividualResource> suppressedInstances = instancesClient
+      .getMany("%s==true", DISCOVERY_SUPPRESS);
+    final List<IndividualResource> notSuppressedInstances = instancesClient
+      .getMany("%s==false", DISCOVERY_SUPPRESS);
+
+    assertThat(suppressedInstances.size(), is(1));
+    assertThat(suppressedInstances.get(0).getId(), is(suppressedInstance.getId()));
+
+    assertThat(notSuppressedInstances.size(), is(1));
+    assertThat(notSuppressedInstances.get(0).getId(), is(notSuppressedInstance.getId()));
+  }
+
+  @Test
+  public void canSearchByStaffSuppressProperty() throws Exception {
+    final IndividualResource suppressedInstance = createInstance(smallAngryPlanet(UUID.randomUUID())
+      .put(STAFF_SUPPRESS, true));
+    final IndividualResource notSuppressedInstance = createInstance(
+      smallAngryPlanet(UUID.randomUUID())
+        .put(STAFF_SUPPRESS, false));
+    final IndividualResource notSuppressedInstanceDefault = createInstance(
+      smallAngryPlanet(UUID.randomUUID()));
+
+    final List<IndividualResource> suppressedInstances = instancesClient
+      .getMany("%s==true", STAFF_SUPPRESS);
+    final List<IndividualResource> notSuppressedInstances = instancesClient
+      .getMany("cql.allRecords=1 not %s==true", STAFF_SUPPRESS);
+
+    assertThat(suppressedInstances.size(), is(1));
+    assertThat(suppressedInstances.get(0).getId(), is(suppressedInstance.getId()));
+
+    assertThat(notSuppressedInstances.size(), is(2));
+    assertThat(notSuppressedInstances.stream()
+        .map(IndividualResource::getId)
+        .collect(Collectors.toList()),
+      containsInAnyOrder(notSuppressedInstance.getId(), notSuppressedInstanceDefault.getId()));
   }
 
   private void setInstanceSequence(long sequenceNumber) {

--- a/src/test/java/org/folio/rest/support/builders/HoldingRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/HoldingRequestBuilder.java
@@ -16,12 +16,14 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
   private String callNumberSuffix;
   private String callNumberTypeId;
   private final String hrid;
+  private final Boolean discoverySuppress;
 
   public HoldingRequestBuilder() {
     this(
       null,
       null,
       UUID.randomUUID(),
+      null,
       null,
       null,
       null,
@@ -41,7 +43,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     String callNumberPrefix,
     String callNumberSuffix,
     String callNumberTypeId,
-    String hrid) {
+    String hrid,
+    Boolean discoverySuppress) {
 
     this.id = id;
     this.instanceId = instanceId;
@@ -53,6 +56,7 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     this.callNumberSuffix = callNumberSuffix;
     this.callNumberTypeId = callNumberTypeId;
     this.hrid = hrid;
+    this.discoverySuppress = discoverySuppress;
   }
 
   @Override
@@ -69,6 +73,7 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
     put(request, "callNumberSuffix", callNumberSuffix);
     put(request, "callNumberTypeId", callNumberTypeId);
     put(request, "hrid", hrid);
+    put(request, "discoverySuppress", discoverySuppress);
 
     return request;
   }
@@ -84,7 +89,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumberPrefix,
       this.callNumberSuffix,
       this.callNumberTypeId,
-      this.hrid);
+      this.hrid,
+      this.discoverySuppress);
   }
 
   public HoldingRequestBuilder withTemporaryLocation(UUID temporaryLocationId) {
@@ -98,7 +104,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumberPrefix,
       this.callNumberSuffix,
       this.callNumberTypeId,
-      this.hrid);
+      this.hrid,
+      this.discoverySuppress);
   }
 
   public HoldingRequestBuilder forInstance(UUID instanceId) {
@@ -112,7 +119,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumberPrefix,
       this.callNumberSuffix,
       this.callNumberTypeId,
-      this.hrid);
+      this.hrid,
+      this.discoverySuppress);
   }
 
   public HoldingRequestBuilder withId(UUID id) {
@@ -126,7 +134,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumberPrefix,
       this.callNumberSuffix,
       this.callNumberTypeId,
-      this.hrid);
+      this.hrid,
+      this.discoverySuppress);
   }
 
   public HoldingRequestBuilder withTags(JsonObject tags) {
@@ -140,7 +149,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumberPrefix,
       this.callNumberSuffix,
       this.callNumberTypeId,
-      this.hrid);
+      this.hrid,
+      this.discoverySuppress);
   }
 
   public HoldingRequestBuilder withCallNumber(String callNumber) {
@@ -154,7 +164,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumberPrefix,
       this.callNumberSuffix,
       this.callNumberTypeId,
-      this.hrid);
+      this.hrid,
+      this.discoverySuppress);
   }
 
   public HoldingRequestBuilder withCallNumberPrefix(String callNumberPrefix) {
@@ -168,7 +179,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       callNumberPrefix,
       this.callNumberSuffix,
       this.callNumberTypeId,
-      this.hrid);
+      this.hrid,
+      this.discoverySuppress);
   }
 
   public HoldingRequestBuilder withCallNumberSuffix(String callNumberSuffix) {
@@ -182,7 +194,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumberPrefix,
       callNumberSuffix,
       this.callNumberTypeId,
-      this.hrid);
+      this.hrid,
+      this.discoverySuppress);
   }
 
   public HoldingRequestBuilder withCallNumberTypeId(String callNumberTypeId) {
@@ -196,7 +209,8 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumberPrefix,
       this.callNumberSuffix,
       callNumberTypeId,
-      this.hrid);
+      this.hrid,
+      this.discoverySuppress);
   }
 
   public HoldingRequestBuilder withHrid(String hrid) {
@@ -210,6 +224,22 @@ public class HoldingRequestBuilder extends JsonRequestBuilder implements Builder
       this.callNumberPrefix,
       this.callNumberSuffix,
       this.callNumberTypeId,
-      hrid);
+      hrid,
+      this.discoverySuppress);
+  }
+
+  public HoldingRequestBuilder withDiscoverySuppress(Boolean discoverySuppress) {
+    return new HoldingRequestBuilder(
+      this.id,
+      this.instanceId,
+      this.permanentLocationId,
+      this.temporaryLocationId,
+      this.tags,
+      this.callNumber,
+      this.callNumberPrefix,
+      this.callNumberSuffix,
+      this.callNumberTypeId,
+      this.hrid,
+      discoverySuppress);
   }
 }

--- a/src/test/java/org/folio/rest/support/builders/JsonRequestBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/JsonRequestBuilder.java
@@ -11,6 +11,12 @@ public class JsonRequestBuilder {
     }
   }
 
+  protected void put(JsonObject request, String property, Boolean value) {
+    if(value != null) {
+      request.put(property, value);
+    }
+  }
+
   protected void put(JsonObject request, String property, UUID value) {
     if(value != null) {
       request.put(property, value.toString());


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-473 - Add b-tree indexes for staffSuppress and discoverySuppress properties.

### Changes:
* Add index for `instance.staffSuppress` and `instance.discoverySuppress` properties;
* Add index for `item.discoverySuppress` property;
* Add index for `holdingsRecord.discoverySuppress` property;