### PR TITLE
MODINVSTOR-568: Release 19.3.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 19.3.3 2020-09-02
 
-* Upgrade to RMB 30.2.6 (MODINVSTOR-562)
+* Upgrade to RMB 30.2.7 (MODINVSTOR-567)
   to fix matching on eAccess URI field (MODDICORE-80)
   * Full text search doesn't match URLs containing & (RMB-703)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## 19.3.3 2020-09-02
+
+* Upgrade to RMB 30.2.6 (MODINVSTOR-562)
+  to fix matching on eAccess URI field (MODDICORE-80)
+  * Full text search doesn't match URLs containing & (RMB-703)
+
 ## 19.3.2 2020-08-27
 
 * ERROR: prepared statement "XYZ" already exists (MODINVSTOR-540)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>19.3.3-SNAPSHOT</version>
+  <version>19.3.3</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -115,7 +115,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v19.3.3</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>19.3.3</version>
+  <version>19.3.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -115,7 +115,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>v19.3.3</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <build>


### PR DESCRIPTION
This updates RMB to v30.2.7 fixing [RMB-703](https://issues.folio.org/browse/RMB-703) "Full text search doesn't match URLs containing &" needed for [MODDICORE-80](https://issues.folio.org/browse/MODDICORE-80) "Cannot match on eAccess URI field"