### PR TITLE
MODINVSTOR-468: RMB upgrade for hitcount (totalRecords) RMB-591

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>29.4.0</raml-module-builder-version>
+    <raml-module-builder-version>29.5.0-SNAPSHOT</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids</generate_routing_context>
     <argLine />
   </properties>

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -709,7 +709,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     json = searchForInstances("title=foo sortBy title/sort.descending", 1, 3);
     allInstances = json.getJsonArray(INSTANCES_KEY);
     assertThat(allInstances.size(), is(3));
-    assertThat(json.getInteger(TOTAL_RECORDS_KEY), is(999999999));
+    assertThat(json.getInteger(TOTAL_RECORDS_KEY), is(10));
     for (int i=0; i<3; i++) {
       JsonObject instance = allInstances.getJsonObject(i);
       assertThat(instance.getString("title"), is("d foo " + (4 - i)));

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -665,7 +665,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     json = searchForInstances("title=foo sortBy title", 0, 5);
     allInstances = json.getJsonArray(INSTANCES_KEY);
     assertThat(allInstances.size(), is(5));
-    assertThat(json.getInteger(TOTAL_RECORDS_KEY), is(999999999));
+    assertThat(json.getInteger(TOTAL_RECORDS_KEY), is(10));
     for (int i=0; i<5; i++) {
       JsonObject instance = allInstances.getJsonObject(i);
       assertThat(instance.getString("title"), is("b foo " + (i + 1)));


### PR DESCRIPTION
https://issues.folio.org/browse/RMB-591 made these changes (https://github.com/folio-org/raml-module-builder/pull/634, https://github.com/folio-org/raml-module-builder/pull/637):
* Always return some estimated totalRecords value for optimized get sql: PgUtil.getWithOptimizedSql.
* No longer use SQL FUNCTION count_estimate_default. It may take long for full text queries when running `SELECT COUNT(*) ... LIMIT 1000`. Instead take the estimation of Postgres' EXPLAIN. Only if that estimation is < 4000 run `SELECT COUNT(*) ... LIMIT 1000`.
* If it is the last page (because > 0 but less than LIMIT records returned) we know for sure the accurate result count and return it as totalRecords.

This pull request uses RMB 29.5.0-SNAPSHOT in mod-inventory-storage master to test it in the folio-perf environment as discussed on https://issues.folio.org/browse/MODINVSTOR-468 .