### PR TITLE
MODINVSTOR-589 Add location code to hierarchy api

### DIFF
--- a/ramls/examples/inventory-items-and-holdings.json
+++ b/ramls/examples/inventory-items-and-holdings.json
@@ -20,13 +20,15 @@
           "name": "Annex",
           "campusName": "City Campus",
           "libraryName": "Datalogisk Institut",
-          "institutionName": "Københavns Universitet"
+          "institutionName": "Københavns Universitet",
+          "code": "KU/CC/DI/A"
         },
         "temporaryLocation": {
           "name": "Annex",
           "campusName": "City Campus",
           "libraryName": "Datalogisk Institut",
-          "institutionName": "Københavns Universitet"
+          "institutionName": "Københavns Universitet",
+          "code": "KU/CC/DI/A"
         }
       },
       "callNumber": {
@@ -119,19 +121,22 @@
           "name": "Annex",
           "campusName": "City Campus",
           "libraryName": "Datalogisk Institut",
-          "institutionName": "Københavns Universitet"
+          "institutionName": "Københavns Universitet",
+          "code": "KU/CC/DI/A"
         },
         "permanentLocation": {
           "name": "Annex",
           "campusName": "City Campus",
           "libraryName": "Datalogisk Institut",
-          "institutionName": "Københavns Universitet"
+          "institutionName": "Københavns Universitet",
+          "code": "KU/CC/DI/A"
         },
         "temporaryLocation": {
           "name": "Annex",
           "campusName": "City Campus",
           "libraryName": "Datalogisk Institut",
-          "institutionName": "Københavns Universitet"
+          "institutionName": "Københavns Universitet",
+          "code": "KU/CC/DI/A"
         }
       },
       "callNumber": {

--- a/ramls/inventory-hierarchy/inventory-instance-records.json
+++ b/ramls/inventory-hierarchy/inventory-instance-records.json
@@ -76,13 +76,18 @@
                   "institutionName": {
                     "description": "The name of the institution, the first-level location unit, this (shelf) location belongs to",
                     "type": "string"
+                  },
+                  "code": {
+                    "description": "Code of the (shelf) location, usually an abbreviation of the name",
+                    "type": "string"
                   }
                 },
                 "required": [
                   "name",
                   "campusName",
                   "libraryName",
-                  "institutionName"
+                  "institutionName",
+                  "code"
                 ]
               },
               "temporaryLocation": {
@@ -103,6 +108,10 @@
                   },
                   "institutionName": {
                     "description": "The name of the institution, the first-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  },
+                  "code": {
+                    "description": "Code of the (shelf) location, usually an abbreviation of the name",
                     "type": "string"
                   }
                 }
@@ -419,6 +428,10 @@
                   "institutionName": {
                     "description": "The name of the institution, the first-level location unit, this (shelf) location belongs to",
                     "type": "string"
+                  },
+                  "code": {
+                    "description": "Code of the (shelf) location, usually an abbreviation of the name",
+                    "type": "string"
                   }
                 }
               },
@@ -441,6 +454,10 @@
                   "institutionName": {
                     "description": "The name of the institution, the first-level location unit, this (shelf) location belongs to",
                     "type": "string"
+                  },
+                  "code": {
+                    "description": "Code of the (shelf) location, usually an abbreviation of the name",
+                    "type": "string"
                   }
                 }
               },
@@ -462,6 +479,10 @@
                   },
                   "institutionName": {
                     "description": "The name of the institution, the first-level location unit, this (shelf) location belongs to",
+                    "type": "string"
+                  },
+                  "code": {
+                    "description": "Code of the (shelf) location, usually an abbreviation of the name",
                     "type": "string"
                   }
                 }

--- a/src/main/resources/templates/db_scripts/inventory-hierarchy/createRecordsViewFunction.sql
+++ b/src/main/resources/templates/db_scripts/inventory-hierarchy/createRecordsViewFunction.sql
@@ -229,11 +229,13 @@ WITH
                                                                CASE WHEN hr.id IS NOT NULL THEN
                                                                    json_build_object('permanentLocation',
                                                                                      jsonb_build_object('name', COALESCE(holdPermLoc.locJsonb ->> 'discoveryDisplayName', holdPermLoc.locJsonb ->> 'name'),
+                                                                                                        'code', holdPermLoc.locJsonb ->> 'code',
                                                                                                         'campusName', holdPermLoc.locCampJsonb ->> 'name',
                                                                                                         'libraryName', holdPermLoc.locLibJsonb ->> 'name',
                                                                                                         'institutionName', holdPermLoc.locInstJsonb ->> 'name'),
                                                                                      'temporaryLocation',
                                                                                      jsonb_build_object('name', COALESCE(holdTempLoc.locJsonb ->> 'discoveryDisplayName', holdTempLoc.locJsonb ->> 'name'),
+                                                                                                        'code', holdTempLoc.locJsonb ->> 'code',
                                                                                                         'campusName', holdTempLoc.locCampJsonb ->> 'name',
                                                                                                         'libraryName', holdTempLoc.locLibJsonb ->> 'name',
                                                                                                         'institutionName', holdTempLoc.locInstJsonb ->> 'name'))
