### PR TITLE
MODINVSTOR-519: Upgrade RMB to 30.0.3, fixing inconsistent hit counts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,11 +85,11 @@
   </dependencies>
 
   <properties>
-    <vertx.version>3.9.0</vertx.version>
+    <vertx.version>3.9.1</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>30.0.2</raml-module-builder-version>
+    <raml-module-builder-version>30.0.3</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances</generate_routing_context>
     <argLine />
   </properties>


### PR DESCRIPTION
Upgrade RMB from 30.0.2 to 30.0.3.
No longer downgrade vertx-unit from 3.9.1 to 3.9.0.

The RMB upgrade contains two fixes relevant for mod-inventory-storage:

* [RMB-645](https://issues.folio.org/browse/RMB-645) Use where-only clause for the "count query" for consistent hit count estimations
* [RMB-640](https://issues.folio.org/browse/RMB-640) Fix Sorby title and limit=0 gives zero hits