### PR TITLE
MODINVSTOR-539 Release mod-inventory-storage 19.3.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,22 +1,23 @@
 ## 19.3.0 2020-07-28
 
-* Add'Agedtolost'statustoalloweditemstatuseslist (MODINVSTOR-503)
-* MakemigratePrecedingSucceedingTitles.sqlidempotent (MODINVSTOR-541)
-* Separatefilteringfromresponsegenerationinoai-pmhview (MODINVSTOR-536)
-* Itemrecord.Effectivecallnumber(item),eyereadable.SearchonexactdatainCallnumberdataelement (MODINVSTOR-481)
-* Holdingsrecord.Callnumber,eyereadable.SearchonexactdatainCallnumberdataelement (MODINVSTOR-480)
-* Searchquerieswithoutdatabaseindex (MODINVSTOR-472)
-* Upgradetoraml-module-builder(RMB)30.2.4 (MODINVSTOR-532)
-* UpdatetoRMBv30.2.3 (MODINVSTOR-531)
-* Expandoai-pmhviewwithadditionalfields (MODINVSTOR-498)
-* OAI-PMHviewdoesn'trespondinBugFest (MODINVSTOR-527)
-* UpgradetoRMB30.2.2 (MODINVSTOR-528)
-* Changepermissionslocationforoai-pmhview (MODINVSTOR-524)
-* AddIndexforInstancesFull-textSubjectsSearch (MODINVSTOR-499)
-* UpgradeRMBtov30.2.0 (MODINVSTOR-522)
-* Postgresrequiresspecialpermissionstodisabletriggersformigrations (MODINVSTOR-476)
-* UpgradeRMBto30.0.3,fixinginconsistenthitcounts(totalRecords)estimation (MODINVSTOR-519)
-* BulkdownloadInstanceUUIDsOOM (MODINVSTOR-465)
+* Add 'Aged to lost' status to allowed item statuses list (MODINVSTOR-503)
+* Make migratePrecedingSucceedingTitles.sql idempotent (MODINVSTOR-541)
+* Separate filtering from response generation in oai-pmh view (MODINVSTOR-536)
+* Item record. Effective call number (item), eye readable. Search on exact data in Call number data element (MODINVSTOR-481)
+* Holdings record. Call number, eye readable. Search on exact data in Call number data element (MODINVSTOR-480)
+* Search queries without database index (MODINVSTOR-472)
+* Upgrade to raml-module-builder (RMB) 30.2.4 (MODINVSTOR-532)
+* Expand oai-pmh view with additional fields (MODINVSTOR-498)
+* OAI-PMH view doesn't respond in Bug Fest (MODINVSTOR-527)
+* Change permissions location for oai-pmh view (MODINVSTOR-524)
+* Add Index for Instances Full-text Subjects Search (MODINVSTOR-499)
+* Postgres requires special permissions to disable triggers for migrations (MODINVSTOR-476)
+* Fixing inconsistent hit counts (totalRecords) estimation (MODINVSTOR-519)
+* Bulk download Instance UUIDs OOM (MODINVSTOR-465)
+* There were upgraded these interfaces:
+  * "item-storage" to version 8.5
+  * "item-storage-batch-sync" to version 0.5
+  * "oaipmhview" to version 1.1
 
 ## 19.2.2 2020-06-17
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,23 @@
+## 19.3.0 2020-07-28
+
+* Add'Agedtolost'statustoalloweditemstatuseslist (MODINVSTOR-503)
+* MakemigratePrecedingSucceedingTitles.sqlidempotent (MODINVSTOR-541)
+* Separatefilteringfromresponsegenerationinoai-pmhview (MODINVSTOR-536)
+* Itemrecord.Effectivecallnumber(item),eyereadable.SearchonexactdatainCallnumberdataelement (MODINVSTOR-481)
+* Holdingsrecord.Callnumber,eyereadable.SearchonexactdatainCallnumberdataelement (MODINVSTOR-480)
+* Searchquerieswithoutdatabaseindex (MODINVSTOR-472)
+* Upgradetoraml-module-builder(RMB)30.2.4 (MODINVSTOR-532)
+* UpdatetoRMBv30.2.3 (MODINVSTOR-531)
+* Expandoai-pmhviewwithadditionalfields (MODINVSTOR-498)
+* OAI-PMHviewdoesn'trespondinBugFest (MODINVSTOR-527)
+* UpgradetoRMB30.2.2 (MODINVSTOR-528)
+* Changepermissionslocationforoai-pmhview (MODINVSTOR-524)
+* AddIndexforInstancesFull-textSubjectsSearch (MODINVSTOR-499)
+* UpgradeRMBtov30.2.0 (MODINVSTOR-522)
+* Postgresrequiresspecialpermissionstodisabletriggersformigrations (MODINVSTOR-476)
+* UpgradeRMBto30.0.3,fixinginconsistenthitcounts(totalRecords)estimation (MODINVSTOR-519)
+* BulkdownloadInstanceUUIDsOOM (MODINVSTOR-465)
+
 ## 19.2.2 2020-06-17
 
 * Disable triggers for migrations without requiring special permissions (MODINVSTOR-476)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 ## 19.3.0 2020-07-28
 
 * Add 'Aged to lost' status to allowed item statuses list (MODINVSTOR-503)
