### PR TITLE
MODINVSTOR-472: Add missing indexes.

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -99,6 +99,14 @@
           "targetTable": "loclibrary",
           "tOps": "ADD"
         }
+      ],
+      "index": [
+        {
+          "fieldName": "primaryServicePoint",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
+        }
       ]
     },
     {
@@ -113,6 +121,14 @@
         {
           "fieldName": "code",
           "tOps": "ADD"
+        }
+      ],
+      "index": [
+        {
+          "fieldName": "pickupLocation",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
         }
       ]
     },
@@ -761,6 +777,12 @@
         },
         {
           "fieldName": "discoverySuppress",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": false
+        },
+        {
+          "fieldName": "purchaseOrderLineIdentifier",
           "tOps": "ADD",
           "caseSensitive": false,
           "removeAccents": false

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -2111,6 +2111,23 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
       containsInAnyOrder(notSuppressedItem.getId(), notSuppressedItemDefault.getId()));
   }
 
+  @Test
+  public void canSearchByPurchaseOrderLineIdentifierProperty() throws Exception {
+    final UUID holdingsId = createInstanceAndHolding(mainLibraryLocationId);
+
+    final IndividualResource firstItem = itemsClient.create(
+      smallAngryPlanet(holdingsId).put("purchaseOrderLineIdentifier", "poli-1"));
+
+    itemsClient.create(smallAngryPlanet(holdingsId)
+      .put("purchaseOrderLineIdentifier", "poli-2"));
+
+    final List<IndividualResource> poli1Items = itemsClient
+      .getMany("purchaseOrderLineIdentifier==\"poli-1\"");
+
+    assertThat(poli1Items.size(), is(1));
+    assertThat(poli1Items.get(0).getId(), is(firstItem.getId()));
+  }
+
   private Response getById(UUID id) throws InterruptedException,
     ExecutionException, TimeoutException {
 

--- a/src/test/java/org/folio/rest/api/LocationsTest.java
+++ b/src/test/java/org/folio/rest/api/LocationsTest.java
@@ -1,10 +1,14 @@
 package org.folio.rest.api;
 
+import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.loanTypesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.locCampusStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.locInstitutionStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.locLibraryStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.locationsStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.materialTypesStorageUrl;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -25,6 +29,8 @@ import java.util.stream.Collectors;
 import org.folio.rest.support.AdditionalHttpStatusCodes;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
+import org.folio.rest.support.client.LoanTypesClient;
+import org.folio.rest.support.client.MaterialTypesClient;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -73,11 +79,26 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
   }
 
   @Before
-  public void beforeEach() {
+  public void beforeEach() throws InterruptedException, ExecutionException,
+    TimeoutException {
+
+    StorageTestSuite.deleteAll(itemsStorageUrl(""));
+    StorageTestSuite.deleteAll(holdingsStorageUrl(""));
+    StorageTestSuite.deleteAll(instancesStorageUrl(""));
     StorageTestSuite.deleteAll(locationsStorageUrl(""));
     StorageTestSuite.deleteAll(locLibraryStorageUrl(""));
     StorageTestSuite.deleteAll(locCampusStorageUrl(""));
     StorageTestSuite.deleteAll(locInstitutionStorageUrl(""));
+    StorageTestSuite.deleteAll(loanTypesStorageUrl(""));
+    StorageTestSuite.deleteAll(materialTypesStorageUrl(""));
+
+    canCirculateLoanTypeID = new LoanTypesClient(
+      new org.folio.rest.support.HttpClient(StorageTestSuite.getVertx()),
+      loanTypesStorageUrl("")).create("Can Circulate");
+
+    journalMaterialTypeID = new MaterialTypesClient(
+      new org.folio.rest.support.HttpClient(StorageTestSuite.getVertx()),
+      materialTypesStorageUrl("")).create("Journal");
 
     createLocUnits(true);
   }


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-472 - Search queries without database index

## Changes:
* Add b-tree indexes:
  * `location.primaryServicePoint`
  * `service_point.pickupLocation`
  * `item.purchaseOrderLineIdentifier`