### PR TITLE
MODINVSTOR-541: Make migratePrecedingSucceedingTitles.sql idempotent

### DIFF
--- a/src/main/resources/templates/db_scripts/migratePrecedingSucceedingTitles.sql
+++ b/src/main/resources/templates/db_scripts/migratePrecedingSucceedingTitles.sql
@@ -5,4 +5,5 @@ INSERT INTO ${myuniversity}_${mymodule}.preceding_succeeding_title (id, jsonb)
     'precedingInstanceId', jsonb->'superInstanceId',
     'succeedingInstanceId', jsonb->'subInstanceId')
   FROM ${myuniversity}_${mymodule}.instance_relationship as ir
-  WHERE ir.instanceRelationshipTypeId ='cde80cc2-0c8b-4672-82d4-721e51dcb990';
+  WHERE ir.instanceRelationshipTypeId ='cde80cc2-0c8b-4672-82d4-721e51dcb990'
+  ON CONFLICT DO NOTHING;


### PR DESCRIPTION
GBV tried migrating from mod-inventory-storage-18.2.3 to mod-inventory-storage-19.2.4 three times.
The second time failed with this error:
```
INFO  PostgresClient [30313837eqId] trying to execute:  INSERT INTO diku_mod_inventory_storage.preceding_succeeding_title (id, jsonb)   SELECT id, jsonb_build_object(     'id', jsonb->'id',     'metadata', jsonb->'metadata',    'precedingInstanceId', jsonb->'superInstanceId',     'succeedingInstanceId', jsonb->'subInstanceId')   FROM diku_mod_inventory_storage.instance_relationship as ir   WHERE ir.instanceRelationshipTypeId ='cde80cc2-0c8b-4672-82d4-721e51dcb990'
ERROR PostgresClient [30313841eqId] FEHLER: doppelter Schlüsselwert verletzt Unique-Constraint »preceding_succeeding_title_pkey«
  Detail: Schlüssel »(id)=(1e772f36-20ac-4429-955b-8cd6c7dd644a)« existiert bereits.
```
In English:
```
ERROR:  duplicate key violates unique constraint »preceding_succeeding_title_pkey«
  Detail: Key »(id)=(1e772f36-20ac-4429-955b-8cd6c7dd644a)« already exists.
```

The migration for preceeding and succeeding titles should be idempotent
(upgrade can run several times without failing) by using
`ON CONFLICT DO NOTHING`.
This solved the issue for GBV when running migratePrecedingSucceedingTitles.sql manually.