### PR TITLE
MODINVSTOR-494: Add 'Lost and paid' status to allowed item statuses list

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "item-storage",
-      "version": "8.3",
+      "version": "8.4",
       "handlers": [
         {
           "methods": ["GET"],
@@ -35,7 +35,7 @@
     },
     {
       "id": "item-storage-batch-sync",
-      "version": "0.3",
+      "version": "0.4",
       "handlers": [
         {
           "methods": ["POST"],

--- a/ramls/item-storage.raml
+++ b/ramls/item-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Item Storage
-version: v8.3
+version: v8.4
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item-sync.raml
+++ b/ramls/item-sync.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Storage Item Batch Sync API
-version: v0.3
+version: v0.4
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -244,7 +244,8 @@
             "Declared lost",
             "Order closed",
             "Claimed returned",
-            "Withdrawn"
+            "Withdrawn",
+            "Lost and paid"
           ]
         },
         "date": {

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -1487,12 +1487,8 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canSearchForItemsByTags()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    UnsupportedEncodingException {
+  public void canSearchForItemsByTags() throws MalformedURLException, InterruptedException,
+    ExecutionException, TimeoutException {
 
     UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
 
@@ -1527,12 +1523,8 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canSearchForItemsByStatus()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    UnsupportedEncodingException {
+  public void canSearchForItemsByStatus() throws MalformedURLException,
+    InterruptedException, ExecutionException, TimeoutException {
 
     UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
 
@@ -1763,8 +1755,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void tenantIsRequiredForGettingAnItem()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
+    throws InterruptedException, ExecutionException, TimeoutException {
 
     URL getInstanceUrl = itemsStorageUrl(String.format("/%s",
       UUID.randomUUID().toString()));
@@ -1781,8 +1772,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void tenantIsRequiredForGettingAllItems()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
+    throws InterruptedException, ExecutionException, TimeoutException {
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 
@@ -1936,7 +1926,8 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     "Declared lost",
     "Order closed",
     "Claimed returned",
-    "Withdrawn"
+    "Withdrawn",
+    "Lost and paid"
   })
   public void canCreateItemWithAllAllowedStatuses(String status) throws Exception {
     final UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
@@ -2215,16 +2206,15 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
         PostgresClient.getInstance(vertx, TENANT_ID);
     final CompletableFuture<Void> sequenceSet = new CompletableFuture<>();
 
-    vertx.runOnContext(v -> {
+    vertx.runOnContext(v ->
       postgresClient.selectSingle("select setval('hrid_items_seq',"
-          + sequenceNumber + ",FALSE)", r -> {
-            if (r.succeeded()) {
-              sequenceSet.complete(null);
-            } else {
-              sequenceSet.completeExceptionally(r.cause());
-            }
-          });
-    });
+        + sequenceNumber + ",FALSE)", r -> {
+        if (r.succeeded()) {
+          sequenceSet.complete(null);
+        } else {
+          sequenceSet.completeExceptionally(r.cause());
+        }
+      }));
 
     try {
       sequenceSet.get(2, SECONDS);


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-494 - Add 'Lost and paid' status to allowed item statuses list.

### Changes:
* Add the new `Lost and paid` status to item's allowed statuses;
* Update API version for `item-storage` and `item-sync`.
* Fix some static code analyzer issues in test class.