### PR TITLE
MODINVSTOR-503: Add new 'Aged to lost' item status.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "item-storage",
-      "version": "8.4",
+      "version": "8.5",
       "handlers": [
         {
           "methods": ["GET"],
@@ -35,7 +35,7 @@
     },
     {
       "id": "item-storage-batch-sync",
-      "version": "0.4",
+      "version": "0.5",
       "handlers": [
         {
           "methods": ["POST"],

--- a/ramls/item-storage.raml
+++ b/ramls/item-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Item Storage
-version: v8.4
+version: v8.5
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item-sync.raml
+++ b/ramls/item-sync.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Storage Item Batch Sync API
-version: v0.4
+version: v0.5
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -245,7 +245,8 @@
             "Order closed",
             "Claimed returned",
             "Withdrawn",
-            "Lost and paid"
+            "Lost and paid",
+            "Aged to lost"
           ]
         },
         "date": {

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -1954,7 +1954,8 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     "Order closed",
     "Claimed returned",
     "Withdrawn",
-    "Lost and paid"
+    "Lost and paid",
+    "Aged to lost"
   })
   public void canCreateItemWithAllAllowedStatuses(String status) throws Exception {
     final UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-503 - Add 'Aged to lost' status to allowed item statuses list


### Changes:

* Add `Aged to lost` item status;
* Update `item-storage` API version;
* Update `item-batch-sync` API version;