### PR TITLE
MODINVSTOR-602: Upgrade to RMB 31.2.0-SNAPSHOT and Vert.x 3.8.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,11 +91,11 @@
   </dependencies>
 
   <properties>
-    <vertx.version>3.9.3</vertx.version>
+    <vertx.version>3.9.4</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>31.1.2</raml-module-builder-version>
+    <raml-module-builder-version>31.2.0-SNAPSHOT</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances,/inventory-hierarchy/updated-instance-ids,/inventory-hierarchy/items-and-holdings</generate_routing_context>
     <argLine />
   </properties>


### PR DESCRIPTION
RMB master=31.2.0-SNAPSHOT contains a fix for the
"prepared statement "XYZ" already exists" issue ([MODINVSTOR-540](https://issues.folio.org/browse/MODINVSTOR-602)).

Merging this to mod-inventory-storage master deploys it to
the FOLIO reference environments for review.