### PR TITLE
MODINVSTOR-483: Remove gen_random_uuid(), it fails in pgpool replication

### DIFF
--- a/src/main/resources/templates/db_scripts/hridSettings.sql
+++ b/src/main/resources/templates/db_scripts/hridSettings.sql
@@ -2,19 +2,12 @@
 ALTER TABLE ${myuniversity}_${mymodule}.${table.tableName}
   ADD COLUMN IF NOT EXISTS
     lock boolean DEFAULT true UNIQUE CHECK(lock=true);
--- Derive id from tenant, module and table, setting UUID version to 4 and
--- UUID variant byte to 8.
--- Don't use pgcrypto gen_random_uuid() because pg-pool cannot replicate
--- random numbers: https://www.pgpool.net/docs/latest/en/html/restrictions.html
 INSERT INTO ${myuniversity}_${mymodule}.${table.tableName}
-  SELECT id, jsonb_build_object(
-    'id', id,
+  SELECT 'a501f2a8-5b31-48b2-874d-2191e48db8cd', jsonb_build_object(
     'instances', jsonb_build_object('prefix', 'in', 'startNumber', 1),
     'holdings', jsonb_build_object('prefix', 'ho', 'startNumber', 1),
     'items', jsonb_build_object('prefix', 'it', 'startNumber', 1)
   )
-  FROM (SELECT overlay(overlay(md5('${myuniversity}_${mymodule}.${table.tableName}')
-                 placing '4' from 13) placing '8' from 17)::uuid AS id) AS alias
   ON CONFLICT DO NOTHING;
 
 -- create initial sequences for HRID generation


### PR DESCRIPTION
See https://issues.folio.org/browse/FOLIO-2447 : "Remove gen_random_uuid(), it fails in pgpool replication"