### PR TITLE
MODINVSTOR-476: Avoid special permissions for trigger disabling/enabling

### DIFF
--- a/src/main/resources/templates/db_scripts/migrateItemCopyNumberToSingleValue.sql
+++ b/src/main/resources/templates/db_scripts/migrateItemCopyNumberToSingleValue.sql
@@ -1,10 +1,6 @@
 START TRANSACTION;
 
-UPDATE pg_trigger
-  SET tgenabled = 'D'
-WHERE tgrelid = '${myuniversity}_${mymodule}.item'::regclass::oid
-  AND tgisinternal IS FALSE
-  AND tgenabled = 'O';
+ALTER TABLE ${myuniversity}_${mymodule}.item DISABLE TRIGGER USER;
 
 UPDATE ${myuniversity}_${mymodule}.item
 SET jsonb = CASE WHEN
@@ -15,10 +11,6 @@ SET jsonb = CASE WHEN
 END
 WHERE jsonb->'copyNumbers' IS NOT NULL;
 
-UPDATE pg_trigger
-  SET tgenabled = 'O'
-WHERE tgrelid = '${myuniversity}_${mymodule}.item'::regclass::oid
-  AND tgisinternal IS FALSE
-  AND tgenabled = 'D';
+ALTER TABLE ${myuniversity}_${mymodule}.item ENABLE TRIGGER USER;
 
 END TRANSACTION;

--- a/src/main/resources/templates/db_scripts/populateDiscoverySuppressIfNotSet.sql
+++ b/src/main/resources/templates/db_scripts/populateDiscoverySuppressIfNotSet.sql
@@ -1,19 +1,11 @@
 START TRANSACTION;
 
-UPDATE pg_trigger
-  SET tgenabled = 'D'
-WHERE tgrelid = '${myuniversity}_${mymodule}.instance'::regclass::oid
-  AND tgisinternal IS FALSE
-  AND tgenabled = 'O';
+ALTER TABLE ${myuniversity}_${mymodule}.instance DISABLE TRIGGER USER;
 
 UPDATE ${myuniversity}_${mymodule}.instance
   SET jsonb = JSONB_SET(instance.jsonb, '{discoverySuppress}', TO_JSONB(false))
 WHERE jsonb->>'discoverySuppress' IS NULL;
 
-UPDATE pg_trigger
-  SET tgenabled = 'O'
-WHERE tgrelid = '${myuniversity}_${mymodule}.instance'::regclass::oid
-  AND tgisinternal IS FALSE
-  AND tgenabled = 'D';
+ALTER TABLE ${myuniversity}_${mymodule}.instance ENABLE TRIGGER USER;
 
 END TRANSACTION;

--- a/src/main/resources/templates/db_scripts/populateEffectiveCallNumberComponentsForExistingItems.sql
+++ b/src/main/resources/templates/db_scripts/populateEffectiveCallNumberComponentsForExistingItems.sql
@@ -1,10 +1,6 @@
 START TRANSACTION;
 
-UPDATE pg_trigger
-  SET tgenabled = 'D'
-WHERE tgrelid = '${myuniversity}_${mymodule}.item'::regclass::oid
-  AND tgisinternal IS FALSE
-  AND tgenabled = 'O';
+ALTER TABLE ${myuniversity}_${mymodule}.item DISABLE TRIGGER USER;
 
 UPDATE ${myuniversity}_${mymodule}.item AS it
   SET jsonb = JSONB_SET(
@@ -20,10 +16,6 @@ UPDATE ${myuniversity}_${mymodule}.item AS it
 FROM ${myuniversity}_${mymodule}.holdings_record AS hr
 WHERE hr.id = it.holdingsrecordid;
 
-UPDATE pg_trigger
-  SET tgenabled = 'O'
-WHERE tgrelid = '${myuniversity}_${mymodule}.item'::regclass::oid
-  AND tgisinternal IS FALSE
-  AND tgenabled = 'D';
+ALTER TABLE ${myuniversity}_${mymodule}.item ENABLE TRIGGER USER;
 
 END TRANSACTION;

--- a/src/main/resources/templates/db_scripts/populateEffectiveLocationForExistingItems.sql
+++ b/src/main/resources/templates/db_scripts/populateEffectiveLocationForExistingItems.sql
@@ -1,10 +1,6 @@
 START TRANSACTION;
 
-UPDATE pg_trigger
-  SET tgenabled = 'D'
-WHERE tgrelid = '${myuniversity}_${mymodule}.item'::regclass::oid
-  AND tgisinternal IS FALSE
-  AND tgenabled = 'O';
+ALTER TABLE ${myuniversity}_${mymodule}.item DISABLE TRIGGER USER;
 
 UPDATE ${myuniversity}_${mymodule}.item AS it
   -- Since holdings_record.permanentLocationId and item.holdingsRecordId are required there can not be a NULL value
@@ -19,10 +15,6 @@ UPDATE ${myuniversity}_${mymodule}.item AS it
 FROM ${myuniversity}_${mymodule}.holdings_record AS hr
 WHERE hr.id = it.holdingsrecordid;
 
-UPDATE pg_trigger
-  SET tgenabled = 'O'
-WHERE tgrelid = '${myuniversity}_${mymodule}.item'::regclass::oid
-  AND tgisinternal IS FALSE
-  AND tgenabled = 'D';
+ALTER TABLE ${myuniversity}_${mymodule}.item ENABLE TRIGGER USER;
 
 END TRANSACTION;

--- a/src/main/resources/templates/db_scripts/populateEffectiveLocationForeignKey.sql
+++ b/src/main/resources/templates/db_scripts/populateEffectiveLocationForeignKey.sql
@@ -1,18 +1,10 @@
 START TRANSACTION;
 
-UPDATE pg_trigger
-  SET tgenabled = 'D'
-WHERE tgrelid = '${myuniversity}_${mymodule}.item'::regclass::oid
-  AND tgisinternal IS FALSE
-  AND tgenabled = 'O';
+ALTER TABLE ${myuniversity}_${mymodule}.item DISABLE TRIGGER USER;
 
 UPDATE ${myuniversity}_${mymodule}.item
   SET effectiveLocationId = (jsonb->>'effectiveLocationId')::uuid;
 
-UPDATE pg_trigger
-  SET tgenabled = 'O'
-WHERE tgrelid = '${myuniversity}_${mymodule}.item'::regclass::oid
-  AND tgisinternal IS FALSE
-  AND tgenabled = 'D';
+ALTER TABLE ${myuniversity}_${mymodule}.item ENABLE TRIGGER USER;
 
 END TRANSACTION;


### PR DESCRIPTION
Replace `UPDATE pg_trigger` (that requires special permissions) by
`ALTER TABLE <table> DISABLE TRIGGER USER` and
`ALTER TABLE <table> ENABLE TRIGGER USER`.

`USER` excludes internally generated constraint triggers such as those that
are used to implement foreign key constraints or deferrable uniqueness and
exclusion constraints that require superuser privileges.