### PR TITLE
MODINVSTOR-508: Item status date is missing on creation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 19.5.0 (in-progress)
 
-* Newly created item records will have the creation date as the status update date (MODINVSTOR-508)
+* Newly created item records will have a last modified date set for status (MODINVSTOR-508)
 
 ## 19.4.0 2020-10-08
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 19.5.0 (in-progress)
 
-* Newly created item records will have a last modified date set for status (MODINVSTOR-508)
+* Item status date is set for newly created item records (MODINVSTOR-508)
 
 ## 19.4.0 2020-10-08
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 19.5.0 (in-progress)
+
+* Newly created item records will have the creation date as the status update date (MODINVSTOR-508)
+
 ## 19.4.0 2020-10-08
 
 * Introduces public and staff only holdings statements notes (MODINVSTOR-543)

--- a/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
@@ -42,10 +42,10 @@ public class ItemBatchSyncAPI implements ItemStorageBatchSynchronous {
     final HridManager hridManager = new HridManager(Vertx.currentContext(), postgresClient);
     
     // add a last modified date to status on all created items
-    Date date = new java.util.Date();
+    Date itemStatusDate = new java.util.Date();
 
     for (Item item : items) {
-      item.getStatus().setDate(date);
+      item.getStatus().setDate(itemStatusDate);
       futures.add(setHrid(item, hridManager));
     }
 

--- a/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
@@ -40,9 +40,8 @@ public class ItemBatchSyncAPI implements ItemStorageBatchSynchronous {
     @SuppressWarnings("rawtypes")
     final List<Future> futures = new ArrayList<>();
     final HridManager hridManager = new HridManager(Vertx.currentContext(), postgresClient);
-    // we'll need to add status update dates to each item before it's created.
-    // unfortunately, setting this from the item created date does not seem to work as it does
-    // elsewhere (see itemstorageAPI) so we are using the current date/time.
+    
+    // add a last modified date to status on all created items
     Date date = new java.util.Date();
 
     for (Item item : items) {

--- a/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
@@ -42,6 +42,8 @@ public class ItemBatchSyncAPI implements ItemStorageBatchSynchronous {
 
     for (Item item : items) {
       futures.add(setHrid(item, hridManager));
+      item.getStatus().setDate(item.getMetadata().getCreatedDate());
+
     }
 
     CompositeFuture.all(futures)

--- a/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
@@ -5,6 +5,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Date;
 
 import javax.ws.rs.core.Response;
 
@@ -39,10 +40,14 @@ public class ItemBatchSyncAPI implements ItemStorageBatchSynchronous {
     @SuppressWarnings("rawtypes")
     final List<Future> futures = new ArrayList<>();
     final HridManager hridManager = new HridManager(Vertx.currentContext(), postgresClient);
+    // we'll need to add status update dates to each item before it's created.
+    // unfortunately, setting this from the item created date does not seem to work as it does
+    // elsewhere (see itemstorageAPI) so we are using the current date/time.
+    Date date = new java.util.Date();
 
     for (Item item : items) {
+      item.getStatus().setDate(date);
       futures.add(setHrid(item, hridManager));
-
     }
 
     CompositeFuture.all(futures)

--- a/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
@@ -42,7 +42,6 @@ public class ItemBatchSyncAPI implements ItemStorageBatchSynchronous {
 
     for (Item item : items) {
       futures.add(setHrid(item, hridManager));
-      item.getStatus().setDate(item.getMetadata().getCreatedDate());
 
     }
 

--- a/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
@@ -28,6 +28,7 @@ import io.vertx.core.Handler;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
+import java.util.Date;
 
 /**
  * CRUD for Item.
@@ -56,8 +57,9 @@ public class ItemStorageAPI implements ItemStorage {
       RoutingContext routingContext, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
-  
-    entity.getStatus().setDate(entity.getMetadata().getCreatedDate());
+
+    Date date = new java.util.Date();
+    entity.getStatus().setDate(date);
     
     final Future<String> hridFuture;
     if (isBlank(entity.getHrid())) {

--- a/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
@@ -58,8 +58,7 @@ public class ItemStorageAPI implements ItemStorage {
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
 
-    Date date = new java.util.Date();
-    entity.getStatus().setDate(date);
+    entity.getStatus().setDate(new java.util.Date());
     
     final Future<String> hridFuture;
     if (isBlank(entity.getHrid())) {

--- a/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
@@ -56,14 +56,9 @@ public class ItemStorageAPI implements ItemStorage {
       RoutingContext routingContext, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
-    //if the initial status is "Available", set the last updated date of that 
-    //status to be the creation date of the item
+  
+    entity.getStatus().setDate(entity.getMetadata().getCreatedDate());
     
-    if (entity.getStatus().getName().toString().equals("Available")) {
-      entity.getStatus().setDate(entity.getMetadata().getCreatedDate());
-    }
-    
-
     final Future<String> hridFuture;
     if (isBlank(entity.getHrid())) {
       final HridManager hridManager = new HridManager(vertxContext,

--- a/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
@@ -56,6 +56,13 @@ public class ItemStorageAPI implements ItemStorage {
       RoutingContext routingContext, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
+    //if the initial status is "Available", set the last updated date of that 
+    //status to be the creation date of the item
+    
+    if (entity.getStatus().getName().toString().equals("Available")) {
+      entity.getStatus().setDate(entity.getMetadata().getCreatedDate());
+    }
+    
 
     final Future<String> hridFuture;
     if (isBlank(entity.getHrid())) {

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -1334,7 +1334,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject createdItem = getById(id).getJson();
 
-    final String createdDate = createdItem.getJsonObject("metadata").getString("createdDate");
+    final String createdDate = createdItem.getJsonObject("status").getString("date");
 
     assertThat(createdItem.getJsonObject("status").getString("name"), is("Available"));
     assertThat(createdItem.getJsonObject("status").getString("date"), is(createdDate));

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -43,6 +43,7 @@ import static org.joda.time.Seconds.seconds;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.isNotNull;
 
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
@@ -1276,7 +1277,6 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     String createdDate = createdItem.getJsonObject("metadata").getString("createdDate");
 
-
     assertThat(initialStatus.getString("name"), is("Available"));
     assertThat(initialStatus.getString("date"), is(createdDate));
 
@@ -1938,6 +1938,20 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     for (int i = 0; i < itemArray.size(); i++) {
       assertGetNotFound(itemsStorageUrl("/" + itemArray.getJsonObject(i).getString("id")));
+    }
+  }
+
+  @Test
+  public void synchronousBatchItemsShouldHaveStatusDateOnCreation() {
+    final JsonArray itemArray = threeItems();
+
+    assertThat(postSynchronousBatch(itemArray), statusCodeIs(HttpStatus.HTTP_CREATED));
+
+    JsonObject item;
+    for (int i = 0; i < itemArray.size(); i++) {
+      item = getById(itemArray.getJsonObject(i).getString("id")).getJson();
+      assertThat(item.getJsonObject("status").getString("date"), notNullValue());
+
     }
   }
 

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -1265,7 +1265,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void cannotSetStatusDate() throws Exception {
+  public void cannotChangeStatusDate() throws Exception {
     UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
     UUID id = UUID.randomUUID();
     JsonObject itemToCreate = smallAngryPlanet(id, holdingsRecordId);
@@ -1335,7 +1335,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject createdItem = getById(id).getJson();
 
-    String createdDate = createdItem.getJsonObject("metadata").getString("createdDate");
+    final String createdDate = createdItem.getJsonObject("metadata").getString("createdDate");
 
     assertThat(createdItem.getJsonObject("status").getString("name"), is("Available"));
     assertThat(createdItem.getJsonObject("status").getString("date"), is(createdDate));
@@ -1346,8 +1346,6 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     itemsClient.replace(id, firstUpdateItem);
 
     JsonObject firstUpdatedItemResponse = itemsClient.getById(id).getJson();
-
-    createdDate = firstUpdatedItemResponse.getJsonObject("metadata").getString("createdDate");
 
     assertThat(firstUpdatedItemResponse.getString("itemLevelCallNumber"),
       is("newItCn"));
@@ -1362,9 +1360,6 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     itemsClient.replace(id, secondUpdateItem);
 
     JsonObject secondUpdatedItemResponse = itemsClient.getById(id).getJson();
-
-    createdDate = secondUpdatedItemResponse.getJsonObject("metadata").getString("createdDate");
-
 
     assertThat(secondUpdatedItemResponse.getString("temporaryLocationId"),
       is(onlineLocationId.toString()));

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -1947,11 +1947,10 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(postSynchronousBatch(itemArray), statusCodeIs(HttpStatus.HTTP_CREATED));
 
-    JsonObject item;
+    JsonObject item = null;
     for (int i = 0; i < itemArray.size(); i++) {
       item = getById(itemArray.getJsonObject(i).getString("id")).getJson();
       assertThat(item.getJsonObject("status").getString("date"), notNullValue());
-
     }
   }
 

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -43,7 +43,6 @@ import static org.joda.time.Seconds.seconds;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.ArgumentMatchers.isNotNull;
 
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -66,6 +66,7 @@ import org.folio.rest.jaxrs.model.LastCheckIn;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.AdditionalHttpStatusCodes;
 import org.folio.rest.support.IndividualResource;
+import org.folio.rest.support.JsonArrayHelper;
 import org.folio.rest.support.JsonErrorResponse;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -1946,11 +1946,11 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(postSynchronousBatch(itemArray), statusCodeIs(HttpStatus.HTTP_CREATED));
 
-    JsonObject item = null;
-    for (int i = 0; i < itemArray.size(); i++) {
-      item = getById(itemArray.getJsonObject(i).getString("id")).getJson();
-      assertThat(item.getJsonObject("status").getString("date"), notNullValue());
-    }
+    JsonArrayHelper.toList(itemArray).forEach(itemInArray -> {
+      final var fetchedItem = getById(itemInArray.getString("id")).getJson();
+
+      assertThat(fetchedItem.getJsonObject("status").getString("date"), notNullValue());
+    });
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -1274,8 +1274,11 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject createdItem = getById(id).getJson();
     JsonObject initialStatus = createdItem.getJsonObject("status");
 
+    String createdDate = createdItem.getJsonObject("metadata").getString("createdDate");
+
+
     assertThat(initialStatus.getString("name"), is("Available"));
-    assertThat(initialStatus.getString("date"), nullValue());
+    assertThat(initialStatus.getString("date"), is(createdDate));
 
     itemsClient.replace(id,
       createdItem.copy()
@@ -1286,7 +1289,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject updatedStatus = updatedItemResponse.getJson().getJsonObject("status");
 
     assertThat(updatedStatus.getString("name"), is("Available"));
-    assertThat(updatedStatus.getString("date"), nullValue());
+    assertThat(updatedStatus.getString("date"), is(createdDate));
   }
 
   @Test
@@ -1323,7 +1326,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void statusUpdatedDateIsNullOnSubsequentUpdates() throws Exception {
+  public void statusUpdatedDateIsUnchangedOnSubsequentUpdates() throws Exception {
     UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
     UUID id = UUID.randomUUID();
     JsonObject itemToCreate = smallAngryPlanet(id, holdingsRecordId)
@@ -1331,8 +1334,11 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     createItem(itemToCreate);
 
     JsonObject createdItem = getById(id).getJson();
+
+    String createdDate = createdItem.getJsonObject("metadata").getString("createdDate");
+
     assertThat(createdItem.getJsonObject("status").getString("name"), is("Available"));
-    assertThat(createdItem.getJsonObject("status").getString("date"), nullValue());
+    assertThat(createdItem.getJsonObject("status").getString("date"), is(createdDate));
 
     JsonObject firstUpdateItem = createdItem.copy()
       .put("itemLevelCallNumber", "newItCn");
@@ -1341,12 +1347,14 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject firstUpdatedItemResponse = itemsClient.getById(id).getJson();
 
+    createdDate = firstUpdatedItemResponse.getJsonObject("metadata").getString("createdDate");
+
     assertThat(firstUpdatedItemResponse.getString("itemLevelCallNumber"),
       is("newItCn"));
     assertThat(firstUpdatedItemResponse.getJsonObject("status").getString("name"),
       is("Available"));
     assertThat(firstUpdatedItemResponse.getJsonObject("status").getString("date"),
-      nullValue());
+      is(createdDate));
 
     JsonObject secondUpdateItem = firstUpdatedItemResponse.copy()
       .put("temporaryLocationId", onlineLocationId.toString());
@@ -1355,12 +1363,15 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject secondUpdatedItemResponse = itemsClient.getById(id).getJson();
 
+    createdDate = secondUpdatedItemResponse.getJsonObject("metadata").getString("createdDate");
+
+
     assertThat(secondUpdatedItemResponse.getString("temporaryLocationId"),
       is(onlineLocationId.toString()));
     assertThat(secondUpdatedItemResponse.getJsonObject("status").getString("name"),
       is("Available"));
     assertThat(secondUpdatedItemResponse.getJsonObject("status").getString("date"),
-      nullValue());
+      is(createdDate));
   }
 
   @Test


### PR DESCRIPTION
For individual items, I initially addressed this by setting the 
status date from the item creation date.  However, this does not work with
batch-created items, for reasons I still have not been able to puzzle out.
Setting batch-created item records to use the item creation date causes all
batch-item creation operations to fail with a status of "Bad request" (400).

So, I changed both creation methods to use the current local date/time as the 
initial status updated date.  I thought it was better to have them both behave 
consistently.  This means the status update date will not exactly match the item 
creation date, but the notes on the bug report indicate this is expected behavior.

I adjusted all tests that expected the status modification date to be null 
and also added a test that checks to make sure batch created items have 
a last-updated date for their statuses.

refs: https://issues.folio.org/browse/MODINVSTOR-508