### PR TITLE
MODINVSTOR-499: Add Index for Instances Full-text Subjects Search

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -375,7 +375,7 @@
         },
         {
           "fieldName": "subjects",
-          "tOps": "ADD",
+          "tOps": "DELETE",
           "caseSensitive": false,
           "removeAccents": true
         }
@@ -466,6 +466,12 @@
           "fieldName": "isbn",
           "sqlExpression" : "normalize_isbns(jsonb->'identifiers')",
           "sqlExpressionQuery": "normalize_digits($)"
+        },
+        {
+          "fieldName": "subjects",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
         }
       ]
     },

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -1133,6 +1133,37 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  public void canSearchBySubjects() throws Exception {
+    JsonObject first = new JsonObject()
+        .put("title", "first")
+        .put("subjects", new JsonArray().add("foo").add("bar").add("baz"));
+    JsonObject second = new JsonObject()
+        .put("title", "second")
+        .put("subjects", new JsonArray().add("abc def ghi").add("uvw xyz"));
+
+    JsonObject [] instances = { first, second };
+    for (JsonObject instance : instances) {
+      instance.put("source", "test");
+      instance.put("instanceTypeId", UUID_INSTANCE_TYPE.toString());
+      createInstance(instance);
+    }
+
+    matchInstanceTitles(searchForInstances("subjects=foo"), "first");
+    matchInstanceTitles(searchForInstances("subjects=bar"), "first");
+    matchInstanceTitles(searchForInstances("subjects=baz"), "first");
+    matchInstanceTitles(searchForInstances("subjects=abc"), "second");
+    matchInstanceTitles(searchForInstances("subjects=def"), "second");
+    matchInstanceTitles(searchForInstances("subjects=ghi"), "second");
+    matchInstanceTitles(searchForInstances("subjects=uvw"), "second");
+    matchInstanceTitles(searchForInstances("subjects=xyz"), "second");
+    // phrase search
+    matchInstanceTitles(searchForInstances("subjects=\"def ghi\""), "second");
+    matchInstanceTitles(searchForInstances("subjects=\"uvw xyz\""), "second");
+    matchInstanceTitles(searchForInstances("subjects=\"baz bar\""));
+    matchInstanceTitles(searchForInstances("subjects=\"abc xyz\""));
+  }
+
+  @Test
   public void canSearchByBarcode()
     throws InterruptedException,
     MalformedURLException,


### PR DESCRIPTION
The JSON array characters ["", ""] are ignored by full text search,
no need to strip them.

The generated query for subjects=a* uses the new index instance_subjects_idx_ft:

```
postgres=# explain analyze select count(*) from instance WHERE to_tsvector('simple', f_unaccent(instance.jsonb->>'subjects')) @@ tsquery_phrase(f_unaccent('a*'));
                                                               QUERY PLAN
-----------------------------------------------------------------------------------------------------------------------------------------
 Aggregate  (cost=35.68..35.69 rows=1 width=8) (actual time=0.029..0.029 rows=1 loops=1)
   ->  Bitmap Heap Scan on instance  (cost=20.08..35.66 rows=10 width=0) (actual time=0.022..0.027 rows=5 loops=1)
         Recheck Cond: (to_tsvector('simple'::regconfig, f_unaccent((jsonb ->> 'subjects'::text))) @@ '''a'':*'::tsquery)
         Heap Blocks: exact=4
         ->  Bitmap Index Scan on instance_subjects_idx_ft  (cost=0.00..20.07 rows=10 width=0) (actual time=0.016..0.016 rows=5 loops=1)
               Index Cond: (to_tsvector('simple'::regconfig, f_unaccent((jsonb ->> 'subjects'::text))) @@ '''a'':*'::tsquery)
```