### PR TITLE
MODINVSTOR-509: Instance. New Instance. Instance status date is missing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 19.5.0 (in-progress)
+
+* Status date set on newly created instance records (MODINVSTOR-509)
+
 ## 19.4.0 2020-10-08
 
 * Introduces public and staff only holdings statements notes (MODINVSTOR-543)

--- a/src/main/java/org/folio/rest/impl/InstanceBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceBatchSyncAPI.java
@@ -22,6 +22,8 @@ import javax.ws.rs.core.Response;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 
 public class InstanceBatchSyncAPI implements InstanceStorageBatchSynchronous {
   @Validate
@@ -36,8 +38,12 @@ public class InstanceBatchSyncAPI implements InstanceStorageBatchSynchronous {
     final List<Future> futures = new ArrayList<>();
     final HridManager hridManager = new HridManager(Vertx.currentContext(), postgresClient);
 
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    final String currentDate = sdf.format(new Date());
+
     for (Instance instance : instances) {
       futures.add(setHrid(instance, hridManager));
+      instance.setStatusUpdatedDate(currentDate);
     }
 
     CompositeFuture.all(futures).setHandler(ar -> {

--- a/src/main/java/org/folio/rest/impl/InstanceBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceBatchSyncAPI.java
@@ -1,6 +1,7 @@
 package org.folio.rest.impl;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.folio.rest.support.StatusUpdatedDateGenerator.generateStatusUpdatedDate;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
@@ -38,12 +39,10 @@ public class InstanceBatchSyncAPI implements InstanceStorageBatchSynchronous {
     final List<Future> futures = new ArrayList<>();
     final HridManager hridManager = new HridManager(Vertx.currentContext(), postgresClient);
 
-    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-    final String currentDate = sdf.format(new Date());
-
+    final String statusUpdatedDate = generateStatusUpdatedDate();
     for (Instance instance : instances) {
       futures.add(setHrid(instance, hridManager));
-      instance.setStatusUpdatedDate(currentDate);
+      instance.setStatusUpdatedDate(statusUpdatedDate);
     }
 
     CompositeFuture.all(futures).setHandler(ar -> {

--- a/src/main/java/org/folio/rest/impl/InstanceStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceStorageAPI.java
@@ -3,6 +3,7 @@ package org.folio.rest.impl;
 import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.lang.invoke.MethodHandles;
+import java.text.SimpleDateFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -107,6 +108,12 @@ public class InstanceStorageAPI implements InstanceStorage {
     Context vertxContext) {
 
     String tenantId = okapiHeaders.get(TENANT_HEADER);
+
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+
+    final String statusDate = sdf.format(entity.getMetadata().getCreatedDate());
+
+    entity.setStatusUpdatedDate(statusDate);
 
     try {
       PostgresClient postgresClient =

--- a/src/main/java/org/folio/rest/impl/InstanceStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceStorageAPI.java
@@ -1,10 +1,9 @@
 package org.folio.rest.impl;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.folio.rest.support.StatusUpdatedDateGenerator.generateStatusUpdatedDate;
 
 import java.lang.invoke.MethodHandles;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -110,9 +109,8 @@ public class InstanceStorageAPI implements InstanceStorage {
 
     String tenantId = okapiHeaders.get(TENANT_HEADER);
     
-    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-    final String statusDate = sdf.format(new Date());
-    entity.setStatusUpdatedDate(statusDate);
+    
+    entity.setStatusUpdatedDate(generateStatusUpdatedDate());
 
     try {
       PostgresClient postgresClient =

--- a/src/main/java/org/folio/rest/impl/InstanceStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceStorageAPI.java
@@ -4,6 +4,7 @@ import static org.apache.commons.lang3.StringUtils.isBlank;
 
 import java.lang.invoke.MethodHandles;
 import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -108,11 +109,9 @@ public class InstanceStorageAPI implements InstanceStorage {
     Context vertxContext) {
 
     String tenantId = okapiHeaders.get(TENANT_HEADER);
-
+    
     SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-
-    final String statusDate = sdf.format(entity.getMetadata().getCreatedDate());
-
+    final String statusDate = sdf.format(new Date());
     entity.setStatusUpdatedDate(statusDate);
 
     try {

--- a/src/main/java/org/folio/rest/impl/InstanceStorageBatchAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceStorageBatchAPI.java
@@ -1,5 +1,7 @@
 package org.folio.rest.impl;
 
+import static org.folio.rest.support.StatusUpdatedDateGenerator.generateStatusUpdatedDate;
+
 import com.google.common.collect.Lists;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.CompositeFuture;
@@ -18,8 +20,6 @@ import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.HridManager;
 import org.folio.rest.tools.utils.MetadataUtil;
 import javax.ws.rs.core.Response;
-import java.text.SimpleDateFormat;
-import java.util.Date;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,10 +44,9 @@ public class InstanceStorageBatchAPI implements InstanceStorageBatchInstances {
                                                 Handler<AsyncResult<Response>> asyncResultHandler,
                                                 Context vertxContext) {
 
-    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-    final String currentDate = sdf.format(new Date());
+    final String statusUpdatedDate = generateStatusUpdatedDate();
     for (Instance instance: entity.getInstances()) {
-        instance.setStatusUpdatedDate(currentDate);
+        instance.setStatusUpdatedDate(statusUpdatedDate);
     }
 
     vertxContext.runOnContext(v -> {

--- a/src/main/java/org/folio/rest/impl/InstanceStorageBatchAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceStorageBatchAPI.java
@@ -18,6 +18,8 @@ import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.HridManager;
 import org.folio.rest.tools.utils.MetadataUtil;
 import javax.ws.rs.core.Response;
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +43,13 @@ public class InstanceStorageBatchAPI implements InstanceStorageBatchInstances {
                                                 Map<String, String> okapiHeaders,
                                                 Handler<AsyncResult<Response>> asyncResultHandler,
                                                 Context vertxContext) {
+
+    SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+    final String currentDate = sdf.format(new Date());
+    for (Instance instance: entity.getInstances()) {
+        instance.setStatusUpdatedDate(currentDate);
+    }
+
     vertxContext.runOnContext(v -> {
       try {
         PostgresClient postgresClient = PgUtil.postgresClient(vertxContext, okapiHeaders);

--- a/src/main/java/org/folio/rest/support/StatusUpdatedDateGenerator.java
+++ b/src/main/java/org/folio/rest/support/StatusUpdatedDateGenerator.java
@@ -1,0 +1,13 @@
+package org.folio.rest.support;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
+public final class StatusUpdatedDateGenerator {
+
+    public static String generateStatusUpdatedDate() {
+      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
+      return sdf.format(new Date());
+    } 
+    
+}

--- a/src/main/java/org/folio/rest/support/StatusUpdatedDateGenerator.java
+++ b/src/main/java/org/folio/rest/support/StatusUpdatedDateGenerator.java
@@ -4,10 +4,8 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 
 public final class StatusUpdatedDateGenerator {
-
     public static String generateStatusUpdatedDate() {
       SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
       return sdf.format(new Date());
     } 
-    
 }

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -169,6 +169,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       containsInAnyOrder(natureOfContentIds));
     assertThat(
       instanceFromGet.getString(STATUS_UPDATED_DATE_PROPERTY), notNullValue());
+    assertThat(
+      instanceFromGet.getString(STATUS_UPDATED_DATE_PROPERTY), hasIsoFormat());
+      
     assertThat(instanceFromGet.getBoolean(DISCOVERY_SUPPRESS), is(false));
   }
 
@@ -208,8 +211,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     JsonArray identifiers = instanceFromGet.getJsonArray("identifiers");
     assertThat(identifiers.size(), is(1));
     assertThat(identifiers, hasItem(identifierMatches(UUID_ISBN.toString(), "9781473619777")));
-    assertThat(
-      instanceFromGet.getString(STATUS_UPDATED_DATE_PROPERTY), notNullValue());
+    assertThat(instanceFromGet.getString(STATUS_UPDATED_DATE_PROPERTY), notNullValue());
+    assertThat(instanceFromGet.getString(STATUS_UPDATED_DATE_PROPERTY), hasIsoFormat());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -1901,7 +1901,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void newSynchronousBatchInstancesShouldHaveInitialStatusDate() throws Exception {
+  public void instancesCreatedInABatchShouldHaveStatusDate() throws Exception {
     JsonArray instancesArray = new JsonArray();
     
     for (int i = 0; i < 3; i++) {

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -168,7 +168,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(instanceFromGet.getJsonArray("natureOfContentTermIds"),
       containsInAnyOrder(natureOfContentIds));
     assertThat(
-      instanceFromGet.getString(STATUS_UPDATED_DATE_PROPERTY), nullValue());
+      instanceFromGet.getString(STATUS_UPDATED_DATE_PROPERTY), notNullValue());
     assertThat(instanceFromGet.getBoolean(DISCOVERY_SUPPRESS), is(false));
   }
 
@@ -209,7 +209,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(identifiers.size(), is(1));
     assertThat(identifiers, hasItem(identifierMatches(UUID_ISBN.toString(), "9781473619777")));
     assertThat(
-      instanceFromGet.getString(STATUS_UPDATED_DATE_PROPERTY), nullValue());
+      instanceFromGet.getString(STATUS_UPDATED_DATE_PROPERTY), notNullValue());
   }
 
   @Test
@@ -1764,7 +1764,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
    * Test case for instanceStatusUpdatedDateTrigger.sql trigger.
    */
   @Test
-  public void shouldSetStatusUpdatedDate() throws Exception {
+  public void shouldChangeInitialStatusUpdatedDate() throws Exception {
     UUID id = UUID.randomUUID();
     JsonObject instanceToCreate = smallAngryPlanet(id)
       .put("statusId", getOtherInstanceType().getId().toString());
@@ -1773,7 +1773,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     Response createdInstance = getById(id);
     assertThat(createdInstance.getJson().getString(STATUS_UPDATED_DATE_PROPERTY),
-      nullValue());
+      notNullValue());
+    assertThat(createdInstance.getJson().getString(STATUS_UPDATED_DATE_PROPERTY), hasIsoFormat());
+
+    final String initialDate = createdInstance.getJson().getString(STATUS_UPDATED_DATE_PROPERTY);
 
     JsonObject replacement = instanceToCreate.copy()
       .put("hrid", createdInstance.getJson().getString("hrid"))
@@ -1784,7 +1787,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(updatedInstance.getString(STATUS_UPDATED_DATE_PROPERTY), hasIsoFormat());
 
     assertThat(updatedInstance
-        .getInstant(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(2)));
+        .getInstant(STATUS_UPDATED_DATE_PROPERTY), not(initialDate));
   }
 
   /**
@@ -1799,8 +1802,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     createInstance(instanceToCreate);
 
     Response createdInstance = getById(id);
+    
     assertThat(createdInstance.getJson().getString(STATUS_UPDATED_DATE_PROPERTY),
-      nullValue());
+      notNullValue());
 
     JsonObject instanceWithCatStatus = instanceToCreate.copy()
       .put("hrid", createdInstance.getJson().getString("hrid"))
@@ -1839,7 +1843,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     Response createdInstance = getById(id);
     assertThat(createdInstance.getJson().getString(STATUS_UPDATED_DATE_PROPERTY),
-      nullValue());
+      notNullValue());
+    assertThat(createdInstance.getJson().getString(STATUS_UPDATED_DATE_PROPERTY),
+      hasIsoFormat());
 
     JsonObject instanceWithCatStatus = instanceToCreate.copy()
       .put("hrid", createdInstance.getJson().getString("hrid"))

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -1275,10 +1275,10 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject createdItem = getById(id).getJson();
     JsonObject initialStatus = createdItem.getJsonObject("status");
 
-    String createdDate = createdItem.getJsonObject("metadata").getString("createdDate");
-
     assertThat(initialStatus.getString("name"), is("Available"));
-    assertThat(initialStatus.getString("date"), is(createdDate));
+    assertThat(initialStatus.getString("date"), notNullValue());
+
+    final String initialStatusDate = initialStatus.getString("date");
 
     itemsClient.replace(id,
       createdItem.copy()
@@ -1289,7 +1289,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     JsonObject updatedStatus = updatedItemResponse.getJson().getJsonObject("status");
 
     assertThat(updatedStatus.getString("name"), is("Available"));
-    assertThat(updatedStatus.getString("date"), is(createdDate));
+    assertThat(updatedStatus.getString("date"), is(initialStatusDate));
   }
 
   @Test


### PR DESCRIPTION
In line with MODINVSTOR-508, I changed operations here to use the current 
date/time as the initial status updated date.  I felt again that it was 
important that creation operations behave consistently.

Getting the current date and time and inserting it into the instance creation
process was the easy part.  What took more time was rewriting tests that 
either expected a null value, or were not checking the status update field
for any value at all.  It also took a while for me to realize there were two 
separate endpoints that batch-create instances.  For single instance and regular
batch-creation processes, I built checking for the status update date into existing 
tests where it seemed to make sense, usually into the initial check to see if such 
items could be correctly created.  For batch asynchronous creation, it was actually 
easier to create a separate test just for checking the status date.

refs: https://issues.folio.org/browse/MODINVSTOR-509