### PR TITLE
Ported fixes of release 19.3.0 issue for mainline.

### DIFF
--- a/src/main/resources/templates/db_scripts/oaipmh/createOaiPmhViewFunction.sql
+++ b/src/main/resources/templates/db_scripts/oaipmh/createOaiPmhViewFunction.sql
@@ -53,6 +53,8 @@ create index if not exists audit_instance_pmh_createddate_idx on ${myuniversity}
 create index if not exists audit_holdings_record_pmh_createddate_idx on ${myuniversity}_${mymodule}.audit_holdings_record ((strToTimestamp(jsonb -> 'record' ->> 'updatedDate')));
 create index if not exists audit_item_pmh_createddate_idx on ${myuniversity}_${mymodule}.audit_item ((strToTimestamp(jsonb -> 'record' ->> 'updatedDate')));
 
+drop function if exists ${myuniversity}_${mymodule}.pmh_view_function(timestamptz, timestamptz, bool, bool);
+
 -- Retained for backward compatibility only. Should be removed for 20.0.0.
 create or replace function ${myuniversity}_${mymodule}.pmh_view_function(startDate timestamptz,
                                                                          endDate timestamptz,

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -928,7 +928,7 @@
     {
       "run": "after",
       "snippetPath": "oaipmh/createOaiPmhViewFunction.sql",
-      "fromModuleVersion": "19.3.0"
+      "fromModuleVersion": "19.3.1"
     },
     {
       "run": "after",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -928,7 +928,7 @@
     {
       "run": "after",
       "snippetPath": "oaipmh/createOaiPmhViewFunction.sql",
-      "fromModuleVersion": "19.2.5"
+      "fromModuleVersion": "19.3.0"
     },
     {
       "run": "after",


### PR DESCRIPTION
This change fixes version of SQL schema for "oai pmh view" fucntionality and added dropping of legacy functions before their creation for the mainline.