### PR TITLE
Release 19.2.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## 19.2.1 2020-06-15
+
+* Upgrade to RAML Module Builder 30.0.3 (MODINVSTOR-519):
+  * Use where-only clause for the "count query" for consistent hit count estimations (RMB-645)
+  * Fix sorby title and limit=0 gives zero hits (RMB-640)
+
 ## 19.2.0 2020-06-08
 
 * Introduces normalised ISBN and invalid ISBN indexes (MODINVSTOR-413, MODINVSTOR-474)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>19.2.1</version>
+  <version>19.3.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -115,7 +115,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>v19.2.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>19.3.0-SNAPSHOT</version>
+  <version>19.2.1</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -115,7 +115,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v19.2.1</tag>
   </scm>
 
   <build>


### PR DESCRIPTION
* Upgrade to RAML Module Builder 30.0.3 (MODINVSTOR-519):
  * Use where-only clause for the "count query" for consistent hit count estimations (RMB-645)
  * Fix sorby title and limit=0 gives zero hits (RMB-640)
