### PR TITLE
MODINVSTOR-478: Implement batch upsert for instances, holdings and items

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -35,7 +35,7 @@
     },
     {
       "id": "item-storage-batch-sync",
-      "version": "0.3",
+      "version": "0.4",
       "handlers": [
         {
           "methods": ["POST"],
@@ -77,7 +77,7 @@
     },
     {
       "id": "holdings-storage-batch-sync",
-      "version": "0.1",
+      "version": "0.2",
       "handlers": [
         {
           "methods": ["POST"],
@@ -193,7 +193,7 @@
     },
     {
       "id": "instance-storage-batch-sync",
-      "version": "0.2",
+      "version": "0.3",
       "handlers": [
         {
           "methods": ["POST"],

--- a/ramls/holdings-sync.raml
+++ b/ramls/holdings-sync.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Storage Holdings Batch Synchronous API
-version: v0.1
+version: v0.2
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 
@@ -14,14 +14,19 @@ types:
 /holdings-storage/batch/synchronous:
   displayName: Holdings Batch Upload Sync API
   post:
-    description: "Create a collection of holdings in a single synchronous request"
+    description: "Create or update a collection of holdings in a single synchronous request"
+    queryParameters:
+      upsert:
+        description: When a record with the same id already exists upsert=true will update it, upsert=false will fail the complete batch.
+        type: boolean
+        default: false
     body:
       application/json:
         type: holdingsrecords_post
         example: !include examples/holdingsrecords_post.json
     responses:
       201:
-        description: "All holdings have been successfully created"
+        description: "All holdings have been successfully created or updated"
       413:
         description: "Payload Too Large"
         body:

--- a/ramls/instance-sync.raml
+++ b/ramls/instance-sync.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Storage Instance Batch Sync API
-version: v0.2
+version: v0.3
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 
@@ -14,14 +14,19 @@ types:
 /instance-storage/batch/synchronous:
   displayName: Instances Batch Upload Sync API
   post:
-    description: "Create a collection of instances in a single synchronous request"
+    description: "Create or update a collection of instances in a single synchronous request"
+    queryParameters:
+      upsert:
+        description: When a record with the same id already exists upsert=true will update it, upsert=false will fail the complete batch.
+        type: boolean
+        default: false
     body:
       application/json:
         type: instances_post
         example: !include examples/instances_post.json
     responses:
       201:
-        description: "All instances have been successfully created"
+        description: "All instances have been successfully created or updated"
       413:
         description: "Payload Too Large"
         body:

--- a/ramls/item-sync.raml
+++ b/ramls/item-sync.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Storage Item Batch Sync API
-version: v0.3
+version: v0.4
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 
@@ -14,14 +14,19 @@ types:
 /item-storage/batch/synchronous:
   displayName: Item Batch Upload Sync API
   post:
-    description: "Create a collection of items in a single synchronous request"
+    description: "Create or update a collection of items in a single synchronous request"
+    queryParameters:
+      upsert:
+        description: When a record with the same id already exists upsert=true will update it, upsert=false will fail the complete batch.
+        type: boolean
+        default: false
     body:
       application/json:
         type: items_post
         example: !include examples/items_post.json
     responses:
       201:
-        description: "All items have been successfully created"
+        description: "All items have been successfully created or updated"
       413:
         description: "Payload Too Large"
         body:

--- a/src/main/java/org/folio/rest/impl/HoldingsBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsBatchSyncAPI.java
@@ -26,7 +26,7 @@ import java.util.Map;
 public class HoldingsBatchSyncAPI implements HoldingsStorageBatchSynchronous {
   @Validate
   @Override
-  public void postHoldingsStorageBatchSynchronous(HoldingsrecordsPost entity, Map<String, String> okapiHeaders,
+  public void postHoldingsStorageBatchSynchronous(boolean upsert, HoldingsrecordsPost entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     final List<HoldingsRecord> holdingsRecords = entity.getHoldingsRecords();
     final PostgresClient postgresClient = PostgresClient.getInstance(
@@ -43,7 +43,7 @@ public class HoldingsBatchSyncAPI implements HoldingsStorageBatchSynchronous {
     CompositeFuture.all(futures).setHandler(ar -> {
       if (ar.succeeded()) {
         StorageHelper.postSync(HoldingsStorageAPI.HOLDINGS_RECORD_TABLE, holdingsRecords,
-            okapiHeaders, asyncResultHandler, vertxContext,
+            okapiHeaders, upsert, asyncResultHandler, vertxContext,
             HoldingsStorageBatchSynchronous.PostHoldingsStorageBatchSynchronousResponse::respond201);
       } else {
         asyncResultHandler.handle(

--- a/src/main/java/org/folio/rest/impl/InstanceBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceBatchSyncAPI.java
@@ -26,7 +26,7 @@ import java.util.Map;
 public class InstanceBatchSyncAPI implements InstanceStorageBatchSynchronous {
   @Validate
   @Override
-  public void postInstanceStorageBatchSynchronous(InstancesPost entity, Map<String, String> okapiHeaders,
+  public void postInstanceStorageBatchSynchronous(boolean upsert, InstancesPost entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     final List<Instance> instances = entity.getInstances();
     final PostgresClient postgresClient = PostgresClient.getInstance(
@@ -43,7 +43,7 @@ public class InstanceBatchSyncAPI implements InstanceStorageBatchSynchronous {
     CompositeFuture.all(futures).setHandler(ar -> {
       if (ar.succeeded()) {
         StorageHelper.postSync(InstanceStorageAPI.INSTANCE_TABLE, entity.getInstances(),
-            okapiHeaders, asyncResultHandler, vertxContext,
+            okapiHeaders, upsert, asyncResultHandler, vertxContext,
             InstanceStorageBatchSynchronous.PostInstanceStorageBatchSynchronousResponse::respond201);
       } else {
         asyncResultHandler.handle(

--- a/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
@@ -17,9 +17,6 @@ import org.folio.rest.support.EndpointFailureHandler;
 import org.folio.rest.support.HridManager;
 import org.folio.rest.tools.utils.TenantTool;
 import org.folio.services.ItemEffectiveCallNumberComponentsService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
@@ -28,11 +25,9 @@ import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 
 public class ItemBatchSyncAPI implements ItemStorageBatchSynchronous {
-  private static final Logger log = LoggerFactory.getLogger(ItemBatchSyncAPI.class);
-
   @Validate
   @Override
-  public void postItemStorageBatchSynchronous(ItemsPost entity, Map<String, String> okapiHeaders,
+  public void postItemStorageBatchSynchronous(boolean upsert, ItemsPost entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     final List<Item> items = entity.getItems();
     final PostgresClient postgresClient = PostgresClient.getInstance(
@@ -53,7 +48,7 @@ public class ItemBatchSyncAPI implements ItemStorageBatchSynchronous {
       .compose(result -> effectiveCallNumberService.populateEffectiveCallNumberComponents(items))
       .map(result -> {
         StorageHelper.postSync(ItemStorageAPI.ITEM_TABLE, entity.getItems(),
-          okapiHeaders, asyncResultHandler, vertxContext,
+          okapiHeaders, upsert, asyncResultHandler, vertxContext,
           PostItemStorageBatchSynchronousResponse::respond201);
         return result;
       }).otherwise(EndpointFailureHandler.handleFailure(asyncResultHandler,

--- a/src/test/java/org/folio/rest/support/http/ResourceClient.java
+++ b/src/test/java/org/folio/rest/support/http/ResourceClient.java
@@ -169,11 +169,16 @@ public class ResourceClient {
   }
 
   public Response attemptToCreate(JsonObject request) throws MalformedURLException,
+      InterruptedException, ExecutionException, TimeoutException {
+    return attemptToCreate("", request);
+  }
+
+  public Response attemptToCreate(String subPath, JsonObject request) throws MalformedURLException,
     InterruptedException, ExecutionException, TimeoutException {
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
-    client.post(urlMaker.combine(""), request, StorageTestSuite.TENANT_ID,
+    client.post(urlMaker.combine(subPath), request, StorageTestSuite.TENANT_ID,
       ResponseHandler.any(createCompleted));
 
     return createCompleted.get(5, TimeUnit.SECONDS);


### PR DESCRIPTION
Extend each of these 3 existing HTTP POST endpoints

* /instance-storage/batch/synchronous
* /holdings-storage/batch/synchronous
* /item-storage/batch/synchronous

by an optional upsert parameter (default: false).

On upsert=true use PostgresClient.upsertBatch.