### PR TITLE
MODINVSTOR-531: Update to RMB v30.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>30.2.2</raml-module-builder-version>
+    <raml-module-builder-version>30.2.3</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances</generate_routing_context>
     <argLine />
   </properties>


### PR DESCRIPTION
There is no need for mod-inventory-storage to get this RMB v30.2.3
release but I would like to have it in the performance test and in
folio-testing and folio-snapshot to be sure that there are no regressions.