### PR TITLE
MODINVSTOR-478: Declare upsert parameter as optional

### DIFF
--- a/ramls/holdings-sync.raml
+++ b/ramls/holdings-sync.raml
@@ -19,6 +19,7 @@ types:
       upsert:
         description: When a record with the same id already exists upsert=true will update it, upsert=false will fail the complete batch.
         type: boolean
+        required: false
         default: false
     body:
       application/json:

--- a/ramls/instance-sync.raml
+++ b/ramls/instance-sync.raml
@@ -19,6 +19,7 @@ types:
       upsert:
         description: When a record with the same id already exists upsert=true will update it, upsert=false will fail the complete batch.
         type: boolean
+        required: false
         default: false
     body:
       application/json:

--- a/ramls/item-sync.raml
+++ b/ramls/item-sync.raml
@@ -19,6 +19,7 @@ types:
       upsert:
         description: When a record with the same id already exists upsert=true will update it, upsert=false will fail the complete batch.
         type: boolean
+        required: false
         default: false
     body:
       application/json:


### PR DESCRIPTION
Add "required: false" to the upsert parameter in the raml file.

This does not affect the validation. We have unit tests without
upsert parameter that succeed for all 3 API endpoints.

It affects the documentation published at
https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/instance-sync.html#instance_storage_batch_synchronous_post
https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/holdings-sync.html#holdings_storage_batch_synchronous_post
https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/item-sync.html#item_storage_batch_synchronous_post
where upsert parameter incorrectly is marked as "required" in red.