### PR TITLE
Release mod-inventory-storage 19.3.1 (MODINVSTOR-549)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 19.3.1 2020-07-31
 
-* 19.3.0 upgrade error "cannot change return type of existing function" (MODINVSTOR-547)
+* Removes `pmh_view_function` function prior to replacement during upgrade (MODINVSTOR-547)
 
 ## 19.3.0 2020-07-28
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 19.3.1 2020-07-31
+
+* 19.3.0 upgrade error "cannot change return type of existing function" (MODINVSTOR-547)
+
 ## 19.3.0 2020-07-28
 
 * Add 'Aged to lost' status to allowed item statuses list (MODINVSTOR-503)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>19.3.1</version>
+  <version>19.3.2-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -115,7 +115,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>v19.3.1</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>19.3.1-SNAPSHOT</version>
+  <version>19.3.1</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -115,7 +115,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v19.3.1</tag>
   </scm>
 
   <build>


### PR DESCRIPTION
* Fixed version of sql schema for oai pmh view. Updated sql script with droping exisitng function due to output data's column renaming.

MODINVSTOR-547: Upgrading mod-inventory-storage to 19.3.0 results in error log output indicating update failed
https://issues.folio.org/browse/MODINVSTOR-547

