### PR TITLE
MODINVSTOR-575 Increase request timeout from 5 s to 10 s in unit tests

### DIFF
--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -1856,11 +1856,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     JsonArray holdingsArray = new JsonArray();
     for (int i=0; i<3; i++) {
       UUID instanceId = UUID.randomUUID();
-      try {
-        instancesClient.create(smallAngryPlanet(instanceId));
-      } catch (MalformedURLException | InterruptedException | ExecutionException | TimeoutException e) {
-        throw new RuntimeException(e);
-      }
+      instancesClient.create(smallAngryPlanet(instanceId));
       holdingsArray.add(new JsonObject()
           .put("id", UUID.randomUUID().toString())
           .put("instanceId", instanceId.toString())

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -851,17 +851,13 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   private JsonArray threeItems() {
-    try {
-      UUID holdingsRecordId = createInstanceAndHoldingWithBuilder(mainLibraryLocationId,
-        holdingRequestBuilder -> holdingRequestBuilder.withCallNumber("hrCallNumber"));
+    UUID holdingsRecordId = createInstanceAndHoldingWithBuilder(mainLibraryLocationId,
+      holdingRequestBuilder -> holdingRequestBuilder.withCallNumber("hrCallNumber"));
 
-      return new JsonArray()
-          .add(nod(holdingsRecordId))
-          .add(smallAngryPlanet(holdingsRecordId))
-          .add(interestingTimes(UUID.randomUUID(), holdingsRecordId));
-    } catch (MalformedURLException | ExecutionException | InterruptedException | TimeoutException e) {
-      throw new RuntimeException(e);
-    }
+    return new JsonArray()
+        .add(nod(holdingsRecordId))
+        .add(smallAngryPlanet(holdingsRecordId))
+        .add(interestingTimes(UUID.randomUUID(), holdingsRecordId));
   }
 
   private Response postSynchronousBatch(JsonArray itemsArray) {

--- a/src/test/java/org/folio/rest/api/LocationUnitTest.java
+++ b/src/test/java/org/folio/rest/api/LocationUnitTest.java
@@ -17,19 +17,15 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
+import static org.folio.rest.api.TestBase.get;
 import static org.folio.rest.support.HttpResponseMatchers.statusCodeIs;
 import static org.folio.rest.support.http.InterfaceUrls.*;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 // Missing tests:
 // - Add/update a campus that points to a non-existing inst
@@ -44,8 +40,7 @@ public class LocationUnitTest {
   private static final Logger logger = LoggerFactory.getLogger(LocationUnitTest.class);
 
   @Before
-  public void beforeEach()
-    throws MalformedURLException {
+  public void beforeEach() {
 
     StorageTestSuite.deleteAll(itemsStorageUrl(""));
     StorageTestSuite.deleteAll(holdingsStorageUrl(""));
@@ -93,11 +88,7 @@ public class LocationUnitTest {
 
   ///////////////////////////////////////////////////////  Inst test helpers
   // May also be used from other tests
-  public static Response createInst(UUID id, String name, String code)
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+  public static Response createInst(UUID id, String name, String code) {
 
     CompletableFuture<Response> createLocationUnit = new CompletableFuture<>();
 
@@ -111,30 +102,22 @@ public class LocationUnitTest {
     send(locInstitutionStorageUrl(""), HttpMethod.POST, request.toString(),
       SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(createLocationUnit));
 
-    return createLocationUnit.get(5, TimeUnit.SECONDS);
+    return get(createLocationUnit);
   }
 
-  private Response getInstById(UUID id)
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  private Response getInstById(UUID id) {
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 
     send(locInstitutionStorageUrl("/" + id.toString()), HttpMethod.GET,
       null, SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(getCompleted));
 
-    return getCompleted.get(5, TimeUnit.SECONDS);
+    return get(getCompleted);
   }
 
 /////////////////////// Inst tests
   @Test
-  public void canCreateAnInst()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canCreateAnInst() {
 
     Response response = createInst(null, "Institute of MetaPhysics", "MPI");
 
@@ -145,11 +128,7 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void cannotCreateInstWithSameName()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotCreateInstWithSameName() {
 
     createInst(null, "Institute of MetaPhysics", "MPI");
     Response response = createInst(null, "Institute of MetaPhysics", "MPI");
@@ -157,11 +136,7 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void cannotCreateInstSameId()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotCreateInstSameId() {
 
     UUID id = UUID.randomUUID();
     createInst(id, "Institute of MetaPhysics", "MPI");
@@ -170,11 +145,7 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void cannotCreateAnInstWithoutCode()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotCreateAnInstWithoutCode() {
 
     UUID id = UUID.randomUUID();
     Response response = createInst(id, "Institute of MetaPhysics", null);
@@ -183,11 +154,7 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void canGetAnInstById()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canGetAnInstById() {
 
     UUID id = UUID.randomUUID();
     createInst(id, "Institute of MetaPhysics", "MPI");
@@ -202,27 +169,18 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void cannotGetAnInstByWrongId()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotGetAnInstByWrongId() {
     createInst(null, "Institute of MetaPhysics", "MPI");
     UUID id = UUID.randomUUID();
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
     send(locInstitutionStorageUrl("/" + id.toString()), HttpMethod.GET,
       null, SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.any(getCompleted));
-    Response getResponse;
-    getResponse = getCompleted.get(5, TimeUnit.SECONDS);
+    Response getResponse = get(getCompleted);
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
   }
 
   @Test
-  public void canListInsts()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canListInsts() {
 
     createInst(null, "Institute of MetaPhysics", "MPI");
     createInst(null, "The Other Institute", "OI");
@@ -232,7 +190,7 @@ public class LocationUnitTest {
     send(locInstitutionStorageUrl("/"), HttpMethod.GET,
       null, SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(getCompleted));
 
-    Response getResponse = getCompleted.get(5, TimeUnit.SECONDS);
+    Response getResponse = get(getCompleted);
 
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
     JsonObject item = getResponse.getJson();
@@ -240,29 +198,21 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void canQueryInsts()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canQueryInsts() {
 
     createInst(null, "Institute of MetaPhysics", "MPI");
     createInst(null, "The Other Institute", "OI");
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
     send(locInstitutionStorageUrl("/?query=name=Other"), HttpMethod.GET,
       null, SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(getCompleted));
-    Response getResponse = getCompleted.get(5, TimeUnit.SECONDS);
+    Response getResponse = get(getCompleted);
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
     JsonObject item = getResponse.getJson();
     assertThat(item.getInteger("totalRecords"), is(1));
   }
 
   @Test
-  public void badQueryInsts()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void badQueryInsts() {
 
     createInst(null, "Institute of MetaPhysics", "MPI");
     createInst(null, "The Other Institute", "OI");
@@ -270,16 +220,12 @@ public class LocationUnitTest {
     send(locInstitutionStorageUrl("/?query=invalidCQL"), HttpMethod.GET,
       null, SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.any(getCompleted));
     Response getResponse;
-    getResponse = getCompleted.get(5, TimeUnit.SECONDS);
+    getResponse = get(getCompleted);
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
   }
 
   @Test
-  public void canUpdateAnInst()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canUpdateAnInst() {
 
     UUID id = UUID.randomUUID();
     createInst(id, "Institute of MetaPhysics", "MPI");
@@ -295,7 +241,7 @@ public class LocationUnitTest {
       updateRequest.toString(), SUPPORTED_CONTENT_TYPE_JSON_DEF,
       ResponseHandler.any(updated));
 
-    Response updateResponse = updated.get(5, TimeUnit.SECONDS);
+    Response updateResponse = get(updated);
 
     assertThat(updateResponse, statusCodeIs(HttpURLConnection.HTTP_NO_CONTENT));
     assertThat(updateResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
@@ -308,11 +254,7 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void cannotUpdateAnInstId()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotUpdateAnInstId() {
 
     UUID id = UUID.randomUUID();
     createInst(id, "Institute of MetaPhysics", "MPI");
@@ -324,32 +266,24 @@ public class LocationUnitTest {
     send(locInstitutionStorageUrl("/" + id.toString()), HttpMethod.PUT,
       updateRequest.toString(), SUPPORTED_CONTENT_TYPE_JSON_DEF,
       ResponseHandler.any(updated));
-    Response updateResponse = updated.get(5, TimeUnit.SECONDS);
+    Response updateResponse = get(updated);
     assertThat(updateResponse, statusCodeIs(HttpURLConnection.HTTP_BAD_REQUEST));
   }
 
   @Test
-  public void canDeleteAnInst()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canDeleteAnInst() {
 
     UUID id = UUID.randomUUID();
     createInst(id, "Institute of MetaPhysics", "MPI");
     CompletableFuture<Response> deleteCompleted = new CompletableFuture<>();
     send(locInstitutionStorageUrl("/" + id.toString()), HttpMethod.DELETE, null,
       SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.any(deleteCompleted));
-    Response deleteResponse = deleteCompleted.get(5, TimeUnit.SECONDS);
+    Response deleteResponse = get(deleteCompleted);
     assertThat(deleteResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
   }
 
 ////////////////////////////////////// Campus test helpers
-  public static Response createCamp(UUID id, String name, String code, UUID instId)
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+  public static Response createCamp(UUID id, String name, String code, UUID instId) {
 
     CompletableFuture<Response> createLocationUnit = new CompletableFuture<>();
 
@@ -366,30 +300,22 @@ public class LocationUnitTest {
     send(locCampusStorageUrl(""), HttpMethod.POST, request.toString(),
       SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(createLocationUnit));
 
-    return createLocationUnit.get(5, TimeUnit.SECONDS);
+    return get(createLocationUnit);
   }
 
-  private Response getCampById(UUID id)
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  private Response getCampById(UUID id) {
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 
     send(locCampusStorageUrl("/" + id.toString()), HttpMethod.GET,
       null, SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(getCompleted));
 
-    return getCompleted.get(5, TimeUnit.SECONDS);
+    return get(getCompleted);
   }
 
 ////////////// Campus tests
   @Test
-  public void canCreateACamp()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canCreateACamp() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -403,11 +329,7 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void cannotCreateCampWithSameName()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotCreateCampWithSameName() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -418,11 +340,7 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void cannotCreateCampSameId()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotCreateCampSameId() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -434,22 +352,14 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void cannotCreateCampWithoutInst()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotCreateCampWithoutInst() {
 
     Response response = createCamp(null, "Campus on the other Side of the River", "OS", null);
     assertThat(response.getStatusCode(), is(AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY));
   }
 
   @Test
-  public void cannotCreateACampWithoutCode()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotCreateACampWithoutCode() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -461,11 +371,7 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void canGetACampById()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canGetACampById() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -483,11 +389,7 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void cannotGetACampWrongId()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotGetACampWrongId() {
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
 
@@ -497,17 +399,12 @@ public class LocationUnitTest {
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
     send(locCampusStorageUrl("/" + id.toString()), HttpMethod.GET,
       null, SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.any(getCompleted));
-    Response getResponse;
-    getResponse = getCompleted.get(5, TimeUnit.SECONDS);
+    Response getResponse = get(getCompleted);
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
   }
 
   @Test
-  public void canListCamps()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canListCamps() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -519,18 +416,14 @@ public class LocationUnitTest {
     send(locCampusStorageUrl("/?query=name=Campus"), HttpMethod.GET,
       null, SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(getCompleted));
 
-    Response getResponse = getCompleted.get(5, TimeUnit.SECONDS);
+    Response getResponse = get(getCompleted);
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
     JsonObject item = getResponse.getJson();
     assertThat(item.getInteger("totalRecords"), is(2));
   }
 
   @Test
-  public void canUpdateACamp()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canUpdateACamp() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -549,7 +442,7 @@ public class LocationUnitTest {
     send(locCampusStorageUrl("/" + id.toString()), HttpMethod.PUT,
       updateRequest.toString(), SUPPORTED_CONTENT_TYPE_JSON_DEF,
       ResponseHandler.any(updated));
-    Response updateResponse = updated.get(5, TimeUnit.SECONDS);
+    Response updateResponse = get(updated);
     assertThat(updateResponse, statusCodeIs(HttpURLConnection.HTTP_NO_CONTENT));
     assertThat(updateResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
 
@@ -562,11 +455,7 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void cannotUpdateACampId()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotUpdateACampId() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -583,16 +472,12 @@ public class LocationUnitTest {
     send(locCampusStorageUrl("/" + id.toString()), HttpMethod.PUT,
       updateRequest.toString(), SUPPORTED_CONTENT_TYPE_JSON_DEF,
       ResponseHandler.any(updated));
-    Response updateResponse = updated.get(5, TimeUnit.SECONDS);
+    Response updateResponse = get(updated);
     assertThat(updateResponse, statusCodeIs(HttpURLConnection.HTTP_BAD_REQUEST));
   }
 
   @Test
-  public void canDeleteACamp()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canDeleteACamp() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -601,16 +486,12 @@ public class LocationUnitTest {
     CompletableFuture<Response> deleteCompleted = new CompletableFuture<>();
     send(locCampusStorageUrl("/" + id.toString()), HttpMethod.DELETE, null,
       SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.any(deleteCompleted));
-    Response deleteResponse = deleteCompleted.get(5, TimeUnit.SECONDS);
+    Response deleteResponse = get(deleteCompleted);
     assertThat(deleteResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
   }
 
   @Test
-  public void cannotDeleteInstUsedByCamp()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotDeleteInstUsedByCamp() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -618,18 +499,13 @@ public class LocationUnitTest {
     CompletableFuture<Response> deleteCompleted = new CompletableFuture<>();
     send(locInstitutionStorageUrl("/" + instId.toString()), HttpMethod.DELETE, null,
       SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.any(deleteCompleted));
-    Response deleteResponse = deleteCompleted.get(5, TimeUnit.SECONDS);
+    Response deleteResponse = get(deleteCompleted);
     assertThat(deleteResponse.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
   }
 
 ////////////////////////////////////// Library test helpers
 
-  public static Response createLib(UUID id, String name, String code, UUID campId)
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
-
+  public static Response createLib(UUID id, String name, String code, UUID campId) {
     CompletableFuture<Response> createLocationUnit = new CompletableFuture<>();
 
     JsonObject request = new JsonObject()
@@ -643,30 +519,22 @@ public class LocationUnitTest {
     send(locLibraryStorageUrl(""), HttpMethod.POST, request.toString(),
       SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(createLocationUnit));
 
-    return createLocationUnit.get(5, TimeUnit.SECONDS);
+    return get(createLocationUnit);
   }
 
-  private Response getLibById(UUID id)
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  private Response getLibById(UUID id) {
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 
     send(locLibraryStorageUrl("/" + id.toString()), HttpMethod.GET,
       null, SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(getCompleted));
 
-    return getCompleted.get(5, TimeUnit.SECONDS);
+    return get(getCompleted);
   }
 
 ////////////// Library tests
   @Test
-  public void canCreateALib()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canCreateALib() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -682,11 +550,7 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void cannotCreateLibWithSameName()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotCreateLibWithSameName() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -699,11 +563,7 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void cannotCreateLibSameId()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotCreateLibSameId() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -717,11 +577,7 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void cannotCreateALibWithoutCode()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotCreateALibWithoutCode() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -735,11 +591,7 @@ public class LocationUnitTest {
   }
 
   @Test
-  public void canGetALibById()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canGetALibById() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -759,11 +611,7 @@ public class LocationUnitTest {
       is("test_user"));  // The userId header triggers creation of metadata
   }
 
-  public void cannotGetALibWrongId()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotGetALibWrongId() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -774,17 +622,12 @@ public class LocationUnitTest {
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
     send(locLibraryStorageUrl("/" + id.toString()), HttpMethod.GET,
       null, SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.any(getCompleted));
-    Response getResponse;
-    getResponse = getCompleted.get(5, TimeUnit.SECONDS);
+    Response getResponse = get(getCompleted);
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
   }
 
   @Test
-  public void canListLibs()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canListLibs() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -798,18 +641,14 @@ public class LocationUnitTest {
     send(locLibraryStorageUrl("/?query=name=LiBRaRy"), HttpMethod.GET,
       null, SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(getCompleted));
 
-    Response getResponse = getCompleted.get(5, TimeUnit.SECONDS);
+    Response getResponse = get(getCompleted);
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
     JsonObject item = getResponse.getJson();
     assertThat(item.getInteger("totalRecords"), is(2));
   }
 
   @Test
-  public void canUpdateALib()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canUpdateALib() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -829,7 +668,7 @@ public class LocationUnitTest {
     send(locLibraryStorageUrl("/" + id.toString()), HttpMethod.PUT,
       updateRequest.toString(), SUPPORTED_CONTENT_TYPE_JSON_DEF,
       ResponseHandler.any(updated));
-    Response updateResponse = updated.get(5, TimeUnit.SECONDS);
+    Response updateResponse = get(updated);
     assertThat(updateResponse, statusCodeIs(HttpURLConnection.HTTP_NO_CONTENT));
     assertThat(updateResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
 
@@ -841,11 +680,7 @@ public class LocationUnitTest {
     assertThat(item.getString("code"), is("MPA"));
   }
 
-  public void cannotUpdateALibId()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotUpdateALibId() {
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
     UUID campId = UUID.randomUUID();
@@ -860,16 +695,12 @@ public class LocationUnitTest {
     send(locInstitutionStorageUrl("/" + id.toString()), HttpMethod.PUT,
       updateRequest.toString(), SUPPORTED_CONTENT_TYPE_JSON_DEF,
       ResponseHandler.any(updated));
-    Response updateResponse = updated.get(5, TimeUnit.SECONDS);
+    Response updateResponse = get(updated);
     assertThat(updateResponse, statusCodeIs(HttpURLConnection.HTTP_BAD_REQUEST));
   }
 
   @Test
-  public void canDeleteALib()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canDeleteALib() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -885,16 +716,12 @@ public class LocationUnitTest {
     send(locLibraryStorageUrl("/" + id.toString()), HttpMethod.DELETE, null,
       SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.any(deleteCompleted));
 
-    Response deleteResponse = deleteCompleted.get(5, TimeUnit.SECONDS);
+    Response deleteResponse = get(deleteCompleted);
     assertThat(deleteResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
   }
 
   @Test
-  public void cannotDeleteCampUsedByLib()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotDeleteCampUsedByLib() {
 
     UUID instId = UUID.randomUUID();
     createInst(instId, "Institute of MetaPhysics", "MPI");
@@ -904,7 +731,7 @@ public class LocationUnitTest {
     CompletableFuture<Response> deleteCompleted = new CompletableFuture<>();
     send(locCampusStorageUrl("/" + campId.toString()), HttpMethod.DELETE, null,
       SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.any(deleteCompleted));
-    Response deleteResponse = deleteCompleted.get(5, TimeUnit.SECONDS);
+    Response deleteResponse = get(deleteCompleted);
     assertThat(deleteResponse.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
   }
 

--- a/src/test/java/org/folio/rest/api/LocationsTest.java
+++ b/src/test/java/org/folio/rest/api/LocationsTest.java
@@ -1,5 +1,6 @@
 package org.folio.rest.api;
 
+import static org.folio.rest.api.StorageTestSuite.TIMEOUT;
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
@@ -200,7 +201,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
     send(locationsStorageUrl("/"), HttpMethod.GET,
       null, SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(getCompleted));
-    Response getResponse = getCompleted.get(5, TimeUnit.SECONDS);
+    Response getResponse = getCompleted.get(TIMEOUT, TimeUnit.SECONDS);
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
     JsonObject item = getResponse.getJson();
     assertThat(item.getInteger("totalRecords"), is(2));
@@ -229,7 +230,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
     send(locationsStorageUrl("/" + id.toString()), HttpMethod.PUT,
       updateRequest.toString(), SUPPORTED_CONTENT_TYPE_JSON_DEF,
       ResponseHandler.any(updated));
-    Response updateResponse = updated.get(5, TimeUnit.SECONDS);
+    Response updateResponse = updated.get(TIMEOUT, TimeUnit.SECONDS);
     assertThat(updateResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
     Response getResponse = getById(id);
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
@@ -259,7 +260,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
     send(locationsStorageUrl("/" + id.toString()), HttpMethod.PUT,
       updateRequest.toString(), SUPPORTED_CONTENT_TYPE_JSON_DEF,
       ResponseHandler.any(updated));
-    Response updateResponse = updated.get(5, TimeUnit.SECONDS);
+    Response updateResponse = updated.get(TIMEOUT, TimeUnit.SECONDS);
     assertThat(updateResponse.getStatusCode(), is(AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY));
   }
 
@@ -274,7 +275,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
     CompletableFuture<Response> deleteCompleted = new CompletableFuture<>();
     send(locationsStorageUrl("/" + id.toString()), HttpMethod.DELETE, null,
       SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.any(deleteCompleted));
-    Response deleteResponse = deleteCompleted.get(5, TimeUnit.SECONDS);
+    Response deleteResponse = deleteCompleted.get(TIMEOUT, TimeUnit.SECONDS);
     assertThat(deleteResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
   }
 
@@ -292,13 +293,13 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
     CompletableFuture<Response> createItemCompleted = new CompletableFuture<>();
     send(itemsStorageUrl(""), HttpMethod.POST, item.toString(),
       SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(createItemCompleted));
-    Response createItemResponse = createItemCompleted.get(5, TimeUnit.SECONDS);
+    Response createItemResponse = createItemCompleted.get(TIMEOUT, TimeUnit.SECONDS);
     assertThat(createItemResponse.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
     CompletableFuture<Response> deleteCompleted = new CompletableFuture<>();
     send(locationsStorageUrl("/" + id.toString()),
       HttpMethod.DELETE, null, SUPPORTED_CONTENT_TYPE_JSON_DEF,
       ResponseHandler.any(deleteCompleted));
-    Response deleteResponse = deleteCompleted.get(5, TimeUnit.SECONDS);
+    Response deleteResponse = deleteCompleted.get(TIMEOUT, TimeUnit.SECONDS);
     assertThat(deleteResponse.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
   }
 
@@ -364,7 +365,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
       HttpMethod.GET, null, SUPPORTED_CONTENT_TYPE_JSON_DEF,
       ResponseHandler.json(getCompleted));
 
-    return getCompleted.get(5, TimeUnit.SECONDS).getJson()
+    return getCompleted.get(TIMEOUT, TimeUnit.SECONDS).getJson()
       .getJsonArray("locations").stream()
       .map(obj -> (JsonObject) obj)
       .collect(Collectors.toList());
@@ -424,7 +425,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
     putIfNotNull(request, "servicePointIds", new JsonArray(servicePoints));
     send(locationsStorageUrl(""), HttpMethod.POST, request.toString(),
       SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(createLocation));
-    return createLocation.get(5, TimeUnit.SECONDS);
+    return createLocation.get(TIMEOUT, TimeUnit.SECONDS);
   }
 
   /**
@@ -464,7 +465,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
     send(locationsStorageUrl("/" + id.toString()), HttpMethod.GET,
       null, SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(getCompleted));
 
-    return getCompleted.get(5, TimeUnit.SECONDS);
+    return getCompleted.get(TIMEOUT, TimeUnit.SECONDS);
   }
 
 }

--- a/src/test/java/org/folio/rest/api/LocationsTest.java
+++ b/src/test/java/org/folio/rest/api/LocationsTest.java
@@ -1,6 +1,5 @@
 package org.folio.rest.api;
 
-import static org.folio.rest.api.StorageTestSuite.TIMEOUT;
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
@@ -15,18 +14,13 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
-
 import org.folio.rest.support.AdditionalHttpStatusCodes;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
@@ -80,8 +74,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
   }
 
   @Before
-  public void beforeEach() throws InterruptedException, ExecutionException,
-    TimeoutException {
+  public void beforeEach() {
 
     StorageTestSuite.deleteAll(itemsStorageUrl(""));
     StorageTestSuite.deleteAll(holdingsStorageUrl(""));
@@ -105,11 +98,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canCreateLocation()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canCreateLocation() {
     Response response = createLocation(null, "Main Library", instID, campID, libID, "PI/CC/ML/X", servicePointIDs);
     assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
     assertThat(response.getJson().getString("id"), notNullValue());
@@ -117,42 +106,26 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void cannotCreateLocationWithoutUnits()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotCreateLocationWithoutUnits() {
     Response response = createLocation(null, "Main Library", null, null, null, "PI/CC/ML/X", servicePointIDs);
     assertThat(response.getStatusCode(), is(AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY));
   }
 
   @Test
-  public void cannotCreateLocationWithoutCode()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotCreateLocationWithoutCode() {
     Response response = createLocation(null, "Main Library", instID, campID, libID, null, servicePointIDs);
     assertThat(response.getStatusCode(), is(AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY));
   }
 
   @Test
-  public void cannotCreateLocationWithSameName()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotCreateLocationWithSameName() {
     createLocation(null, "Main Library", "PI/CC/ML/X");
     Response response = createLocation(null, "Main Library", instID, campID, libID, "AA/BB", servicePointIDs);
     assertThat(response.getStatusCode(), is(AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY));
   }
 
   @Test
-  public void cannotCreateLocationWithSameCode()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotCreateLocationWithSameCode() {
     createLocation(null, "Main Library", "PI/CC/ML/X");
     Response response = createLocation(null, "Some Other Library", instID, campID, libID, "PI/CC/ML/X",
         servicePointIDs);
@@ -160,11 +133,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void cannotCreateLocationWithSameId()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotCreateLocationWithSameId() {
     UUID id = UUID.randomUUID();
     createLocation(id, "Main Library", "PI/CC/ML/X");
     Response response = createLocation(id, "Some Other Library", instID, campID, libID, "AA/BB", servicePointIDs);
@@ -172,11 +141,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canGetALocationById()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canGetALocationById() {
 
     UUID id = UUID.randomUUID();
     createLocation(id, "Main Library", "PI/CC/ML/X");
@@ -190,29 +155,21 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canListLocations()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canListLocations() {
 
     createLocation(null, "Main Library", "PI/CC/ML");
     createLocation(null, "Annex Library", "PI/CC/AL");
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
     send(locationsStorageUrl("/"), HttpMethod.GET,
       null, SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(getCompleted));
-    Response getResponse = getCompleted.get(TIMEOUT, TimeUnit.SECONDS);
+    Response getResponse = get(getCompleted);
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
     JsonObject item = getResponse.getJson();
     assertThat(item.getInteger("totalRecords"), is(2));
   }
 
   @Test
-  public void canUpdateALocation()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canUpdateALocation() {
 
     UUID id = UUID.randomUUID();
     createLocation(id, "Main Library", "PI/CC/ML/X");
@@ -230,7 +187,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
     send(locationsStorageUrl("/" + id.toString()), HttpMethod.PUT,
       updateRequest.toString(), SUPPORTED_CONTENT_TYPE_JSON_DEF,
       ResponseHandler.any(updated));
-    Response updateResponse = updated.get(TIMEOUT, TimeUnit.SECONDS);
+    Response updateResponse = get(updated);
     assertThat(updateResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
     Response getResponse = getById(id);
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
@@ -238,12 +195,9 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
     assertThat(item.getString("id"), is(id.toString()));
     assertThat(item.getString("name"), is("Annex Library"));
   }
+
   @Test
-  public void cannotUpdateId()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotUpdateId() {
 
     UUID id = UUID.randomUUID();
     createLocation(id, "Main Library", "PI/CC/ML/X");
@@ -260,31 +214,23 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
     send(locationsStorageUrl("/" + id.toString()), HttpMethod.PUT,
       updateRequest.toString(), SUPPORTED_CONTENT_TYPE_JSON_DEF,
       ResponseHandler.any(updated));
-    Response updateResponse = updated.get(TIMEOUT, TimeUnit.SECONDS);
+    Response updateResponse = get(updated);
     assertThat(updateResponse.getStatusCode(), is(AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY));
   }
 
   @Test
-  public void canDeleteALocation()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void canDeleteALocation() {
     UUID id = UUID.randomUUID();
     createLocation(id, "Main Library", "PI/CC/ML/X");
     CompletableFuture<Response> deleteCompleted = new CompletableFuture<>();
     send(locationsStorageUrl("/" + id.toString()), HttpMethod.DELETE, null,
       SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.any(deleteCompleted));
-    Response deleteResponse = deleteCompleted.get(TIMEOUT, TimeUnit.SECONDS);
+    Response deleteResponse = get(deleteCompleted);
     assertThat(deleteResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
   }
 
   @Test
-  public void cannotDeleteALocationAssociatedWithAnItem()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  public void cannotDeleteALocationAssociatedWithAnItem() {
 
     UUID id = UUID.randomUUID();
     createLocation(id, "Main Library", "PI/CC/ML/X");
@@ -293,13 +239,13 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
     CompletableFuture<Response> createItemCompleted = new CompletableFuture<>();
     send(itemsStorageUrl(""), HttpMethod.POST, item.toString(),
       SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(createItemCompleted));
-    Response createItemResponse = createItemCompleted.get(TIMEOUT, TimeUnit.SECONDS);
+    Response createItemResponse = get(createItemCompleted);
     assertThat(createItemResponse.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
     CompletableFuture<Response> deleteCompleted = new CompletableFuture<>();
     send(locationsStorageUrl("/" + id.toString()),
       HttpMethod.DELETE, null, SUPPORTED_CONTENT_TYPE_JSON_DEF,
       ResponseHandler.any(deleteCompleted));
-    Response deleteResponse = deleteCompleted.get(TIMEOUT, TimeUnit.SECONDS);
+    Response deleteResponse = get(deleteCompleted);
     assertThat(deleteResponse.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
   }
 
@@ -356,8 +302,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
     request.end(buffer);
   }
 
-  private List<JsonObject> getMany(String cql, Object... args) throws InterruptedException,
-    ExecutionException, TimeoutException {
+  private List<JsonObject> getMany(String cql, Object... args) {
 
     final CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 
@@ -365,7 +310,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
       HttpMethod.GET, null, SUPPORTED_CONTENT_TYPE_JSON_DEF,
       ResponseHandler.json(getCompleted));
 
-    return getCompleted.get(TIMEOUT, TimeUnit.SECONDS).getJson()
+    return get(getCompleted).getJson()
       .getJsonArray("locations").stream()
       .map(obj -> (JsonObject) obj)
       .collect(Collectors.toList());
@@ -402,11 +347,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
   }
 
   public static Response createLocation(UUID id, String name,
-      UUID inst, UUID camp, UUID lib, String code, List<UUID> servicePoints)
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+      UUID inst, UUID camp, UUID lib, String code, List<UUID> servicePoints) {
 
     CompletableFuture<Response> createLocation = new CompletableFuture<>();
     JsonObject request = new JsonObject()
@@ -425,7 +366,7 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
     putIfNotNull(request, "servicePointIds", new JsonArray(servicePoints));
     send(locationsStorageUrl(""), HttpMethod.POST, request.toString(),
       SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(createLocation));
-    return createLocation.get(TIMEOUT, TimeUnit.SECONDS);
+    return get(createLocation);
   }
 
   /**
@@ -454,19 +395,14 @@ public class LocationsTest extends TestBaseWithInventoryUtil {
     return id;
   }
 
-  private Response getById(UUID id)
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+  private Response getById(UUID id) {
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 
     send(locationsStorageUrl("/" + id.toString()), HttpMethod.GET,
       null, SUPPORTED_CONTENT_TYPE_JSON_DEF, ResponseHandler.json(getCompleted));
 
-    return getCompleted.get(TIMEOUT, TimeUnit.SECONDS);
+    return get(getCompleted);
   }
 
 }
-

--- a/src/test/java/org/folio/rest/api/MigrationTestBase.java
+++ b/src/test/java/org/folio/rest/api/MigrationTestBase.java
@@ -1,9 +1,7 @@
 package org.folio.rest.api;
 
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
-import static org.folio.rest.api.StorageTestSuite.TIMEOUT;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -64,7 +62,7 @@ abstract class MigrationTestBase extends TestBaseWithInventoryUtil {
       }
     });
 
-    result.get(TIMEOUT, SECONDS);
+    get(result);
   }
 
   RowSet<Row> executeSql(String sql)
@@ -80,7 +78,7 @@ abstract class MigrationTestBase extends TestBaseWithInventoryUtil {
       }
     });
 
-    return result.get(TIMEOUT, SECONDS);
+    return get(result);
   }
 
   void updateJsonbProperty(
@@ -118,7 +116,7 @@ abstract class MigrationTestBase extends TestBaseWithInventoryUtil {
         result.complete(resultSet.result());
       });
 
-    return result.get(TIMEOUT, SECONDS);
+    return get(result);
   }
 
   private PostgresClient getPostgresClient() {

--- a/src/test/java/org/folio/rest/api/MigrationTestBase.java
+++ b/src/test/java/org/folio/rest/api/MigrationTestBase.java
@@ -3,6 +3,7 @@ package org.folio.rest.api;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
+import static org.folio.rest.api.StorageTestSuite.TIMEOUT;
 
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -63,7 +64,7 @@ abstract class MigrationTestBase extends TestBaseWithInventoryUtil {
       }
     });
 
-    result.get(5, SECONDS);
+    result.get(TIMEOUT, SECONDS);
   }
 
   RowSet<Row> executeSql(String sql)
@@ -79,7 +80,7 @@ abstract class MigrationTestBase extends TestBaseWithInventoryUtil {
       }
     });
 
-    return result.get(5, SECONDS);
+    return result.get(TIMEOUT, SECONDS);
   }
 
   void updateJsonbProperty(
@@ -117,7 +118,7 @@ abstract class MigrationTestBase extends TestBaseWithInventoryUtil {
         result.complete(resultSet.result());
       });
 
-    return result.get(5, SECONDS);
+    return result.get(TIMEOUT, SECONDS);
   }
 
   private PostgresClient getPostgresClient() {

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -70,9 +70,6 @@ import org.junit.runners.Suite;
 })
 public class StorageTestSuite {
   public static final String TENANT_ID = "test_tenant";
-  /** timeout in seconds for simple requests. Usage: completableFuture.get(TIMEOUT, TimeUnit.SECONDS) */
-  public static final long TIMEOUT = 10;
-
   private static Vertx vertx;
   private static int port;
 
@@ -173,7 +170,7 @@ public class StorageTestSuite {
       client.delete(rootUrl, TENANT_ID,
         ResponseHandler.any(deleteAllFinished));
 
-      Response response = deleteAllFinished.get(10, TimeUnit.SECONDS);
+      Response response = TestBase.get(deleteAllFinished);
 
       if (response.getStatusCode() != 204) {
         Assert.fail("Delete all preparation failed: " +
@@ -211,7 +208,7 @@ public class StorageTestSuite {
         .map(deleteResult -> cf.complete(deleteResult.rowCount() >= 0))
         .otherwise(error -> cf.complete(false));
 
-      return cf.get(10, TimeUnit.SECONDS);
+      return TestBase.get(cf);
     } catch (Exception e) {
       throw new RuntimeException("WARNING!!!!! Unable to delete all: " + e.getMessage(), e);
     }
@@ -238,7 +235,7 @@ public class StorageTestSuite {
       }
     });
 
-    return selectCompleted.get(10, TimeUnit.SECONDS);
+    return TestBase.get(selectCompleted);
   }
 
   private static void startVerticle(DeploymentOptions options)

--- a/src/test/java/org/folio/rest/api/TestBase.java
+++ b/src/test/java/org/folio/rest/api/TestBase.java
@@ -7,17 +7,10 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowIterator;
-import io.vertx.sqlclient.RowSet;
 import org.folio.rest.support.HttpClient;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
@@ -98,7 +91,7 @@ public abstract class TestBase {
     client.get(url, TENANT_ID, ResponseHandler.text(getCompleted));
     Response response;
     try {
-      response = getCompleted.get(5, SECONDS);
+      response = getCompleted.get(StorageTestSuite.TIMEOUT, SECONDS);
       assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
     } catch (InterruptedException | ExecutionException | TimeoutException e) {
       throw new RuntimeException(e);

--- a/src/test/java/org/folio/rest/api/TestBase.java
+++ b/src/test/java/org/folio/rest/api/TestBase.java
@@ -48,7 +48,7 @@ public abstract class TestBase {
   /**
    * Returns future.get({@link #TIMEOUT}, {@link TimeUnit#SECONDS}).
    *
-   * <p>These checked exceptions are wrapped into RuntimeException:
+   * <p>Wraps these checked exceptions into RuntimeException:
    * InterruptedException, ExecutionException, TimeoutException.
    */
   public static <T> T get(CompletableFuture<T> future) {

--- a/src/test/java/org/folio/rest/api/TestBase.java
+++ b/src/test/java/org/folio/rest/api/TestBase.java
@@ -1,6 +1,5 @@
 package org.folio.rest.api;
 
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -9,6 +8,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
 import org.folio.rest.support.HttpClient;
@@ -26,6 +26,9 @@ import io.vertx.core.Vertx;
  * IDE during development.
  */
 public abstract class TestBase {
+  /** timeout in seconds for simple requests. Usage: completableFuture.get(TIMEOUT, TimeUnit.SECONDS) */
+  public static final long TIMEOUT = 10;
+
   private static boolean invokeStorageTestSuiteAfter = false;
   static HttpClient client;
   protected static ResourceClient instancesClient;
@@ -42,6 +45,19 @@ public abstract class TestBase {
   static ResourceClient instancesStorageBatchInstancesClient;
   static ResourceClient instanceTypesClient;
 
+  /**
+   * Returns future.get({@link #TIMEOUT}, {@link TimeUnit#SECONDS}).
+   *
+   * <p>These checked exceptions are wrapped into RuntimeException:
+   * InterruptedException, ExecutionException, TimeoutException.
+   */
+  public static <T> T get(CompletableFuture<T> future) {
+    try {
+      return future.get(TestBase.TIMEOUT, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   @BeforeClass
   public static void testBaseBeforeClass() throws Exception {
@@ -89,13 +105,8 @@ public abstract class TestBase {
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 
     client.get(url, TENANT_ID, ResponseHandler.text(getCompleted));
-    Response response;
-    try {
-      response = getCompleted.get(StorageTestSuite.TIMEOUT, SECONDS);
-      assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      throw new RuntimeException(e);
-    }
+    Response response = get(getCompleted);
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
   }
 
 }

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -1,7 +1,6 @@
 package org.folio.rest.api;
 
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
-import static org.folio.rest.api.StorageTestSuite.TIMEOUT;
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instanceStatusesUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
@@ -13,17 +12,12 @@ import static org.folio.rest.support.http.InterfaceUrls.locLibraryStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.locationsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.materialTypesStorageUrl;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.net.MalformedURLException;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.function.UnaryOperator;
-
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.Response;
@@ -80,10 +74,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   protected static final UUID UUID_INSTANCE_TYPE = UUID.fromString("535e3160-763a-42f9-b0c0-d8ed7df6e2a2");
 
   @BeforeClass
-  public static void beforeAny()
-    throws InterruptedException,
-    ExecutionException,
-    TimeoutException {
+  public static void beforeAny() {
 
     StorageTestSuite.deleteAll(TENANT_ID, "preceding_succeeding_title");
     StorageTestSuite.deleteAll(TENANT_ID, "instance_relationship");
@@ -116,17 +107,12 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     LocationsTest.createLocation(fourthFloorLocationId,  FOURTH_FLOOR_LOCATION,  "TestBaseWI/FF");
   }
 
-  protected static UUID createInstanceAndHolding(UUID holdingsPermanentLocationId)
-    throws ExecutionException, InterruptedException, MalformedURLException, TimeoutException {
+  protected static UUID createInstanceAndHolding(UUID holdingsPermanentLocationId) {
     return createInstanceAndHolding(holdingsPermanentLocationId, null);
   }
 
   protected static UUID createInstanceAndHolding(UUID holdingsPermanentLocationId,
-                                                 UUID holdingsTemporaryLocationId)
-    throws ExecutionException,
-    InterruptedException,
-    MalformedURLException,
-    TimeoutException {
+                                                 UUID holdingsTemporaryLocationId) {
 
     UUID instanceId = UUID.randomUUID();
     instancesClient.create(instance(instanceId));
@@ -134,8 +120,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   }
 
   static UUID createInstanceAndHoldingWithBuilder(
-    UUID holdingsPermanentLocationId, UnaryOperator<HoldingRequestBuilder> holdingsBuilderProcessor)
-    throws ExecutionException, InterruptedException, MalformedURLException, TimeoutException {
+    UUID holdingsPermanentLocationId, UnaryOperator<HoldingRequestBuilder> holdingsBuilderProcessor) {
 
     UUID instanceId = UUID.randomUUID();
     instancesClient.create(instance(instanceId));
@@ -152,11 +137,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
 
   protected static UUID createHolding(UUID instanceId,
                                       UUID holdingsPermanentLocationId,
-                                      UUID holdingsTemporaryLocationId)
-                                          throws ExecutionException,
-                                          InterruptedException,
-                                          MalformedURLException,
-                                          TimeoutException {
+                                      UUID holdingsTemporaryLocationId) {
     return holdingsClient.create(
         new HoldingRequestBuilder()
           .withId(UUID.randomUUID())
@@ -166,11 +147,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
       ).getId();
   }
 
-  protected static UUID createInstanceAndHoldingWithCallNumber(UUID holdingsPermanentLocationId)
-      throws ExecutionException,
-      InterruptedException,
-      MalformedURLException,
-      TimeoutException {
+  protected static UUID createInstanceAndHoldingWithCallNumber(UUID holdingsPermanentLocationId) {
 
       UUID instanceId = UUID.randomUUID();
       instancesClient.create(instance(instanceId));
@@ -184,11 +161,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
       ).getId();
   }
 
-  protected static UUID createInstanceAndHoldingWithCallNumberPrefix(UUID holdingsPermanentLocationId)
-      throws MalformedURLException,
-      InterruptedException,
-      ExecutionException,
-      TimeoutException {
+  protected static UUID createInstanceAndHoldingWithCallNumberPrefix(UUID holdingsPermanentLocationId) {
 
     UUID instanceId = UUID.randomUUID();
     instancesClient.create(instance(instanceId));
@@ -202,11 +175,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     ).getId();
   }
 
-  protected static UUID createInstanceAndHoldingWithCallNumberSuffix(UUID holdingsPermanentLocationId)
-      throws MalformedURLException,
-      InterruptedException,
-      ExecutionException,
-      TimeoutException {
+  protected static UUID createInstanceAndHoldingWithCallNumberSuffix(UUID holdingsPermanentLocationId) {
 
     UUID instanceId = UUID.randomUUID();
     instancesClient.create(instance(instanceId));
@@ -253,27 +222,23 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     return itemToCreate.mapTo(Item.class);
   }
 
-  protected void createItem(JsonObject itemToCreate)
-      throws MalformedURLException,
-      InterruptedException,
-      ExecutionException,
-      TimeoutException {
+  protected void createItem(JsonObject itemToCreate) {
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
     client.post(itemsStorageUrl(""), itemToCreate, TENANT_ID,
         ResponseHandler.json(createCompleted));
 
-    Response response = createCompleted.get(2, TimeUnit.SECONDS);
+    Response response = get(createCompleted);
 
     assertThat(response.getStatusCode(), is(201));
   }
 
-  protected IndividualResource createItem(Item item) throws Exception {
+  protected IndividualResource createItem(Item item) {
     return itemsClient.create(JsonObject.mapFrom(item));
   }
 
-  protected IndividualResource createItem(ItemRequestBuilder item) throws Exception {
+  protected IndividualResource createItem(ItemRequestBuilder item) {
     return itemsClient.create(item.create());
   }
 
@@ -313,21 +278,21 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     return instanceToCreate;
   }
 
-  IndividualResource getCatalogedInstanceType() throws Exception {
+  IndividualResource getCatalogedInstanceType() {
     return getInstanceStatusByCode("cat");
   }
 
-  IndividualResource getOtherInstanceType() throws Exception {
+  IndividualResource getOtherInstanceType() {
     return getInstanceStatusByCode("other");
   }
 
-  private IndividualResource getInstanceStatusByCode(String code) throws Exception {
+  private IndividualResource getInstanceStatusByCode(String code) {
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 
     client.get(instanceStatusesUrl("?query=code=" + code),
       TENANT_ID, ResponseHandler.json(getCompleted));
 
-    JsonObject instanceStatus = getCompleted.get(TIMEOUT, TimeUnit.SECONDS)
+    JsonObject instanceStatus = get(getCompleted)
       .getJson()
       .getJsonArray("instanceStatuses").getJsonObject(0);
 

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -1,6 +1,7 @@
 package org.folio.rest.api;
 
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
+import static org.folio.rest.api.StorageTestSuite.TIMEOUT;
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instanceStatusesUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
@@ -326,7 +327,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     client.get(instanceStatusesUrl("?query=code=" + code),
       TENANT_ID, ResponseHandler.json(getCompleted));
 
-    JsonObject instanceStatus = getCompleted.get(5, TimeUnit.SECONDS)
+    JsonObject instanceStatus = getCompleted.get(TIMEOUT, TimeUnit.SECONDS)
       .getJson()
       .getJsonArray("instanceStatuses").getJsonObject(0);
 

--- a/src/test/java/org/folio/rest/support/client/LoanTypesClient.java
+++ b/src/test/java/org/folio/rest/support/client/LoanTypesClient.java
@@ -2,15 +2,13 @@ package org.folio.rest.support.client;
 
 import io.vertx.core.json.JsonObject;
 import org.folio.rest.api.StorageTestSuite;
+import org.folio.rest.api.TestBase;
 import org.folio.rest.support.HttpClient;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
 
 import java.net.URL;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class LoanTypesClient {
   private final HttpClient client;
@@ -21,8 +19,7 @@ public class LoanTypesClient {
     this.loanTypesUrl = loanTypesUrl;
   }
 
-  public String create(String name)
-    throws InterruptedException, ExecutionException, TimeoutException {
+  public String create(String name) {
 
     CompletableFuture<Response> completed = new CompletableFuture<>();
 
@@ -32,7 +29,7 @@ public class LoanTypesClient {
     client.post(loanTypesUrl, loanTypeRequest, StorageTestSuite.TENANT_ID,
       ResponseHandler.json(completed));
 
-    Response response = completed.get(5, TimeUnit.SECONDS);
+    Response response = TestBase.get(completed);
 
     return response.getJson().getString("id");
   }

--- a/src/test/java/org/folio/rest/support/client/MaterialTypesClient.java
+++ b/src/test/java/org/folio/rest/support/client/MaterialTypesClient.java
@@ -2,15 +2,13 @@ package org.folio.rest.support.client;
 
 import io.vertx.core.json.JsonObject;
 import org.folio.rest.api.StorageTestSuite;
+import org.folio.rest.api.TestBase;
 import org.folio.rest.support.HttpClient;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
 
 import java.net.URL;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 
 public class MaterialTypesClient {
   private final HttpClient client;
@@ -21,8 +19,7 @@ public class MaterialTypesClient {
     this.materialTypesUrl = materialTypesUrl;
   }
 
-  public String create(String name)
-    throws InterruptedException, ExecutionException, TimeoutException {
+  public String create(String name) {
 
     CompletableFuture<Response> completed = new CompletableFuture<>();
 
@@ -32,7 +29,7 @@ public class MaterialTypesClient {
     client.post(materialTypesUrl, materialTypeRequest, StorageTestSuite.TENANT_ID,
       ResponseHandler.json(completed));
 
-    Response response = completed.get(5, TimeUnit.SECONDS);
+    Response response = TestBase.get(completed);
 
     return response.getJson().getString("id");
   }

--- a/src/test/java/org/folio/rest/support/http/ResourceClient.java
+++ b/src/test/java/org/folio/rest/support/http/ResourceClient.java
@@ -9,12 +9,10 @@ import java.net.URL;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 
 import org.folio.rest.api.StorageTestSuite;
+import org.folio.rest.api.TestBase;
 import org.folio.rest.support.HttpClient;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.JsonArrayHelper;
@@ -139,17 +137,12 @@ public class ResourceClient {
     this.collectionArrayPropertyName = resourceName;
   }
 
-  public IndividualResource create(Builder builder)
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
+  public IndividualResource create(Builder builder) {
 
     return create(builder.create());
   }
 
-  public IndividualResource create(JsonObject request) throws MalformedURLException,
-    InterruptedException, ExecutionException, TimeoutException {
+  public IndividualResource create(JsonObject request) {
 
     Response response = attemptToCreate(request);
 
@@ -163,8 +156,7 @@ public class ResourceClient {
     return new IndividualResource(response);
   }
 
-  public void createNoResponse(JsonObject request) throws MalformedURLException,
-    InterruptedException, ExecutionException, TimeoutException {
+  public void createNoResponse(JsonObject request) {
 
     Response response = attemptToCreate(request);
 
@@ -173,33 +165,30 @@ public class ResourceClient {
       response.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
   }
 
-  public Response attemptToCreate(JsonObject request) throws MalformedURLException,
-      InterruptedException, ExecutionException, TimeoutException {
+  public Response attemptToCreate(JsonObject request) {
     return attemptToCreate("", request);
   }
 
-  public Response attemptToCreate(String subPath, JsonObject request) throws MalformedURLException,
-    InterruptedException, ExecutionException, TimeoutException {
+  public Response attemptToCreate(String subPath, JsonObject request) {
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
-    client.post(urlMaker.combine(subPath), request, StorageTestSuite.TENANT_ID,
-      ResponseHandler.any(createCompleted));
+    try {
+      client.post(urlMaker.combine(subPath), request, StorageTestSuite.TENANT_ID,
+        ResponseHandler.any(createCompleted));
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(subPath + ": " + e.getMessage(), e);
+    }
 
-    return createCompleted.get(5, TimeUnit.SECONDS);
+    return TestBase.get(createCompleted);
   }
 
-  public void replace(UUID id, Builder builder)
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+  public void replace(UUID id, Builder builder) {
 
     replace(id, builder.create());
   }
 
-  public void replace(UUID id, JsonObject request) throws MalformedURLException,
-    InterruptedException, ExecutionException, TimeoutException {
+  public void replace(UUID id, JsonObject request) {
 
     Response putResponse = attemptToReplace(id != null ? id.toString() : null, request);
 
@@ -208,47 +197,55 @@ public class ResourceClient {
       putResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
   }
 
-  public Response attemptToReplace(String id, JsonObject request) throws MalformedURLException,
-    InterruptedException, ExecutionException, TimeoutException {
+  /**
+   * Return urlMaker.combine(String.format("/%s", id)).
+   *
+   * <p>Wrap MalformedURLException into RuntimeException.
+   */
+  private URL urlMakerWithId(String id) {
+    try {
+      return urlMaker.combine(String.format("/%s", id));
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public Response attemptToReplace(String id, JsonObject request) {
 
     CompletableFuture<Response> putCompleted = new CompletableFuture<>();
 
-    client.put(urlMaker.combine(String.format("/%s", id)), request,
+    client.put(urlMakerWithId(id), request,
       StorageTestSuite.TENANT_ID, ResponseHandler.any(putCompleted));
 
-    return putCompleted.get(5, TimeUnit.SECONDS);
+    return TestBase.get(putCompleted);
   }
 
-  public Response getById(UUID id) throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
+  public Response getById(UUID id) {
 
     return getByIdIfPresent(id != null ? id.toString() : null);
   }
 
-  public Response getByIdIfPresent(String id) throws MalformedURLException,
-    InterruptedException, ExecutionException, TimeoutException {
+  public Response getByIdIfPresent(String id) {
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 
-    client.get(urlMaker.combine(String.format("/%s", id)),
-      StorageTestSuite.TENANT_ID, ResponseHandler.any(getCompleted));
+    client.get(urlMakerWithId(id),
+        StorageTestSuite.TENANT_ID, ResponseHandler.any(getCompleted));
 
-    return getCompleted.get(5, TimeUnit.SECONDS);
+    return TestBase.get(getCompleted);
   }
 
-  public Response deleteIfPresent(String id) throws MalformedURLException,
-    InterruptedException, ExecutionException, TimeoutException {
+  public Response deleteIfPresent(String id) {
 
     CompletableFuture<Response> deleteFinished = new CompletableFuture<>();
 
-    client.delete(urlMaker.combine(String.format("/%s", id)),
+    client.delete(urlMakerWithId(id),
       StorageTestSuite.TENANT_ID, ResponseHandler.any(deleteFinished));
 
-    return deleteFinished.get(5, TimeUnit.SECONDS);
+    return TestBase.get(deleteFinished);
   }
 
-  public void delete(UUID id) throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
+  public void delete(UUID id) {
 
     Response response = deleteIfPresent(id != null ? id.toString() : null);
 
@@ -257,35 +254,30 @@ public class ResourceClient {
       response.getStatusCode(), is(204));
   }
 
-  public Response attemptToDelete(UUID id) throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
+  public Response attemptToDelete(UUID id) {
 
     return deleteIfPresent(id != null ? id.toString() : null);
   }
 
-  public void deleteAll()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+  public void deleteAll() {
 
     CompletableFuture<Response> deleteAllFinished = new CompletableFuture<>();
 
-    client.delete(urlMaker.combine(""), StorageTestSuite.TENANT_ID,
-      ResponseHandler.any(deleteAllFinished));
+    try {
+      client.delete(urlMaker.combine(""), StorageTestSuite.TENANT_ID,
+        ResponseHandler.any(deleteAllFinished));
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
 
-    Response response = deleteAllFinished.get(5, TimeUnit.SECONDS);
+    Response response = TestBase.get(deleteAllFinished);
 
     assertThat(String.format(
       "Failed to delete %s: %s", resourceName, response.getBody()),
       response.getStatusCode(), is(204));
   }
 
-  public void deleteAllIndividually()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+  public void deleteAllIndividually() {
 
     List<JsonObject> records = getAll();
 
@@ -293,11 +285,10 @@ public class ResourceClient {
       try {
         CompletableFuture<Response> deleteFinished = new CompletableFuture<>();
 
-        client.delete(urlMaker.combine(String.format("/%s",
-          record.getString("id"))), StorageTestSuite.TENANT_ID,
+        client.delete(urlMakerWithId(record.getString("id")), StorageTestSuite.TENANT_ID,
           ResponseHandler.any(deleteFinished));
 
-        Response deleteResponse = deleteFinished.get(5, TimeUnit.SECONDS);
+        Response deleteResponse = TestBase.get(deleteFinished);
 
         assertThat(String.format(
           "Failed to delete %s: %s", resourceName, deleteResponse.getBody()),
@@ -311,24 +302,23 @@ public class ResourceClient {
     });
   }
 
-  public List<JsonObject> getAll()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+  public List<JsonObject> getAll() {
 
     return getByQuery("");
   }
 
-  public List<JsonObject> getByQuery(String query) throws MalformedURLException,
-    InterruptedException, ExecutionException, TimeoutException {
+  public List<JsonObject> getByQuery(String query) {
 
     CompletableFuture<Response> getFinished = new CompletableFuture<>();
 
-    client.get(urlMaker.combine(query), StorageTestSuite.TENANT_ID,
-      ResponseHandler.any(getFinished));
+    try {
+      client.get(urlMaker.combine(query), StorageTestSuite.TENANT_ID,
+        ResponseHandler.any(getFinished));
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
 
-    Response response = getFinished.get(5, TimeUnit.SECONDS);
+    Response response = TestBase.get(getFinished);
 
     assertThat(String.format("Get all records failed: %s", response.getBody()),
       response.getStatusCode(), is(200));
@@ -337,18 +327,21 @@ public class ResourceClient {
       .getJsonArray(collectionArrayPropertyName));
   }
 
-  public List<IndividualResource> getMany(String query, Object... queryParams)
-    throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+  public List<IndividualResource> getMany(String query, Object... queryParams) {
 
     CompletableFuture<Response> getFinished = new CompletableFuture<>();
 
     final String encodedQuery = StringUtil
       .urlEncode(String.format(query, queryParams));
 
-    client.get(urlMaker.combine("?query=" + encodedQuery),
-      StorageTestSuite.TENANT_ID, ResponseHandler.json(getFinished));
+    try {
+      client.get(urlMaker.combine("?query=" + encodedQuery),
+        StorageTestSuite.TENANT_ID, ResponseHandler.json(getFinished));
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(e);
+    }
 
-    Response response = getFinished.get(5, TimeUnit.SECONDS);
+    Response response = TestBase.get(getFinished);
 
     assertThat(String.format("Get all records failed: %s", response.getBody()),
       response.getStatusCode(), is(200));


### PR DESCRIPTION
In addition three catch blocks are fixed to no longer swallow
stack traces but pass on the (possibly checked) exception wrapped
in a RuntimeException.