### PR TITLE
MODINVSTOR-528: Upgrade to RMB 30.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>30.2.0</raml-module-builder-version>
+    <raml-module-builder-version>30.2.2</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances</generate_routing_context>
     <argLine />
   </properties>


### PR DESCRIPTION
Most notable fix: RMB-657 Database connections no longer
get cancelled when they take longer than 60 seconds.
This probably resolves MODINVSTOR-527.

Changelog:
https://github.com/folio-org/raml-module-builder/releases/tag/v30.2.2