### PR TITLE
FOLIO-2625: Upgrade to RMB v30.0.2 for hitcount/analyze fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>30.0.0</raml-module-builder-version>
+    <raml-module-builder-version>30.0.2</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances</generate_routing_context>
     <argLine />
   </properties>


### PR DESCRIPTION
RMB [v30.0.2](https://github.com/folio-org/raml-module-builder/releases/tag/v30.0.2) contains the fix

* [RMB-637](https://issues.folio.org/browse/RMB-637) Run ANALYZE after index (re-)creation

that is needed to solve [FOLIO-2625](https://issues.folio.org/browse/FOLIO-2625).