### PR TITLE
MODINVSTOR-557: Upgrade to RMB 30.2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>30.2.4</raml-module-builder-version>
+    <raml-module-builder-version>30.2.5</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances</generate_routing_context>
     <argLine />
   </properties>


### PR DESCRIPTION
Most notable bug fixes in [RMB 30.2.5](https://github.com/folio-org/raml-module-builder/releases/tag/v30.2.5):

https://issues.folio.org/browse/RMB-693 "Close prepared statements
in PostgresClient stream get"
This fixes https://issues.folio.org/browse/MODINVSTOR-540 "ERROR:
prepared statement XYZ already exists"

https://issues.folio.org/browse/RMB-684 "GET query returns no
records when offset value >= estimated totalRecords"