### PR TITLE
MODINVSTOR-596: Add unique key constraint for statistical_code.name.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,6 +42,12 @@
       <version>${raml-module-builder-version}</version>
     </dependency>
     <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>1.18.12</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
       <groupId>org.folio</groupId>
       <artifactId>testing</artifactId>
       <version>${raml-module-builder-version}</version>

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -280,6 +280,10 @@
         {
           "fieldName": "code, statisticalCodeTypeId",
           "tOps": "ADD"
+        },
+        {
+          "fieldName": "name",
+          "tOps": "ADD"
         }
       ],
       "foreignKeys": [

--- a/src/test/java/org/folio/rest/api/StatisticalCodeTest.java
+++ b/src/test/java/org/folio/rest/api/StatisticalCodeTest.java
@@ -1,0 +1,52 @@
+package org.folio.rest.api;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+
+import org.folio.rest.support.builders.StatisticalCodeBuilder;
+import org.junit.Before;
+import org.junit.Test;
+
+public class StatisticalCodeTest extends TestBaseWithInventoryUtil {
+  @Before
+  public void removeTestStatisticalCodes() {
+    statisticalCodeFixture.removeTestStatisticalCodes();
+  }
+
+  @Test
+  public void cannotCreateStatisticalCodeWhenNameIsTheSameButInUpperCase() {
+    final var firstStatisticalCode = new StatisticalCodeBuilder()
+      .withCode("stcone")
+      .withName("Statistical code");
+
+    final var secondStatisticalCode = new StatisticalCodeBuilder()
+      .withCode("stctwo")
+      .withName("STATISTICAL CODE");
+
+    statisticalCodeFixture.createSerialManagementCode(firstStatisticalCode);
+    final var response = statisticalCodeFixture
+      .attemptCreateSerialManagementCode(secondStatisticalCode);
+
+    assertThat(response.getStatusCode(), is(400));
+    assertThat(response.getBody(), containsString(
+      "duplicate key value violates unique constraint \"statistical_code_name_idx_unique\""));
+  }
+
+  @Test
+  public void canCreateStatisticalCodeWhenNamesAreDifferent() {
+    final var firstStatisticalCode = new StatisticalCodeBuilder()
+      .withCode("stcone")
+      .withName("Statistical code 1");
+
+    final var secondStatisticalCode = new StatisticalCodeBuilder()
+      .withCode("stctwo")
+      .withName("STATISTICAL CODE 2");
+
+    final var firstCreated = statisticalCodeFixture.createSerialManagementCode(firstStatisticalCode);
+    final var secondCreated = statisticalCodeFixture.createSerialManagementCode(secondStatisticalCode);
+
+    assertThat(firstCreated.getJson().getString("name"), is("Statistical code 1"));
+    assertThat(secondCreated.getJson().getString("name"), is("STATISTICAL CODE 2"));
+  }
+}

--- a/src/test/java/org/folio/rest/api/TestBase.java
+++ b/src/test/java/org/folio/rest/api/TestBase.java
@@ -14,6 +14,7 @@ import java.util.concurrent.TimeoutException;
 import org.folio.rest.support.HttpClient;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
+import org.folio.rest.support.fixtures.StatisticalCodeFixture;
 import org.folio.rest.support.http.ResourceClient;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -45,6 +46,7 @@ public abstract class TestBase {
   static ResourceClient instancesStorageBatchInstancesClient;
   static ResourceClient instanceTypesClient;
   static ResourceClient illPoliciesClient;
+  static StatisticalCodeFixture statisticalCodeFixture;
 
   /**
    * Returns future.get({@link #TIMEOUT}, {@link TimeUnit#SECONDS}).
@@ -86,6 +88,7 @@ public abstract class TestBase {
     instanceTypesClient = ResourceClient
       .forInstanceTypes(client);
     illPoliciesClient = ResourceClient.forIllPolicies(client);
+    statisticalCodeFixture = new StatisticalCodeFixture(client);
   }
 
   @AfterClass

--- a/src/test/java/org/folio/rest/support/builders/StatisticalCodeBuilder.java
+++ b/src/test/java/org/folio/rest/support/builders/StatisticalCodeBuilder.java
@@ -1,0 +1,34 @@
+package org.folio.rest.support.builders;
+
+import java.util.UUID;
+
+import io.vertx.core.json.JsonObject;
+import lombok.AllArgsConstructor;
+import lombok.ToString;
+import lombok.With;
+
+@With
+@AllArgsConstructor
+@ToString
+public final class StatisticalCodeBuilder extends JsonRequestBuilder implements Builder {
+  private final String code;
+  private final String name;
+  private final UUID statisticalCodeTypeId;
+  private final String source;
+
+  public StatisticalCodeBuilder() {
+    this(null, null, null, "test");
+  }
+
+  @Override
+  public JsonObject create() {
+    final var json = new JsonObject();
+
+    put(json, "code", code);
+    put(json, "name", name);
+    put(json, "statisticalCodeTypeId", statisticalCodeTypeId);
+    put(json, "source", source);
+
+    return json;
+  }
+}

--- a/src/test/java/org/folio/rest/support/fixtures/StatisticalCodeFixture.java
+++ b/src/test/java/org/folio/rest/support/fixtures/StatisticalCodeFixture.java
@@ -1,0 +1,48 @@
+package org.folio.rest.support.fixtures;
+
+import static org.folio.rest.support.http.ResourceClient.forStatisticalCodeTypes;
+import static org.folio.rest.support.http.ResourceClient.forStatisticalCodes;
+
+import java.util.UUID;
+
+import org.folio.rest.support.HttpClient;
+import org.folio.rest.support.IndividualResource;
+import org.folio.rest.support.Response;
+import org.folio.rest.support.builders.StatisticalCodeBuilder;
+import org.folio.rest.support.http.ResourceClient;
+
+public final class StatisticalCodeFixture {
+  private final ResourceClient codeTypesClient;
+  private final ResourceClient codesClient;
+
+  public StatisticalCodeFixture(HttpClient httpClient) {
+    codeTypesClient = forStatisticalCodeTypes(httpClient);
+    codesClient = forStatisticalCodes(httpClient);
+  }
+
+  public IndividualResource createSerialManagementCode(StatisticalCodeBuilder builder) {
+    return codesClient.create(builder
+      .withStatisticalCodeTypeId(getSerialManagementStatisticalCodeType()));
+  }
+
+  public Response attemptCreateSerialManagementCode(StatisticalCodeBuilder builder) {
+    final var json = builder
+      .withStatisticalCodeTypeId(getSerialManagementStatisticalCodeType())
+      .create();
+
+    return codesClient.attemptToCreate(json);
+  }
+
+  public void removeTestStatisticalCodes() {
+    codesClient.getMany("source==\"test\"").stream()
+      .map(IndividualResource::getId)
+      .forEach(codesClient::delete);
+  }
+
+  private UUID getSerialManagementStatisticalCodeType() {
+    return codeTypesClient.getMany("name==\"%s\"", "SERM (Serial management)")
+      .stream().findFirst()
+      .map(IndividualResource::getId)
+      .orElse(null);
+  }
+}

--- a/src/test/java/org/folio/rest/support/http/ResourceClient.java
+++ b/src/test/java/org/folio/rest/support/http/ResourceClient.java
@@ -120,6 +120,16 @@ public class ResourceClient {
       "Ill Policies", "illPolicies");
   }
 
+  public static ResourceClient forStatisticalCodeTypes(HttpClient client) {
+    return new ResourceClient(client, InterfaceUrls::statisticalCodeTypesUrl,
+      "Statistical code types", "statisticalCodeTypes");
+  }
+
+  public static ResourceClient forStatisticalCodes(HttpClient client) {
+    return new ResourceClient(client, InterfaceUrls::statisticalCodesUrl,
+      "Statistical codes", "statisticalCodes");
+  }
+
   private ResourceClient(
     HttpClient client,
     UrlMaker urlMaker, String resourceName,


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-596 - Settings > Inventory > Statistical codes. Statistical code name is being case sensitive.

### Changes:

* Add UK for statistical_code.name.
* Add lombok dependency.
* Add StatisticalCodeBuilder/Fixture classes.