### PR TITLE
MODINVSTOR-532: RMB 30.2.4: totalRecords for limit=0, requestId logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>30.2.3</raml-module-builder-version>
+    <raml-module-builder-version>30.2.4</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances</generate_routing_context>
     <argLine />
   </properties>


### PR DESCRIPTION
Updating RMB from 30.2.3 to 30.2.4 fixes this:
https://issues.folio.org/browse/RMB-673 totalRecords returns exact hit count for limit=0
https://issues.folio.org/browse/RMB-670 Fix RestVerticle requestId logging, replace log4j 1.2 MDC by log4j 2 ThreadContext