### PR TITLE
MODINVSTOR-608: "tuple concurrently updated" when "REVOKE ALL PRIVILE…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>31.1.3</raml-module-builder-version>
+    <raml-module-builder-version>31.2.0-SNAPSHOT</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/instance-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances,/inventory-hierarchy/updated-instance-ids,/inventory-hierarchy/items-and-holdings</generate_routing_context>
     <argLine />
   </properties>


### PR DESCRIPTION
Upgrade to RMB 31.2.0-SNAPSHOT that contains a potential fix: https://github.com/folio-org/raml-module-builder/pull/798

We cannot reproduce the bug locally, therefore we need to have the RMB
-SNAPSHOT version on master to let Jenkins build a docker container with
the mod-inventory-storage -SNAPSHOT version with the fix
so that TAMU can try it out.