### PR TITLE
MODINVSTOR-536: Separate filtering from response generation in oai-pmh view

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1057,10 +1057,14 @@
     },
     {
       "id": "oaipmhview",
-      "version": "1.0",
+      "version": "2.0",
       "handlers" : [
         {
           "methods" : [ "GET" ],
+          "pathPattern" : "/oai-pmh-view/updatedInstanceIds",
+          "permissionsRequired": ["inventory-storage.oai-pmh-view.updatedinstanceids.collection.get"]
+        }, {
+          "methods" : [ "POST" ],
           "pathPattern" : "/oai-pmh-view/instances",
           "permissionsRequired": ["inventory-storage.oai-pmh-view.instances.collection.get"]
         }

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
     <raml-module-builder-version>30.2.4</raml-module-builder-version>
-    <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances</generate_routing_context>
+    <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds</generate_routing_context>
     <argLine />
   </properties>
 

--- a/ramls/examples/oaipmhinstanceids.json
+++ b/ramls/examples/oaipmhinstanceids.json
@@ -1,6 +1,6 @@
 {
-  "instanceid": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39",
-  "instanceUpdatedDate": "2020-06-23",
-  "suppressdiscovery": false,
+  "instanceId": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39",
+  "instanceUpdatedDate": "2020-06-23T12:00:00Z",
+  "suppressDiscovery": false,
   "deleted": false
 }

--- a/ramls/examples/oaipmhinstanceids.json
+++ b/ramls/examples/oaipmhinstanceids.json
@@ -1,0 +1,6 @@
+{
+  "instanceid": "5bf370e0-8cca-4d9c-82e4-5170ab2a0a39",
+  "instanceUpdatedDate": "2020-06-23",
+  "suppressdiscovery": false,
+  "deleted": false
+}

--- a/ramls/oai-pmh-view.raml
+++ b/ramls/oai-pmh-view.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Storage OAI-PMH view API
-version: v1.0
+version: v2.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://github.com/org/folio/mod-inventory-storage
 
@@ -10,6 +10,7 @@ documentation:
 
 types:
   oaipmhInstances: !include oaipmh/oaipmhinstances.json
+  oaipmhInstanceIds: !include oaipmh/oaipmhinstanceids.json
   errors: !include raml-util/schemas/errors.schema
 
 traits:
@@ -20,14 +21,14 @@ resourceTypes:
   collection-get: !include raml-util/rtypes/collection-get.raml
 
 /oai-pmh-view:
-  /instances:
-    displayName: Stream API to get data for OAI-PMH
+  /updatedInstanceIds:
+    displayName: Stream API to get instances ids for OAI-PMH
     type:
       collection-get:
        schemaCollection: oaipmhInstances
        exampleCollection: !include examples/oaipmhinstances.json
     get:
-      description: Stream data for oai-pmh
+      description: Stream updated instances ids for oai-pmh
       is:
         [validate]
       queryParameters:
@@ -49,4 +50,25 @@ resourceTypes:
           type: boolean
           required: false
           default: true
-
+  /instances:
+    displayName: Stream API to get instances with items and holdings for OAI-PMH
+    post:
+      description: Stream instances view data for oai-pmh
+      is:
+        [validate]
+      body:
+        application/json:
+          description: List of instances Ids
+          type: string[]
+      queryParameters:
+        skipSuppressedFromDiscoveryRecords:
+          description: skip discovery suppressed records
+          type: boolean
+          required: false
+          default: true
+      responses:
+        200:
+          body:
+            application/json:
+              type: oaipmhInstanceIds
+              example: !include examples/oaipmhinstanceids.json

--- a/ramls/oaipmh/oaipmhinstanceids.json
+++ b/ramls/oaipmh/oaipmhinstanceids.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Response schema for oai-pmh updated instances ids view",
+  "type": "object",
+  "properties": {
+    "instanceids": {
+      "description": "OAI-PMH updated instances ids",
+      "type": "array",
+      "maxDate": {
+      "description": "The last updated date or deleted date of an instance or it's items and holdings",
+      "type": "string",
+      "format": "date-time"
+      },
+      "suppressDiscovery": {
+        "description": "Indicates if instance should be suppressed from discovery",
+        "type": "boolean"
+      },
+      "deleted": {
+        "description": "Indicates if an instance was deleted in inventory",
+        "type": "boolean"
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/ramls/oaipmh/oaipmhinstanceids.json
+++ b/ramls/oaipmh/oaipmhinstanceids.json
@@ -3,22 +3,22 @@
   "description": "Response schema for oai-pmh updated instances ids view",
   "type": "object",
   "properties": {
-    "instanceids": {
+    "instanceId": {
       "description": "OAI-PMH updated instances ids",
-      "type": "array",
-      "maxDate": {
+      "type": "string"
+    },
+    "instanceUpdatedDate": {
       "description": "The last updated date or deleted date of an instance or it's items and holdings",
       "type": "string",
       "format": "date-time"
-      },
-      "suppressDiscovery": {
+    },
+    "suppressDiscovery": {
         "description": "Indicates if instance should be suppressed from discovery",
         "type": "boolean"
-      },
-      "deleted": {
+    },
+    "deleted": {
         "description": "Indicates if an instance was deleted in inventory",
         "type": "boolean"
-      }
     }
   },
   "additionalProperties": false

--- a/ramls/oaipmh/oaipmhinstances.json
+++ b/ramls/oaipmh/oaipmhinstances.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "Response schema for oai-pmh view",
+  "description": "Response schema for oai-pmh instances view",
   "type": "object",
   "properties": {
     "instance": {

--- a/src/main/resources/templates/db_scripts/oaipmh/createOaiPmhViewFunction.sql
+++ b/src/main/resources/templates/db_scripts/oaipmh/createOaiPmhViewFunction.sql
@@ -66,7 +66,7 @@ create or replace function ${myuniversity}_${mymodule}.pmh_get_updated_instances
             )
 as
 $body$
-with instanceIdsInRange as ( select inst.id                                                      as instanceId,
+with instanceIdsInRange as ( select inst.id                                                       as instanceId,
                                     (strToTimestamp(inst.jsonb -> 'metadata' ->> 'updatedDate')) as maxDate
                              from ${myuniversity}_${mymodule}.instance inst
                              where (strToTimestamp(inst.jsonb -> 'metadata' ->> 'updatedDate')) between dateOrMin($1) and dateOrMax($2)
@@ -100,7 +100,6 @@ select instanceId,
                                      where instanceIdsInRange.maxDate between dateOrMin($1) and dateOrMax($2)
                                        and instance.id = instanceIdsInRange.instanceId
                                        and not ($4 and coalesce((instance.jsonb ->> 'discoverySuppress')::bool, false))
-
                                      group by 1, 3
 union all
 select (audit_instance.jsonb #>> '{record,id}')::uuid as instanceId,
@@ -113,9 +112,6 @@ where $3
 
 $body$ language sql;
 
-
-
-
 create or replace function ${myuniversity}_${mymodule}.pmh_instance_view_function(instanceIds text[],
                                                                          skipSuppressedFromDiscoveryRecords bool default true)
     returns table
@@ -125,7 +121,7 @@ create or replace function ${myuniversity}_${mymodule}.pmh_instance_view_functio
             )
 as
 $body$
-     select instId,
+select instId,
 (select to_jsonb(itemAndHoldingsAttrs) as itemsAndHoldingsFields
          from ( select hr.instanceid,
                        jsonb_agg(jsonb_build_object('id', item.id, 'callNumber',
@@ -158,7 +154,7 @@ $body$
                                                                 coalesce(hr.jsonb #> '{electronicAccess}', '[]'::jsonb)),
                                                     'suppressDiscovery',
                                                                 coalesce((hr.jsonb ->> 'discoverySuppress')::bool, false) or
-                                                                coalesce((item.jsonb ->> 'discoverySuppress')::bool, false)
+                                                                coalesce((item.jsonb ->> 'discoverySuppress')::bool, false),
                                                     'notes',
                                                     getItemNoteTypeName(item.jsonb-> 'notes'),
                                                     'barcode',

--- a/src/main/resources/templates/db_scripts/oaipmh/createOaiPmhViewFunction.sql
+++ b/src/main/resources/templates/db_scripts/oaipmh/createOaiPmhViewFunction.sql
@@ -54,9 +54,9 @@ create index if not exists audit_holdings_record_pmh_createddate_idx on ${myuniv
 create index if not exists audit_item_pmh_createddate_idx on ${myuniversity}_${mymodule}.audit_item ((strToTimestamp(jsonb -> 'record' ->> 'updatedDate')));
 
 create or replace function ${myuniversity}_${mymodule}.pmh_get_updated_instances_ids(startDate timestamptz,
-                                                                         endDate timestamptz,
-                                                                         deletedRecordSupport bool default true,
-                                                                         skipSuppressedFromDiscoveryRecords bool default true)
+                                                                                     endDate timestamptz,
+                                                                                     deletedRecordSupport bool default true,
+                                                                                     skipSuppressedFromDiscoveryRecords bool default true)
     returns table
             (
                 instanceId             uuid,
@@ -112,8 +112,8 @@ where $3
 
 $body$ language sql;
 
-create or replace function ${myuniversity}_${mymodule}.pmh_instance_view_function(instanceIds text[],
-                                                                         skipSuppressedFromDiscoveryRecords bool default true)
+create or replace function ${myuniversity}_${mymodule}./(instanceIds uuid[],
+                                                                                  skipSuppressedFromDiscoveryRecords bool default true)
     returns table
             (
                 instanceId             uuid,


### PR DESCRIPTION
Updated RAML description and implementation for intances view. Now it consists from two routines: 
1) "updated instances view" and 2) "instances view" itself. The order of invocatrion is the same as mentioned above.

