### PR TITLE
MODINVSTOR-556: RowStreamToBufferAdapter should close RowStream<Row>

### DIFF
--- a/src/main/java/org/folio/rest/support/RowStreamToBufferAdapter.java
+++ b/src/main/java/org/folio/rest/support/RowStreamToBufferAdapter.java
@@ -19,9 +19,12 @@ public class RowStreamToBufferAdapter implements ReadStream<Buffer> {
     this.delegate = delegate;
   }
 
-  public ReadStream<Buffer> exceptionHandler(Handler<Throwable> handler) {
-    this.delegate.exceptionHandler(handler);
-    return null;
+  public ReadStream<Buffer> exceptionHandler(Handler<Throwable> exceptionHandler) {
+    this.delegate.exceptionHandler(handler -> {
+      exceptionHandler.handle(handler);
+      delegate.close();
+    });
+    return this;
   }
 
   public RowStreamToBufferAdapter handler(Handler<Buffer> handler) {
@@ -47,7 +50,10 @@ public class RowStreamToBufferAdapter implements ReadStream<Buffer> {
   }
 
   public ReadStream<Buffer> endHandler(Handler<Void> endHandler) {
-    this.delegate.endHandler(endHandler);
+    this.delegate.endHandler(handler -> {
+      endHandler.handle(handler);
+      delegate.close();
+    });
     return this;
   }
 


### PR DESCRIPTION
Fixing this omission is needed for the next RMB update:
https://issues.folio.org/browse/RMB-693
see upgrading.md in https://github.com/folio-org/raml-module-builder/pull/741/files
If the RowStream is not closed, the prepared statement names remains open on the PostgreSQL connection preventing the number of prepared statements to exceed 0x10000. This results in `ERROR: prepared statement "XYZ" already exists`