### PR TITLE
MODINVSTOR-587: Add property `Instance.matchKey` for building a shared index with Inventory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,5 @@ nbproject/
 #npm
 node_modules
 /bin/
+.factorypath
+.vscode/

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -88,7 +88,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "7.4",
+      "version": "7.5",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -12,6 +12,10 @@
       "type": "string",
       "description": "The human readable ID, also called eye readable ID. A system-assigned sequential ID which maps to the Instance ID"
     },
+    "matchKey": {
+      "type": "string",
+      "description" : "An unique instance identifier matching a client-side bibliographic record identification. Could be an actual local identifier or a key generated from metadata in the local bibliographic record. Enables the client to determine if a client side bibliographic record already exists as an Instance in Inventory"
+    },
     "source": {
       "type": "string",
       "description": "The metadata source and its format of the underlying record to the instance record. (e.g. FOLIO if it's a record created in Inventory;  MARC if it's a MARC record created in MARCcat or EPKB if it's a record coming from eHoldings)"

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -14,7 +14,7 @@
     },
     "matchKey": {
       "type": "string",
-      "description" : "An unique instance identifier matching a client-side bibliographic record identification. Could be an actual local identifier or a key generated from metadata in the local bibliographic record. Enables the client to determine if a client side bibliographic record already exists as an Instance in Inventory"
+      "description" : "A unique instance identifier matching a client-side bibliographic record identification scheme, in particular for a scenario where multiple separate catalogs with no shared record identifiers contribute to the same Instance in Inventory. A match key is typically generated from select, normalized pieces of metadata in bibliographic records"
     },
     "source": {
       "type": "string",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -356,6 +356,10 @@
         {
           "fieldName": "hrid",
           "tOps": "ADD"
+        },
+        {
+          "fieldName": "matchKey",
+          "tOps": "ADD"
         }
       ],
       "ginIndex": [

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -2469,6 +2469,41 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  public void cannotCreateInstanceWithDuplicateMatchKey() throws Exception {
+    log.info("Starting cannotCreateInstanceWithDuplicateMatchKey");
+
+    final UUID id = UUID.randomUUID();
+    final JsonObject instanceToCreate = smallAngryPlanet(id);
+    instanceToCreate.put("matchKey", "match_key");
+
+    setInstanceSequence(1);
+
+    createInstance(instanceToCreate);
+
+    final Response createdInstance = getById(id);
+
+    assertThat(createdInstance.getJson().getString("matchKey"), is("match_key"));
+
+    final JsonObject instanceToCreateWithSameMatchKey = nod(UUID.randomUUID());
+    instanceToCreateWithSameMatchKey.put("matchKey", "match_key");
+
+    final CompletableFuture<Response> createCompleted = new CompletableFuture<>();
+
+    client.post(instancesStorageUrl(""), instanceToCreateWithSameMatchKey, TENANT_ID,
+      text(createCompleted));
+
+    final Response response = createCompleted.get(5, SECONDS);
+
+    assertThat(response.getStatusCode(), is(400));
+    assertThat(response.getBody(),
+        is("duplicate key value violates unique constraint \"instance_matchkey_idx_unique\": " +
+          "Key (lower(f_unaccent(jsonb ->> 'matchKey'::text)))=(match_key) already exists."));
+
+    log.info("Finished cannotCreateInstanceWithDuplicateMatchKey");
+  }
+
+
+  @Test
   public void canPostSynchronousBatchWithDiscoverySuppressedInstances() throws Exception {
     final JsonArray instancesArray = new JsonArray();
     final UUID smallAngryPlanetId = UUID.randomUUID();


### PR DESCRIPTION
  matchKey can be used for storing a key like the Gold Rush® match key
  that identifies "same" bibliographic records from separate
  library catalogs. It basically implements a compare of metadata
  in the bibliographic records.

  This way, one Inventory Instance can represent multiple underlying
  bibliographic records.

  matchKey could conceivably hold other matching schemes instead if
  desired.