### PR TITLE
Fixed format of returning empty data for "items" and "holdings" fields;

### DIFF
--- a/ramls/examples/inventory-items-and-holdings.json
+++ b/ramls/examples/inventory-items-and-holdings.json
@@ -1,6 +1,10 @@
 {
   "instanceId": "2fd27465-e6ce-4143-9b7c-606860747f03",
   "source": "FOLIO",
+  "modeOfIssuance": "serial",
+  "natureOfContent": [
+    "journal"
+  ],
   "holdings": [
     {
       "id": "7df791c5-e330-4cfe-bb0b-a5f0e555ac68",

--- a/ramls/holdingsrecord.json
+++ b/ramls/holdingsrecord.json
@@ -26,6 +26,7 @@
       "uniqueItems": true
     },
     "instanceId": {
+      "description": "Inventory instances identifier",
       "type": "string",
       "$ref": "uuid.json"
     },
@@ -35,6 +36,7 @@
       "$ref" : "uuid.json"
     },
     "permanentLocation": {
+      "description": "The permanent shelving location in which an item resides",
       "type": "object",
       "folio:$ref": "location.json",
       "readonly": true,
@@ -50,6 +52,7 @@
       "$ref": "uuid.json"
     },
     "electronicAccess": {
+      "description": "List of electronic access items",
       "type": "array",
       "items": {
         "type": "object",
@@ -103,10 +106,12 @@
       "description": "Indicates the shelving form of title."
     },
     "acquisitionFormat": {
-      "type": "string"
+      "type": "string",
+      "description": "Format of holdings record acquisition"
     },
     "acquisitionMethod": {
-      "type": "string"
+      "type": "string",
+      "description": "Method of holdings record acquisition"
     },
     "receiptStatus": {
       "type": "string",
@@ -169,9 +174,11 @@
       "description": "Records information regarding how long we have agreed to keep something."
     },
     "digitizationPolicy": {
+      "description": "Records information regarding digitization aspects.",
       "type": "string"
     },
     "holdingsStatements": {
+      "description": "Notes about action, copy, binding etc.",
       "type": "array",
       "items": {
         "type": "object",
@@ -192,6 +199,7 @@
       }
     },
     "holdingsStatementsForIndexes": {
+      "description": "Holdings record indexes statements",
       "type": "array",
       "items": {
         "type": "object",
@@ -212,6 +220,7 @@
       }
     },
     "holdingsStatementsForSupplements": {
+      "description": "Holdings record supplements statements",
       "type": "array",
       "items": {
         "type": "object",
@@ -240,6 +249,7 @@
       "description": "Text (Number)"
     },
     "receivingHistory": {
+      "description": "Receiving history of holdings record",
       "type": "object",
       "properties": {
         "displayType": {
@@ -248,7 +258,7 @@
         },
         "entries": {
           "type": "array",
-          "description": ".",
+          "description": "Entries of receiving history",
           "items": {
             "type": "object",
             "properties": {
@@ -283,6 +293,7 @@
       "uniqueItems": true
     },
     "holdingsItems": {
+      "description": "Items related to holdings record",
       "type": "array",
       "items": {
         "type": "object",
@@ -296,6 +307,7 @@
       "folio:includedElement": "items"
     },
     "bareHoldingsItems": {
+      "description": "Items of bareHoldings",
       "type": "array",
       "items": {
         "type": "object",
@@ -309,6 +321,7 @@
       "folio:includedElement": "items"
     },
     "holdingsInstance": {
+      "description": "Instance of holding record",
       "type": "object",
       "folio:$ref": "instance.json",
       "readonly": true,

--- a/ramls/inventory-hierarchy/inventory-instance-records.json
+++ b/ramls/inventory-hierarchy/inventory-instance-records.json
@@ -12,6 +12,17 @@
       "description": "Source of metadata and format of the underlying record to the instance record",
       "type": "string"
     },
+    "modeOfIssuance": {
+      "description": "The mode of issuance would tell if the material is a serial or not",
+      "type": "string"
+    },
+    "natureOfContent": {
+      "description": "A periodical (which is a subset of serials) might also have a nature of content periodical (journal, newspaper)",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
     "holdings": {
       "type": "array",
       "description": "Holdings record fields",

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -146,6 +146,7 @@
             "description": "ID of the type of note"
           },
           "itemNoteType": {
+            "description": "Type of item's note",
             "type": "object",
             "folio:$ref": "itemnotetype.json",
             "javaType": "org.folio.rest.jaxrs.model.itemNoteTypeVirtual",
@@ -276,6 +277,7 @@
       "description": "Permanent item location is the default location, shelving location, or holding which is a physical place where items are stored, or an Online location."
     },
     "permanentLocation": {
+      "description": "The permanent shelving location in which an item resides",
       "type": "object",
       "folio:$ref": "location.json",
       "readonly": true,
@@ -290,6 +292,7 @@
       "description": "Temporary item location is the temporarily location, shelving location, or holding which is a physical place where items are stored, or an Online location."
     },
     "temporaryLocation": {
+      "description": "Temporary location, shelving location, or holding which is a physical place where items are stored, or an Online location",
       "type": "object",
       "folio:$ref": "location.json",
       "readonly": true,

--- a/ramls/location.json
+++ b/ramls/location.json
@@ -32,6 +32,7 @@
       "type": "string"
     },
     "institution": {
+      "description": "The institution, the first-level location unit, this (shelf) location belongs to.",
       "type": "object",
       "folio:$ref": "locinst.json",
       "readonly": true,
@@ -46,6 +47,7 @@
       "type": "string"
     },
     "campus": {
+      "description": "The campus, the second-level location unit, this (shelf) location belongs to",
       "type": "object",
       "folio:$ref": "loccamp.json",
       "readonly": true,
@@ -60,6 +62,7 @@
       "type": "string"
     },
     "library": {
+      "description": "The library, the third-level location unit, this (shelf) location belongs to.",
       "type": "object",
       "folio:$ref": "locinst.json",
       "readonly": true,

--- a/src/main/resources/templates/db_scripts/inventory-hierarchy/createRecordsViewFunction.sql
+++ b/src/main/resources/templates/db_scripts/inventory-hierarchy/createRecordsViewFunction.sql
@@ -172,6 +172,8 @@ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.get_items_and_holdings_vi
             (
                 "instanceId"             uuid,
                 "source"                 varchar,
+                "modeOfIssuance"         varchar,
+                "natureOfContent"        jsonb,
                 "holdings"               jsonb,
                 "items"                  jsonb
             )
@@ -391,8 +393,8 @@ WITH
 SELECT
       vi.instId AS "instanceId",
       vi.source AS "source",
-  	  vi.modeOfIssuance,
-  	  vi.natureOfContent,
+  	  vi.modeOfIssuance AS "modeOfIssuance",
+  	  vi.natureOfContent AS "natureOfContent",
       COALESCE(viah.records -> 'holdings', '[]'::jsonb) AS "holdings",
       COALESCE(viah.records -> 'items', '[]'::jsonb) AS "items"
 FROM viewInstances vi

--- a/src/main/resources/templates/db_scripts/inventory-hierarchy/createRecordsViewFunction.sql
+++ b/src/main/resources/templates/db_scripts/inventory-hierarchy/createRecordsViewFunction.sql
@@ -203,14 +203,14 @@ WITH
                                             jsonb_build_object('id', hr.id,
                                                                'hrId', hr.jsonb ->> 'hrId',
                                                                'suppressFromDiscovery',
-                                                               CASE WHEN item.id IS NOT NULL THEN
+                                                               CASE WHEN hr.id IS NOT NULL THEN
                                                                   COALESCE((i.jsonb ->> 'discoverySuppress')::bool, false) OR
                                                                   COALESCE((hr.jsonb ->> 'discoverySuppress')::bool, false)
                                                                ELSE NULL END::bool,
                                                                'holdingsType', ht.jsonb ->> 'name',
                                                                'formerIds', hr.jsonb -> 'formerIds',
                                                                'location',
-                                                               CASE WHEN item.id IS NOT NULL THEN
+                                                               CASE WHEN hr.id IS NOT NULL THEN
                                                                    json_build_object('permanentLocation',
                                                                                      jsonb_build_object('name', COALESCE(holdPermLoc.locJsonb ->> 'discoveryDisplayName', holdPermLoc.locJsonb ->> 'name'),
                                                                                                         'campusName', holdPermLoc.locCampJsonb ->> 'name',


### PR DESCRIPTION
Fixed error with handling "onlyInstanceUpdateDate" flag passed to "updated instance ids" routine;
Fixed returning holdings where there are no items at all.
Removed empty objects from data when there are no items in holdings records.
Fixed copy-past issue which is affecting returned holdings data when there are no items.


Jira: https://issues.folio.org/browse/MODINVSTOR-570