### PR TITLE
Add support for using inventory as shared index

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,7 +4,7 @@
   "provides": [
     {
       "id": "item-storage",
-      "version": "8.5",
+      "version": "8.6",
       "handlers": [
         {
           "methods": ["GET"],
@@ -88,7 +88,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "7.4",
+      "version": "7.5",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -12,6 +12,10 @@
       "type": "string",
       "description": "The human readable ID, also called eye readable ID. A system-assigned sequential ID which maps to the Instance ID"
     },
+    "matchKey": {
+      "type": "string",
+      "description" : "An unique instance identifier matching a client-side bibliographic record identification. Could be an actual local identifier or a key generated from metadata in the local bibliographic record. Enables the client to determine if a client side bibliographic record already exists as an Instance in Inventory"
+    },
     "source": {
       "type": "string",
       "description": "The metadata source and its format of the underlying record to the instance record. (e.g. FOLIO if it's a record created in Inventory;  MARC if it's a MARC record created in MARCcat or EPKB if it's a record coming from eHoldings)"

--- a/ramls/item.json
+++ b/ramls/item.json
@@ -245,6 +245,7 @@
             "Declared lost",
             "Order closed",
             "Claimed returned",
+            "Unknown",
             "Withdrawn",
             "Lost and paid",
             "Aged to lost"

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -356,6 +356,10 @@
         {
           "fieldName": "hrid",
           "tOps": "ADD"
+        },
+        {
+          "fieldName": "matchKey",
+          "tOps": "ADD"
         }
       ],
       "ginIndex": [

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -2469,6 +2469,41 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  public void cannotCreateInstanceWithDuplicateMatchKey() throws Exception {
+    log.info("Starting cannotCreateInstanceWithDuplicateMatchKey");
+
+    final UUID id = UUID.randomUUID();
+    final JsonObject instanceToCreate = smallAngryPlanet(id);
+    instanceToCreate.put("matchKey", "match_key");
+
+    setInstanceSequence(1);
+
+    createInstance(instanceToCreate);
+
+    final Response createdInstance = getById(id);
+
+    assertThat(createdInstance.getJson().getString("matchKey"), is("match_key"));
+
+    final JsonObject instanceToCreateWithSameMatchKey = nod(UUID.randomUUID());
+    instanceToCreateWithSameMatchKey.put("matchKey", "match_key");
+
+    final CompletableFuture<Response> createCompleted = new CompletableFuture<>();
+
+    client.post(instancesStorageUrl(""), instanceToCreateWithSameMatchKey, TENANT_ID,
+      text(createCompleted));
+
+    final Response response = createCompleted.get(5, SECONDS);
+
+    assertThat(response.getStatusCode(), is(400));
+    assertThat(response.getBody(),
+        is("duplicate key value violates unique constraint \"instance_matchkey_idx_unique\": " +
+          "Key (lower(f_unaccent(jsonb ->> 'matchKey'::text)))=(match_key) already exists."));
+
+    log.info("Finished cannotCreateInstanceWithDuplicateMatchKey");
+  }
+
+
+  @Test
   public void canPostSynchronousBatchWithDiscoverySuppressedInstances() throws Exception {
     final JsonArray instancesArray = new JsonArray();
     final UUID smallAngryPlanetId = UUID.randomUUID();


### PR DESCRIPTION
 - add matchKey property to Instance
 - add enumeration element "Unknown" for Item.status

This pull request suggests two changes to Inventory Storage in order to use Inventory for shared indexes, with 1)  being the most important: 

1)
It's suggested to extend the Instance schema of Inventory storage with a unique, optional property `matchKey`. 

`Instance.matchKey` can be used in a setting where multiple libraries contribute bibliographic records to the same Inventory -- a shared index --  and thus need a way to identify identical instances across multiple catalogs in order to provide updates to bibliographic data or holdings in the shared index. One option is to use match key values based on metadata in the bibliographic record for example.  

Please note that the change includes a new index added to the DB schema. 

2) 
It's suggested to extend the enumeration of `Item.status` with a new option "Unknown".  With a shared index, circulation may be handled by the participating libraries individually, outside of FOLIO. When presenting the bibliographic data and their holdings from the shared index it is thus not necessarily possible to know the status of any given item. There's not currently a status option that indicates that the item's status isn't currently known. Having that option is convenient if FOLIO Stripes module `ui-inventory` is being used for displaying records of the shared index, since it would have to display an arbitrary (misleading) status in lieu of 'Unknown', 'NA' or similar.  

These two changes are the only ones we've identified as necessary/desirable during over six months of working with Inventory Storage in a shared index setting, giving us some confidence that this _is_ what will be required.  