### PR TITLE
MODINVSTOR-562: Upgrade to RMB 30.2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,11 +85,11 @@
   </dependencies>
 
   <properties>
-    <vertx.version>3.9.1</vertx.version>
+    <vertx.version>3.9.2</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>30.2.5</raml-module-builder-version>
+    <raml-module-builder-version>30.2.6</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances</generate_routing_context>
     <argLine />
   </properties>


### PR DESCRIPTION
https://github.com/folio-org/raml-module-builder/releases/tag/v30.2.6 :

 * [RMB-701](https://issues.folio.org/browse/RMB-701) Update to [Vert.x 3.9.2](https://github.com/vert-x3/wiki/wiki/3.9.2-Release-Notes), fixing WebClient request timeout races
 * [RMB-700](https://issues.folio.org/browse/RMB-700) NPE when RestVerticle calls LogUtil.formatStatsLogMessage
 * [RMB-677](https://issues.folio.org/browse/RMB-677) Close PostgreSQL connection after invalid CQL failure