### PR TITLE
MODINVSTOR-508 Item status date missing when set default value Available

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 19.5.0 (in-progress)
+
+* Newly created item records will have the creation date as the status update date (MODINVSTOR-508)
+
 ## 19.4.0 2020-10-08
 
 * Introduces public and staff only holdings statements notes (MODINVSTOR-543)

--- a/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
@@ -42,6 +42,8 @@ public class ItemBatchSyncAPI implements ItemStorageBatchSynchronous {
 
     for (Item item : items) {
       futures.add(setHrid(item, hridManager));
+      item.getStatus().setDate(item.getMetadata().getCreatedDate());
+
     }
 
     CompositeFuture.all(futures)

--- a/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
@@ -42,7 +42,6 @@ public class ItemBatchSyncAPI implements ItemStorageBatchSynchronous {
 
     for (Item item : items) {
       futures.add(setHrid(item, hridManager));
-      item.getStatus().setDate(item.getMetadata().getCreatedDate());
 
     }
 

--- a/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
@@ -56,14 +56,9 @@ public class ItemStorageAPI implements ItemStorage {
       RoutingContext routingContext, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
-    //if the initial status is "Available", set the last updated date of that 
-    //status to be the creation date of the item
+  
+    entity.getStatus().setDate(entity.getMetadata().getCreatedDate());
     
-    if (entity.getStatus().getName().toString().equals("Available")) {
-      entity.getStatus().setDate(entity.getMetadata().getCreatedDate());
-    }
-    
-
     final Future<String> hridFuture;
     if (isBlank(entity.getHrid())) {
       final HridManager hridManager = new HridManager(vertxContext,

--- a/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
@@ -56,6 +56,13 @@ public class ItemStorageAPI implements ItemStorage {
       RoutingContext routingContext, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
+    //if the initial status is "Available", set the last updated date of that 
+    //status to be the creation date of the item
+    
+    if (entity.getStatus().getName().toString().equals("Available")) {
+      entity.getStatus().setDate(entity.getMetadata().getCreatedDate());
+    }
+    
 
     final Future<String> hridFuture;
     if (isBlank(entity.getHrid())) {

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -1265,7 +1265,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void cannotSetStatusDate() throws Exception {
+  public void cannotChangeStatusDate() throws Exception {
     UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
     UUID id = UUID.randomUUID();
     JsonObject itemToCreate = smallAngryPlanet(id, holdingsRecordId);
@@ -1335,7 +1335,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject createdItem = getById(id).getJson();
 
-    String createdDate = createdItem.getJsonObject("metadata").getString("createdDate");
+    final String createdDate = createdItem.getJsonObject("metadata").getString("createdDate");
 
     assertThat(createdItem.getJsonObject("status").getString("name"), is("Available"));
     assertThat(createdItem.getJsonObject("status").getString("date"), is(createdDate));
@@ -1346,8 +1346,6 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     itemsClient.replace(id, firstUpdateItem);
 
     JsonObject firstUpdatedItemResponse = itemsClient.getById(id).getJson();
-
-    createdDate = firstUpdatedItemResponse.getJsonObject("metadata").getString("createdDate");
 
     assertThat(firstUpdatedItemResponse.getString("itemLevelCallNumber"),
       is("newItCn"));
@@ -1362,9 +1360,6 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     itemsClient.replace(id, secondUpdateItem);
 
     JsonObject secondUpdatedItemResponse = itemsClient.getById(id).getJson();
-
-    createdDate = secondUpdatedItemResponse.getJsonObject("metadata").getString("createdDate");
-
 
     assertThat(secondUpdatedItemResponse.getString("temporaryLocationId"),
       is(onlineLocationId.toString()));

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -1274,8 +1274,11 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject createdItem = getById(id).getJson();
     JsonObject initialStatus = createdItem.getJsonObject("status");
 
+    String createdDate = createdItem.getJsonObject("metadata").getString("createdDate");
+
+
     assertThat(initialStatus.getString("name"), is("Available"));
-    assertThat(initialStatus.getString("date"), nullValue());
+    assertThat(initialStatus.getString("date"), is(createdDate));
 
     itemsClient.replace(id,
       createdItem.copy()
@@ -1286,7 +1289,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject updatedStatus = updatedItemResponse.getJson().getJsonObject("status");
 
     assertThat(updatedStatus.getString("name"), is("Available"));
-    assertThat(updatedStatus.getString("date"), nullValue());
+    assertThat(updatedStatus.getString("date"), is(createdDate));
   }
 
   @Test
@@ -1323,7 +1326,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void statusUpdatedDateIsNullOnSubsequentUpdates() throws Exception {
+  public void statusUpdatedDateIsUnchangedOnSubsequentUpdates() throws Exception {
     UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
     UUID id = UUID.randomUUID();
     JsonObject itemToCreate = smallAngryPlanet(id, holdingsRecordId)
@@ -1331,8 +1334,11 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     createItem(itemToCreate);
 
     JsonObject createdItem = getById(id).getJson();
+
+    String createdDate = createdItem.getJsonObject("metadata").getString("createdDate");
+
     assertThat(createdItem.getJsonObject("status").getString("name"), is("Available"));
-    assertThat(createdItem.getJsonObject("status").getString("date"), nullValue());
+    assertThat(createdItem.getJsonObject("status").getString("date"), is(createdDate));
 
     JsonObject firstUpdateItem = createdItem.copy()
       .put("itemLevelCallNumber", "newItCn");
@@ -1341,12 +1347,14 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject firstUpdatedItemResponse = itemsClient.getById(id).getJson();
 
+    createdDate = firstUpdatedItemResponse.getJsonObject("metadata").getString("createdDate");
+
     assertThat(firstUpdatedItemResponse.getString("itemLevelCallNumber"),
       is("newItCn"));
     assertThat(firstUpdatedItemResponse.getJsonObject("status").getString("name"),
       is("Available"));
     assertThat(firstUpdatedItemResponse.getJsonObject("status").getString("date"),
-      nullValue());
+      is(createdDate));
 
     JsonObject secondUpdateItem = firstUpdatedItemResponse.copy()
       .put("temporaryLocationId", onlineLocationId.toString());
@@ -1355,12 +1363,15 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject secondUpdatedItemResponse = itemsClient.getById(id).getJson();
 
+    createdDate = secondUpdatedItemResponse.getJsonObject("metadata").getString("createdDate");
+
+
     assertThat(secondUpdatedItemResponse.getString("temporaryLocationId"),
       is(onlineLocationId.toString()));
     assertThat(secondUpdatedItemResponse.getJsonObject("status").getString("name"),
       is("Available"));
     assertThat(secondUpdatedItemResponse.getJsonObject("status").getString("date"),
-      nullValue());
+      is(createdDate));
   }
 
   @Test


### PR DESCRIPTION
Addressed this by making the item post method check for available status,
and fill it in with the item creation date from the item metadata.The status
check may not be strictly necessary, from what I can see, new item records
are automatically given a status of Available, and you can't change that.
I'm assuming that the method I'm altering is only used for creating new item
records-it looks like the "put" method is used for updating item data.
I also had to modify several tests that expected the initial status of a
created item to be null.

refs: https://issues.folio.org/browse/MODINVSTOR-508