### PR TITLE
MODINVSTOR-591 - Release 19.3.4

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 19.3.4 2020-10-14
+
+* Upgrade to RMB 30.2.8 (MODINVSTOR-591)
+  * doStreamGetQuery returns only 100 records when limit>100 (RMB-732)
+
 ## 19.3.3 2020-09-02
 
 * Upgrade to RMB 30.2.7 (MODINVSTOR-567)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>19.3.4-SNAPSHOT</version>
+  <version>19.3.4</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -115,7 +115,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v19.3.4</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>19.3.4</version>
+  <version>19.3.5-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -115,7 +115,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>v19.3.4</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <build>


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-591.

Includes upgrade to RMB 30.2.8 / Vert.x 3.9.3 which resolves [RMB-732](https://issues.folio.org/browse/RMB-732)