### PR TITLE
MODINVSTOR-558: Revert "Update to OpenJDK-11 MOVINVSTOR-555 (#485)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM folioci/alpine-jre-openjdk11:latest
+FROM folioci/alpine-jre-openjdk8:latest
 
 ENV VERTICLE_FILE mod-inventory-storage-fat.jar
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,7 +7,6 @@ buildMvn {
   runLintRamlCop = 'yes'
   doKubeDeploy = true
   publishPreview = false
-  buildNode = 'jenkins-agent-java11'
 
   doDocker = {
     buildJavaDocker {

--- a/docker/docker-entrypoint.sh
+++ b/docker/docker-entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# This is the Docker entrypoint script specified in
+# Dockerfile.   It supports invoking the container
+# with both optional JVM runtime options as well as
+# optional module arguments.
+#
+# Example:
+#
+#  'docker run -d -e JAVA_OPTS="-Xmx256M" folio-module embed_mongo=true'
+#
+
+set -e
+
+if [ -n "$JAVA_OPTS" ]; then
+   exec java "$JAVA_OPTS" -jar ${VERTICLE_HOME}/module.jar "$@"
+else
+   exec java -jar ${VERTICLE_HOME}/module.jar "$@"
+fi
+

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>31.0.0</raml-module-builder-version>
+    <raml-module-builder-version>30.2.4</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances</generate_routing_context>
     <argLine />
   </properties>
@@ -123,9 +123,10 @@
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.8.1</version>
+        <version>3.1</version>
         <configuration>
-          <release>11</release>
+          <source>1.8</source>
+          <target>1.8</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>
@@ -193,9 +194,9 @@
       </plugin>
 
       <plugin>
-        <groupId>com.nickwongdev</groupId>
+        <groupId>org.codehaus.mojo</groupId>
         <artifactId>aspectj-maven-plugin</artifactId>
-        <version>1.12.6</version>
+        <version>1.9</version>
         <configuration>
           <verbose>true</verbose>
           <showWeaveInfo>false</showWeaveInfo>
@@ -220,12 +221,12 @@
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjrt</artifactId>
-            <version>1.9.5</version>
+            <version>1.8.9</version>
           </dependency>
           <dependency>
             <groupId>org.aspectj</groupId>
             <artifactId>aspectjtools</artifactId>
-            <version>1.9.5</version>
+            <version>1.8.9</version>
           </dependency>
         </dependencies>
       </plugin>


### PR DESCRIPTION
This reverts commit 71c619a6fbb35ab1b0bfa1b8a56d6d974e469f94.
This fixes https://issues.folio.org/browse/MODINVSTOR-558
'/item-storage/items fails because "module name: netty_parent"'