### PR TITLE
Modinvstor 479: Index - Filter Instance records by Date updated

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -428,6 +428,12 @@
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": false
+        },
+        {
+          "fieldName": "metadata.updatedDate",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
         }
       ],
       "fullTextIndex": [

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -564,9 +564,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject metadata = ir.getJson().getJsonObject("metadata");
 
-    String query = urlEncode(String.format("%s.updatedDate>=\"%s\"", METADATA_KEY, metadata.getString("updatedDate")));
+    String query = urlEncode(String.format("%s.updatedDate>=%s", METADATA_KEY, metadata.getString("updatedDate")));
 
-    client.get(instancesStorageUrl(String.format("query=%s", query)), StorageTestSuite.TENANT_ID,
+    client.get(instancesStorageUrl(String.format("?query=%s", query)), StorageTestSuite.TENANT_ID,
         ResponseHandler.json(getCompleted));
 
     Response response = getCompleted.get(5, TimeUnit.SECONDS);

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -542,7 +542,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canSearchUsingMetadataDateUpdatedIndexAll()
+  public void canSearchUsingMetadataDateUpdatedIndex()
     throws MalformedURLException,
     InterruptedException,
     ExecutionException,
@@ -576,6 +576,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     JsonArray allInstances = responseBody.getJsonArray("instances");
 
     assertThat(allInstances.size(), is(1));
+
+    JsonObject instance = allInstances.getJsonObject(0);
+
+    assertThat(instance.getString("title"), is(ir.getJson().getString("title")));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -566,7 +566,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     String query = urlEncode(String.format("%s.updatedDate>=\"%s\"", METADATA_KEY, metadata.getString("updatedDate")));
 
-    client.get(instancesStorageUrl(String.format("query=%s", query), ResponseHandler.json(getCompleted)));
+    client.get(instancesStorageUrl(String.format("query=%s", query)), StorageTestSuite.TENANT_ID,
+        ResponseHandler.json(getCompleted));
 
     Response response = getCompleted.get(5, TimeUnit.SECONDS);
 

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -542,6 +542,41 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  public void canSearchUsingMetadataDateUpdatedIndexAll()
+    throws MalformedURLException,
+    InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    UUID firstInstanceId = UUID.randomUUID();
+
+    JsonObject firstInstanceToCreate = smallAngryPlanet(firstInstanceId);
+
+    createInstance(firstInstanceToCreate);
+
+    UUID secondInstanceId = UUID.randomUUID();
+
+    JsonObject secondInstanceToCreate = nod(secondInstanceId);
+
+    createInstance(secondInstanceToCreate);
+
+    CompletableFuture<Response> getCompleted = new CompletableFuture<>();
+
+    JsonObject metadata = secondInstanceToCreate.getJsonObject("metadata");
+
+    client.get(instancesStorageUrl("?query=" + urlEncode("metadata.updatedDate>=\""+ metadata.getString("updatedDate") +"\"")), StorageTestSuite.TENANT_ID,
+        ResponseHandler.json(getCompleted));
+
+    Response response = getCompleted.get(5, TimeUnit.SECONDS);
+
+    JsonObject responseBody = response.getJson();
+
+    JsonArray allInstances = responseBody.getJsonArray("instances");
+
+    assertThat(allInstances.size(), is(1));
+  }
+
+  @Test
   public void canPageAllInstances()
     throws MalformedURLException,
     InterruptedException,

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -564,8 +564,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject metadata = secondInstanceToCreate.getJsonObject("metadata");
 
-    client.get(instancesStorageUrl("?query=" + urlEncode("metadata.updatedDate>=\""+ metadata.getString("updatedDate") +"\"")), StorageTestSuite.TENANT_ID,
-        ResponseHandler.json(getCompleted));
+    String query = urlEncode(String.format("%s.updatedDate>=\"%s\"", METADATA_KEY, metadata.getString("updatedDate")));
+
+    client.get(instancesStorageUrl(String.format("query=%s", query), ResponseHandler.json(getCompleted)));
 
     Response response = getCompleted.get(5, TimeUnit.SECONDS);
 

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -558,11 +558,11 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject secondInstanceToCreate = nod(secondInstanceId);
 
-    createInstance(secondInstanceToCreate);
+    IndividualResource ir = createInstance(secondInstanceToCreate);
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 
-    JsonObject metadata = secondInstanceToCreate.getJsonObject("metadata");
+    JsonObject metadata = ir.getJson().getJsonObject("metadata");
 
     String query = urlEncode(String.format("%s.updatedDate>=\"%s\"", METADATA_KEY, metadata.getString("updatedDate")));
 


### PR DESCRIPTION
Resolves [MODINVSTOR-479](https://issues.folio.org/browse/MODINVSTOR-479) by adding and index rule to the schema.json.