### PR TITLE
MODINVSTOR-522: Upgrade RMB to v30.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>30.0.3</raml-module-builder-version>
+    <raml-module-builder-version>30.2.0</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances</generate_routing_context>
     <argLine />
   </properties>

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -1402,7 +1402,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(errors.size(), is(1));
 
     JsonObject firstError = errors.getJsonObject(0);
-    assertThat(firstError.getString("message"), is("may not be null"));
+    assertThat(firstError.getString("message"), anyOf(is("may not be null"), is("must not be null")));
     assertThat(firstError.getJsonArray("parameters").getJsonObject(0).getString("key"),
       is("permanentLocationId"));
   }

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -24,6 +24,7 @@ import static org.folio.rest.support.matchers.PostgresErrorMessageMatchers.isMax
 import static org.folio.rest.support.matchers.ResponseMatcher.hasValidationError;
 import static org.folio.util.StringUtil.urlEncode;
 import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.anyOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
@@ -500,8 +501,9 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
       postResponse.getJson().getJsonArray("errors"));
 
     assertThat(errors.size(), is(1));
-    assertThat(errors, hasItem(
-      validationErrorMatches("may not be null", "materialTypeId")));
+    assertThat(errors, anyOf(
+        hasItem(validationErrorMatches("may not be null", "materialTypeId")),
+        hasItem(validationErrorMatches("must not be null", "materialTypeId"))));
   }
 
   @Test
@@ -1883,7 +1885,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(updateResponse.getErrors().size(), is(1));
 
     JsonObject error = updateResponse.getErrors().get(0);
-    assertThat(error.getString("message"), is("may not be null"));
+    assertThat(error.getString("message"), anyOf(is("may not be null"), is("must not be null")));
     assertThat(error.getJsonArray("parameters").getJsonObject(0).getString("key"),
       is("status"));
   }
@@ -1915,7 +1917,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(updateResponse.getErrors().size(), is(1));
 
     JsonObject error = updateResponse.getErrors().get(0);
-    assertThat(error.getString("message"), is("may not be null"));
+    assertThat(error.getString("message"), anyOf(is("may not be null"), is("must not be null")));
     assertThat(error.getJsonArray("parameters").getJsonObject(0).getString("key"),
       is("status.name"));
   }
@@ -1926,9 +1928,10 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     itemArray.getJsonObject(1).remove("status");
 
     final Response response = postSynchronousBatch(itemArray);
-    assertThat(response,
-      hasValidationError("may not be null", "items[1].status", "null")
-    );
+    assertThat(response, anyOf(
+        hasValidationError("may not be null", "items[1].status", "null"),
+        hasValidationError("must not be null", "items[1].status", "null")
+    ));
 
     for (int i = 0; i < itemArray.size(); i++) {
       assertGetNotFound(itemsStorageUrl("/" + itemArray.getJsonObject(i).getString("id")));


### PR DESCRIPTION
First try out RMB v30.2.0 in master to see whether there are any regressions in folio-testing and folio-perf.

See https://issues.folio.org/browse/RMB-652 '"may not be null" changed to "must not be null" (hibernate-validator)'
why several unit tests were changed to also accept the new wording.