-* Make migratePrecedingSucceedingTitles.sql idempotent (MODINVSTOR-541)
+* Solving issue with GBV by making migration for preceeding and succeeding titles to be possible to run several times without failing (MODINVSTOR-541)
 * Separate filtering from response generation in oai-pmh view (MODINVSTOR-536)
 * Item record. Effective call number (item), eye readable. Search on exact data in Call number data element (MODINVSTOR-481)
 * Holdings record. Call number, eye readable. Search on exact data in Call number data element (MODINVSTOR-480)

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "item-storage",
-      "version": "8.4",
+      "version": "8.5",
       "handlers": [
         {
           "methods": ["GET"],
@@ -35,7 +35,7 @@
     },
     {
       "id": "item-storage-batch-sync",
-      "version": "0.4",
+      "version": "0.5",
       "handlers": [
         {
           "methods": ["POST"],

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>19.3.0</version>
+  <version>19.4.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -115,7 +115,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>v19.3.0</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>19.4.0-SNAPSHOT</version>
+  <version>19.3.1-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>19.3.0-SNAPSHOT</version>
+  <version>19.3.0</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -115,7 +115,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v19.3.0</tag>
   </scm>
 
   <build>

--- a/ramls/item-storage.raml
+++ b/ramls/item-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Item Storage
-version: v8.4
+version: v8.5
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item-sync.raml
+++ b/ramls/item-sync.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Storage Item Batch Sync API
-version: v0.4
+version: v0.5
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -245,7 +245,8 @@
             "Order closed",
             "Claimed returned",
             "Withdrawn",
-            "Lost and paid"
+            "Lost and paid",
+            "Aged to lost"
           ]
         },
         "date": {

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -1954,7 +1954,8 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     "Order closed",
     "Claimed returned",
     "Withdrawn",
-    "Lost and paid"
+    "Lost and paid",
+    "Aged to lost"
   })
   public void canCreateItemWithAllAllowedStatuses(String status) throws Exception {
     final UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);


### PR DESCRIPTION
Release 19.3.0 includes these features:

* Add 'Aged to lost' status to allowed item statuses list (MODINVSTOR-503)
* Solving issue with GBV by making migration for preceeding and succeeding titles to be possible to run several times without failing (MODINVSTOR-541)
* Separate filtering from response generation in oai-pmh view (MODINVSTOR-536)
* Item record. Effective call number (item), eye readable. Search on exact data in Call number data element (MODINVSTOR-481)
* Holdings record. Call number, eye readable. Search on exact data in Call number data element (MODINVSTOR-480)
* Search queries without database index (MODINVSTOR-472)
* Upgrade to raml-module-builder (RMB) 30.2.4 (MODINVSTOR-532)
* Expand oai-pmh view with additional fields (MODINVSTOR-498)
* OAI-PMH view doesn't respond in Bug Fest (MODINVSTOR-527)
* Change permissions location for oai-pmh view (MODINVSTOR-524)
* Add Index for Instances Full-text Subjects Search (MODINVSTOR-499)
* Postgres requires special permissions to disable triggers for migrations (MODINVSTOR-476)
* Fixing inconsistent hit counts (totalRecords) estimation (MODINVSTOR-519)
* Bulk download Instance UUIDs OOM (MODINVSTOR-465)
* There were upgraded these interfaces:
  * "item-storage" to version 8.5
  * "item-storage-batch-sync" to version 0.5
  * "oaipmhview" to version 1.1