### PR TITLE
MODINVSTOR-569: Upgrade RMB to 31.1.0-SNAPSHOT on master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>31.0.2</raml-module-builder-version>
+    <raml-module-builder-version>31.1.0-SNAPSHOT</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances</generate_routing_context>
     <argLine />
   </properties>
@@ -356,7 +356,17 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>2.3</version>
+        <version>3.2.4</version>
+        <configuration>
+          <filters>
+            <filter>
+              <artifact>*:*</artifact>
+              <excludes>
+                <exclude>**/Log4j2Plugins.dat</exclude>
+              </excludes>
+            </filter>
+          </filters>
+        </configuration>
         <executions>
           <execution>
             <phase>package</phase>

--- a/src/main/java/org/folio/rest/impl/InstanceStorageBatchAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceStorageBatchAPI.java
@@ -7,22 +7,19 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-import org.folio.okapi.common.OkapiToken;
 import org.folio.rest.jaxrs.model.Instance;
 import org.folio.rest.jaxrs.model.Instances;
 import org.folio.rest.jaxrs.model.InstancesBatchResponse;
-import org.folio.rest.jaxrs.model.Metadata;
 import org.folio.rest.jaxrs.resource.InstanceStorageBatchInstances;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.HridManager;
+import org.folio.rest.tools.utils.MetadataUtil;
 import javax.ws.rs.core.Response;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -30,8 +27,6 @@ import java.util.stream.Collectors;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
 import static org.folio.rest.RestVerticle.MODULE_SPECIFIC_ARGS;
-import static org.folio.rest.RestVerticle.OKAPI_HEADER_TOKEN;
-import static org.folio.rest.RestVerticle.OKAPI_USERID_HEADER;
 
 public class InstanceStorageBatchAPI implements InstanceStorageBatchInstances {
 
@@ -49,7 +44,7 @@ public class InstanceStorageBatchAPI implements InstanceStorageBatchInstances {
     vertxContext.runOnContext(v -> {
       try {
         PostgresClient postgresClient = PgUtil.postgresClient(vertxContext, okapiHeaders);
-        populateMetaDataForList(entity.getInstances(), okapiHeaders);
+        MetadataUtil.populateMetadata(entity.getInstances(), okapiHeaders);
         executeInBatch(entity.getInstances(),
           (instances, saveFutures) -> saveInstances(instances, postgresClient, saveFutures))
           .setHandler(ar -> {
@@ -179,29 +174,5 @@ public class InstanceStorageBatchAPI implements InstanceStorageBatchInstances {
     response.setTotalRecords(response.getInstances().size());
     return response;
   }
-
-  private void populateMetaDataForList(List<Instance> list, Map<String, String> okapiHeaders) {
-    String userId = okapiHeaders.getOrDefault(OKAPI_USERID_HEADER, "");
-    String token = okapiHeaders.getOrDefault(OKAPI_HEADER_TOKEN, "");
-    if (userId == null && token != null) {
-      userId = userIdFromToken(token);
-    }
-    Metadata md = new Metadata();
-    md.setUpdatedDate(new Date());
-    md.setCreatedDate(md.getUpdatedDate());
-    md.setCreatedByUserId(userId);
-    md.setUpdatedByUserId(userId);
-    list.forEach(instance -> instance.setMetadata(md));
-  }
-
-  private static String userIdFromToken(String token) {
-    try {
-      return new OkapiToken(token).getUserIdWithoutValidation();
-    } catch (Exception e) {
-      log.warn("Invalid x-okapi-token: " + token, e);
-      return null;
-    }
-  }
-
 
 }

--- a/src/main/java/org/folio/rest/impl/InstanceStorageBatchAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceStorageBatchAPI.java
@@ -10,7 +10,7 @@ import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
-
+import org.folio.okapi.common.OkapiToken;
 import org.folio.rest.jaxrs.model.Instance;
 import org.folio.rest.jaxrs.model.Instances;
 import org.folio.rest.jaxrs.model.InstancesBatchResponse;
@@ -19,8 +19,6 @@ import org.folio.rest.jaxrs.resource.InstanceStorageBatchInstances;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.HridManager;
-import org.folio.rest.tools.utils.JwtUtils;
-
 import javax.ws.rs.core.Response;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
@@ -198,10 +196,7 @@ public class InstanceStorageBatchAPI implements InstanceStorageBatchInstances {
 
   private static String userIdFromToken(String token) {
     try {
-      String[] split = token.split("\\.");
-      String json = JwtUtils.getJson(split[1]);
-      JsonObject j = new JsonObject(json);
-      return j.getString("user_id");
+      return new OkapiToken(token).getUserIdWithoutValidation();
     } catch (Exception e) {
       log.warn("Invalid x-okapi-token: " + token, e);
       return null;


### PR DESCRIPTION
This is temporarily needed to verify this Goldenrod hot-fix:

MODINVSTOR-568 Release mod-inventory-storage 19.3.3
MODINVSTOR-567 Upgrade b19.3 (Goldenrod) to RMB 30.2.7
This updates RMB to v30.2.7 fixing RMB-703 "Full text search
doesn't match URLs containing &" needed for
MODDICORE-80 "Cannot match on eAccess URI field"

This pull request
* excludes Log4j2Plugins.dat from the shaded jar, otherwise
  the logging will fail with "Unrecognized format specifier"
* replaces populateMetaDataForList by RMB's MetadataUtil.populateMetadata
   because RMB has removed JwtUtils.