### PR TITLE
MODINVSTOR-605: Upgrade to RMB v30.2.9 and Vert.x 3.9.4, and release 19.3.5

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,13 @@
+## 19.3.5 2020-10-22
+
+* Upgrade to RMB 30.2.9 (MODINVSTOR-605)
+ * Use FOLIO fork of vertx-sql-client and vertx-pg-client with
+   the following two patches (RMB-740)
+ * Make RMB's DB\_CONNECTIONRELEASEDELAY work again, defaults to 60 seconds (RMB-739)
+ * Fix duplicate names causing 'prepared statement "XYZ" already exists' (FOLIO-2840)
+ * Upgrade to Vert.x 3.9.4, most notable fix: RowStream fetch can close prematurely
+   the stream https://github.com/eclipse-vertx/vertx-sql-client/issues/778 (RMB-738)
+
 ## 19.3.4 2020-10-14
 
 * Upgrade to RMB 30.2.8 (MODINVSTOR-591)

--- a/pom.xml
+++ b/pom.xml
@@ -85,11 +85,11 @@
   </dependencies>
 
   <properties>
-    <vertx.version>3.9.3</vertx.version>
+    <vertx.version>3.9.4</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>30.2.8</raml-module-builder-version>
+    <raml-module-builder-version>30.2.9</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances</generate_routing_context>
     <argLine />
   </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>19.3.5</version>
+  <version>19.3.6-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -115,7 +115,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>v19.3.5</tag>
+    <tag>HEAD</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>19.3.5-SNAPSHOT</version>
+  <version>19.3.5</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -115,7 +115,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>HEAD</tag>
+    <tag>v19.3.5</tag>
   </scm>
 
   <build>


### PR DESCRIPTION
This has been tested on master, see https://issues.folio.org/browse/MODINVSTOR-602

RMB 30.2.9 contains this:
 * [RMB-740](https://issues.folio.org/browse/RMB-740) Use FOLIO fork of vertx-sql-client and vertx-pg-client with
   the following two patches
 * [RMB-739](https://issues.folio.org/browse/RMB-739) Make RMB's DB\_CONNECTIONRELEASEDELAY work again, defaults to 60 seconds
 * [FOLIO-2840](https://issues.folio.org/browse/FOLIO-2840) Fix duplicate names causing 'prepared statement "XYZ" already exists'
 * [RMB-738](https://issues.folio.org/browse/RMB-738) Upgrade to Vert.x 3.9.4, most notable fixed bug: RowStream fetch can close prematurely the stream https://github.com/eclipse-vertx/vertx-sql-client/issues/778