### PR TITLE
MODINVSTOR-578: Add `dateOfPublication` index

### DIFF
--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -484,6 +484,10 @@
           "sqlExpressionQuery": "normalize_digits($)"
         },
         {
+          "fieldName": "dateOfPublication",
+          "sqlExpression" : "concat_array_object_values(jsonb->'publication', 'dateOfPublication')"
+        },
+        {
           "fieldName": "subjects",
           "tOps": "ADD",
           "caseSensitive": false,

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -542,6 +542,27 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  public void canSearchUsingDateOfPublication() throws Exception {
+
+    JsonObject instance1 = smallAngryPlanet(null)
+        .put("publication", new JsonArray()
+            .add(new JsonObject().put("dateOfPublication", "1910")));
+    createInstance(instance1);
+
+    JsonObject instance2 = nod(null)
+        .put("publication", new JsonArray()
+            .add(new JsonObject().put("dateOfPublication", "2020"))
+            .add(new JsonObject().put("dateOfPublication", "1910")));
+    createInstance(instance2);
+
+    JsonArray instances2020 = searchForInstances("dateOfPublication = 2020").getJsonArray("instances");
+    assertThat(instances2020.size(), is(1));
+
+    JsonArray instances1910 = searchForInstances("dateOfPublication = 1910").getJsonArray("instances");
+    assertThat(instances1910.size(), is(2));
+  }
+
+  @Test
   public void canSearchUsingMetadataDateUpdatedIndex()
     throws MalformedURLException,
     InterruptedException,


### PR DESCRIPTION
The index contains all the dateOfPublication
values of the publication array. Example array:

```
"publication" : [ {
      "publisher" : "Random House",
      "place" : "New York",
      "dateOfPublication" : "[1998]",
      "role" : "Publication"
    }, {
      "publisher" : null,
      "place" : null,
      "dateOfPublication" : "©1998",
      "role" : null
    }
]
```