@@ -287,16 +289,19 @@ WITH
                                                CASE WHEN item.id IS NOT NULL THEN
                                                    json_build_object('location',
                                                                      jsonb_build_object('name', COALESCE(itemEffLoc.locJsonb ->> 'discoveryDisplayName', itemEffLoc.locJsonb ->> 'name'),
+                                                                                        'code', itemEffLoc.locJsonb ->> 'code',
                                                                                         'campusName', itemEffLoc.locCampJsonb ->> 'name',
                                                                                         'libraryName', itemEffLoc.locLibJsonb ->> 'name',
                                                                                         'institutionName', itemEffLoc.locInstJsonb ->> 'name'),
                                                                      'permanentLocation',
                                                                      jsonb_build_object('name', COALESCE(itemPermLoc.locJsonb ->> 'discoveryDisplayName', itemPermLoc.locJsonb ->> 'name'),
+                                                                                        'code', itemPermLoc.locJsonb ->> 'code',
                                                                                         'campusName', itemPermLoc.locCampJsonb ->> 'name',
                                                                                         'libraryName', itemPermLoc.locLibJsonb ->> 'name',
                                                                                         'institutionName', itemPermLoc.locInstJsonb ->> 'name'),
                                                                      'temporaryLocation',
                                                                      jsonb_build_object('name', COALESCE(itemTempLoc.locJsonb ->> 'discoveryDisplayName', itemTempLoc.locJsonb ->> 'name'),
+                                                                                        'code', itemTempLoc.locJsonb ->> 'code',
                                                                                         'campusName', itemTempLoc.locCampJsonb ->> 'name',
                                                                                         'libraryName', itemTempLoc.locLibJsonb ->> 'name',
                                                                                         'institutionName', itemTempLoc.locInstJsonb ->> 'name'))

--- a/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
+++ b/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
@@ -14,6 +14,8 @@ import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers
 import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.hasEffectiveLocationInstitutionNameForItems;
 import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.hasIdForHoldings;
 import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.hasIdForInstance;
+import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.hasPermanentLocationCodeForHoldings;
+import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.hasLocationCodeForItems;
 import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.hasPermanentLocationForHoldings;
 import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.hasSourceForInstance;
 import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.isDeleted;
@@ -142,6 +144,7 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
       allOf(
         hasIdForHoldings(predefinedHoldings.getString("id")),
         hasPermanentLocationForHoldings("d:Main Library"),
+        hasPermanentLocationCodeForHoldings("TestBaseWI/M"),
         hasAggregatedNumberOfHoldings(1)
       )
     );
@@ -160,6 +163,7 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
       allOf(
         hasCallNumberForItems("item effective call number 1", "item effective call number 2"),
         hasEffectiveLocationInstitutionNameForItems("Primary Institution"),
+        hasLocationCodeForItems("TestBaseWI/M", "TestBaseWI/TF"),
         hasAggregatedNumberOfItems(2)
       )
     );

--- a/src/test/java/org/folio/rest/support/matchers/InventoryHierarchyResponseMatchers.java
+++ b/src/test/java/org/folio/rest/support/matchers/InventoryHierarchyResponseMatchers.java
@@ -143,6 +143,14 @@ public final class InventoryHierarchyResponseMatchers {
     return hasHoldingsElement(JsonPointer.from("/location/permanentLocation/name"), ArrayUtils.toArray(permanentLocation));
   }
 
+  public static Matcher<JsonObject> hasPermanentLocationCodeForHoldings(String location) {
+    return hasHoldingsElement(JsonPointer.from("/location/permanentLocation/code"), ArrayUtils.toArray(location));
+  }
+
+  public static Matcher<JsonObject> hasLocationCodeForItems(String...code) {
+    return hasItemsElement(JsonPointer.from("/location/location/code"), ArrayUtils.toArray(code));
+  }
+
   public static Matcher<JsonObject> hasAggregatedNumberOfHoldings(int size) {
     return hasHoldingsCount(size);
   }


### PR DESCRIPTION
Purpose:
https://issues.folio.org/browse/MODINVSTOR-589
Approach:
For data-export module, we want to use https://s3.amazonaws.com/foliodocs/api/mod-inventory-storage/inventory-hierarchy.html API. We need location code to be present in the response, modified https://github.com/folio-org/mod-inventory-storage/blob/master/src/main/resources/templates/db_scripts/inventory-hierarchy/createRecordsViewFunction.sql to return location code. Updated schemas and unit test.