### PR TITLE
Create instance type before tests MODINVSTOR-613

### DIFF
--- a/src/test/java/org/folio/rest/api/InstanceRelationshipsTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceRelationshipsTest.java
@@ -24,7 +24,6 @@ import org.junit.Test;
 import io.vertx.core.json.JsonObject;
 
 public class InstanceRelationshipsTest extends TestBaseWithInventoryUtil {
-
   private final static String INSTANCE_TYPE_ID_TEXT = "6312d172-f0cf-40f6-b27d-9fa8feaf332f";
   private final static String INSTANCE_RELATIONSHIP_TYPE_ID_BOUNDWITH = "758f13db-ffb4-440e-bb10-8a364aa6cb4a";
 

--- a/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
+++ b/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
@@ -48,7 +48,6 @@ import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.builders.ItemRequestBuilder;
 import org.folio.rest.tools.utils.TenantTool;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -90,15 +89,6 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
 
     createItem(mainLibraryLocationId, "item barcode", "item effective call number 1", journalMaterialTypeId);
     createItem(thirdFloorLocationId, "item barcode 2", "item effective call number 2", bookMaterialTypeId);
-  }
-
-  @BeforeClass
-  public static void beforeClass() {
-    deleteAll(itemsStorageUrl(""));
-    deleteAll(holdingsStorageUrl(""));
-    deleteAll(instancesStorageUrl(""));
-
-    createDefaultInstanceType();
   }
 
   @Test
@@ -422,5 +412,4 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
 
     return results;
   }
-
 }

--- a/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
+++ b/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
@@ -99,19 +99,12 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
   }
 
   @BeforeClass
-  public static void beforeClass() throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
-    if (instanceTypesClient.getAll()
-      .size() == 0) {
-      InstanceType it = new InstanceType();
-      it.withId(UUID_INSTANCE_TYPE.toString());
-      it.withCode("it code");
-      it.withName("it name");
-      it.withSource("tests");
-      instanceTypesClient.create(JsonObject.mapFrom(it));
-    }
+  public static void beforeClass() {
     deleteAll(itemsStorageUrl(""));
     deleteAll(holdingsStorageUrl(""));
     deleteAll(instancesStorageUrl(""));
+
+    createDefaultInstanceType();
   }
 
   @Test
@@ -441,4 +434,15 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
     return results;
   }
 
+  private static void createDefaultInstanceType() {
+    if (instanceTypesClient.getAll()
+      .size() == 0) {
+      InstanceType it = new InstanceType();
+      it.withId(UUID_INSTANCE_TYPE.toString());
+      it.withCode("it code");
+      it.withName("it name");
+      it.withSource("tests");
+      instanceTypesClient.create(JsonObject.mapFrom(it));
+    }
+  }
 }

--- a/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
+++ b/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
@@ -41,7 +41,6 @@ import java.util.stream.Stream;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.ArrayUtils;
-import org.folio.rest.jaxrs.model.InstanceType;
 import org.folio.rest.jaxrs.model.InventoryInstanceIds;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.Response;
@@ -424,15 +423,4 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
     return results;
   }
 
-  private static void createDefaultInstanceType() {
-    if (instanceTypesClient.getAll()
-      .size() == 0) {
-      InstanceType it = new InstanceType();
-      it.withId(UUID_INSTANCE_TYPE.toString());
-      it.withCode("it code");
-      it.withName("it name");
-      it.withSource("tests");
-      instanceTypesClient.create(JsonObject.mapFrom(it));
-    }
-  }
 }

--- a/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
+++ b/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
@@ -14,8 +14,8 @@ import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers
 import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.hasEffectiveLocationInstitutionNameForItems;
 import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.hasIdForHoldings;
 import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.hasIdForInstance;
-import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.hasPermanentLocationCodeForHoldings;
 import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.hasLocationCodeForItems;
+import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.hasPermanentLocationCodeForHoldings;
 import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.hasPermanentLocationForHoldings;
 import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.hasSourceForInstance;
 import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.isDeleted;
@@ -23,7 +23,6 @@ import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import java.net.MalformedURLException;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
@@ -37,7 +36,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -74,13 +72,11 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
 
   private UUID holdingsRecordIdPredefined;
   private Map<String, String> params;
-  private UUID instanceIdPreDefined;
   private JsonObject predefinedInstance;
   private JsonObject predefinedHoldings;
 
   @Before
-  public void setUp() throws InterruptedException, ExecutionException, MalformedURLException, TimeoutException {
-
+  public void setUp() {
     deleteAll(itemsStorageUrl(""));
     deleteAll(holdingsStorageUrl(""));
     deleteAll(instancesStorageUrl(""));
@@ -92,7 +88,6 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
     predefinedHoldings = holdingsClient.getById(holdingsRecordIdPredefined).getJson();
 
     predefinedInstance = instancesClient.getAll().get(0);
-    instanceIdPreDefined = UUID.fromString(predefinedInstance.getString("id"));
 
     createItem(mainLibraryLocationId, "item barcode", "item effective call number 1", journalMaterialTypeId);
     createItem(thirdFloorLocationId, "item barcode 2", "item effective call number 2", bookMaterialTypeId);
@@ -177,7 +172,7 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void testDeletedRecordSupport() throws InterruptedException, TimeoutException, ExecutionException, MalformedURLException {
+  public void testDeletedRecordSupport() throws InterruptedException, TimeoutException, ExecutionException {
     // given
     itemsClient.deleteAll();
     holdingsClient.deleteAll();
@@ -316,10 +311,6 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
       ));
   }
 
-  private Predicate<Object> instancePredicate() {
-    return jo -> StringUtils.equals(((JsonObject) jo).getString("instanceId"), instanceIdPreDefined.toString());
-  }
-
   /**
    * The decode exception is thrown when we try to parse the response, but the only relevant thing is the correct response status of
    * 400.
@@ -350,8 +341,7 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
     getInventoryHierarchyInstances(params, response -> assertThat(response.getStatusCode(), is(400)));
   }
 
-  private void createItem(UUID mainLibraryLocationId, String s, String s2, UUID journalMaterialTypeId)
-      throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
+  private void createItem(UUID mainLibraryLocationId, String s, String s2, UUID journalMaterialTypeId) {
     super.createItem(createItemRequest(mainLibraryLocationId, s, s2, journalMaterialTypeId).create());
   }
 

--- a/src/test/java/org/folio/rest/api/OaiPmhViewTest.java
+++ b/src/test/java/org/folio/rest/api/OaiPmhViewTest.java
@@ -16,6 +16,7 @@ import static org.folio.rest.support.matchers.OaiPmhResponseMatchers.isDeleted;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+
 import java.net.MalformedURLException;
 import java.time.LocalDateTime;
 import java.time.OffsetDateTime;
@@ -30,13 +31,11 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang3.ArrayUtils;
-import org.folio.rest.jaxrs.model.InstanceType;
 import org.folio.rest.jaxrs.model.OaipmhInstanceIds;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.Response;
@@ -47,6 +46,7 @@ import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
 import io.vertx.core.Handler;
 import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
@@ -66,11 +66,9 @@ public class OaiPmhViewTest extends TestBaseWithInventoryUtil {
 
   private UUID holdingsRecordId1;
   private Map<String, String> params;
-  private UUID instanceId1;
 
   @Before
   public void setUp() throws InterruptedException, ExecutionException, MalformedURLException, TimeoutException {
-
     deleteAll(itemsStorageUrl(""));
     deleteAll(holdingsStorageUrl(""));
     deleteAll(instancesStorageUrl(""));
@@ -79,28 +77,18 @@ public class OaiPmhViewTest extends TestBaseWithInventoryUtil {
     params = new HashMap<>();
 
     holdingsRecordId1 = createInstanceAndHolding(mainLibraryLocationId);
-    final JsonObject instanceObj = instancesClient.getAll()
-      .get(0);
-    instanceId1 = UUID.fromString(instanceObj.getString("id"));
 
     createItem(mainLibraryLocationId, "item barcode", "item effective call number 1", journalMaterialTypeId);
     createItem(thirdFloorLocationId, "item barcode 2", "item effective call number 2", bookMaterialTypeId);
   }
 
   @BeforeClass
-  public static void beforeClass() throws InterruptedException, MalformedURLException, TimeoutException, ExecutionException {
-    if (instanceTypesClient.getAll()
-      .size() == 0) {
-      InstanceType it = new InstanceType();
-      it.withId(UUID_INSTANCE_TYPE.toString());
-      it.withCode("it code");
-      it.withName("it name");
-      it.withSource("tests");
-      instanceTypesClient.create(JsonObject.mapFrom(it));
-    }
+  public static void beforeClass() {
     deleteAll(itemsStorageUrl(""));
     deleteAll(holdingsStorageUrl(""));
     deleteAll(instancesStorageUrl(""));
+
+    createDefaultInstanceType();
   }
 
   @Test
@@ -140,7 +128,7 @@ public class OaiPmhViewTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void testDeletedRecordSupport() throws InterruptedException, TimeoutException, ExecutionException, MalformedURLException {
+  public void testDeletedRecordSupport() throws InterruptedException, TimeoutException, ExecutionException {
     // given
     itemsClient.deleteAll();
     holdingsClient.deleteAll();
@@ -331,10 +319,6 @@ public class OaiPmhViewTest extends TestBaseWithInventoryUtil {
     assertThat(data.get(0),
       allOf(hasCallNumber("item effective call number 1", "item effective call number 2", "item effective call number 3"),
         hasAggregatedNumberOfItems(3), hasEffectiveLocationInstitutionName("Primary Institution")));
-  }
-
-  private Predicate<Object> instancePredicate() {
-    return jo -> StringUtils.equals(((JsonObject) jo).getString("instanceid"), instanceId1.toString());
   }
 
   /**

--- a/src/test/java/org/folio/rest/api/OaiPmhViewTest.java
+++ b/src/test/java/org/folio/rest/api/OaiPmhViewTest.java
@@ -43,7 +43,6 @@ import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.builders.ItemRequestBuilder;
 import org.folio.rest.tools.utils.TenantTool;
 import org.junit.Before;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -80,15 +79,6 @@ public class OaiPmhViewTest extends TestBaseWithInventoryUtil {
 
     createItem(mainLibraryLocationId, "item barcode", "item effective call number 1", journalMaterialTypeId);
     createItem(thirdFloorLocationId, "item barcode 2", "item effective call number 2", bookMaterialTypeId);
-  }
-
-  @BeforeClass
-  public static void beforeClass() {
-    deleteAll(itemsStorageUrl(""));
-    deleteAll(holdingsStorageUrl(""));
-    deleteAll(instancesStorageUrl(""));
-
-    createDefaultInstanceType();
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/PrecedingSucceedingTitleTest.java
+++ b/src/test/java/org/folio/rest/api/PrecedingSucceedingTitleTest.java
@@ -1,55 +1,33 @@
 package org.folio.rest.api;
 
-import static org.folio.rest.api.TestBaseWithInventoryUtil.UUID_ISBN;
-import static org.folio.rest.api.TestBaseWithInventoryUtil.identifier;
-import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
-import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import io.netty.handler.codec.http.HttpResponseStatus;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import org.folio.rest.api.entities.Instance;
+import java.net.HttpURLConnection;
+import java.util.List;
+import java.util.UUID;
+
 import org.folio.rest.api.entities.PrecedingSucceedingTitle;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.Response;
-import org.junit.BeforeClass;
 import org.junit.Test;
 
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.util.List;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeoutException;
+import io.netty.handler.codec.http.HttpResponseStatus;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 
-public class PrecedingSucceedingTitleTest extends TestBase {
-
+public class PrecedingSucceedingTitleTest extends TestBaseWithInventoryUtil {
   private static final String INVALID_UUID_ERROR_MESSAGE = "Invalid UUID format of id, should be " +
     "xxxxxxxx-xxxx-Mxxx-Nxxx-xxxxxxxxxxxx where M is 1-5 and N is 8, 9, a, b, A or B and x is 0-9, a-f or A-F.";
-  private static final String PRECEDING_SUCCEEDING_TITLE_TABLE = "preceding_succeeding_title";
-  private static final String TEST_TENANT = "test_tenant";
-  private static final String INSTANCE_TYPE_ID_TEXT = "6312d172-f0cf-40f6-b27d-9fa8feaf332f";
   private static final String HRID = "inst000000000022";
   private static final String TITLE = "A web primer";
 
-  @BeforeClass
-  public static void beforeAll() {
-    StorageTestSuite.deleteAll(TEST_TENANT, PRECEDING_SUCCEEDING_TITLE_TABLE);
-    StorageTestSuite.deleteAll(itemsStorageUrl(""));
-    StorageTestSuite.deleteAll(holdingsStorageUrl(""));
-    StorageTestSuite.deleteAll(instancesStorageUrl(""));
-  }
-
   @Test
-  public void canCreateConnectedPrecedingSucceedingTitle() throws InterruptedException,
-    ExecutionException, TimeoutException, MalformedURLException {
-
-    IndividualResource instance1Resource = createInstance("Title One", INSTANCE_TYPE_ID_TEXT);
-    IndividualResource instance2Resource = createInstance("Title Two", INSTANCE_TYPE_ID_TEXT);
+  public void canCreateConnectedPrecedingSucceedingTitle() {
+    IndividualResource instance1Resource = createInstance("Title One");
+    IndividualResource instance2Resource = createInstance("Title Two");
     String instance1Id = instance1Resource.getId().toString();
     String instance2Id = instance2Resource.getId().toString();
 
@@ -61,10 +39,8 @@ public class PrecedingSucceedingTitleTest extends TestBase {
   }
 
   @Test
-  public void canCreateUnconnectedPrecedingTitle() throws InterruptedException,
-    ExecutionException, TimeoutException, MalformedURLException {
-
-    IndividualResource instanceResource = createInstance("Title One", INSTANCE_TYPE_ID_TEXT);
+  public void canCreateUnconnectedPrecedingTitle() {
+    IndividualResource instanceResource = createInstance("Title One");
     String instanceId = instanceResource.getId().toString();
     JsonArray identifiers = new JsonArray();
     identifiers.add(identifier(UUID_ISBN, "9781473619777"));
@@ -77,10 +53,8 @@ public class PrecedingSucceedingTitleTest extends TestBase {
   }
 
   @Test
-  public void canCreateUnconnectedSucceedingTitle() throws InterruptedException,
-    ExecutionException, TimeoutException, MalformedURLException {
-
-    IndividualResource instanceResource = createInstance("Title One", INSTANCE_TYPE_ID_TEXT);
+  public void canCreateUnconnectedSucceedingTitle() {
+    IndividualResource instanceResource = createInstance("Title One");
     String instanceId = instanceResource.getId().toString();
     JsonArray identifiers = new JsonArray();
     identifiers.add(identifier(UUID_ISBN, "9781473619777"));
@@ -93,11 +67,9 @@ public class PrecedingSucceedingTitleTest extends TestBase {
   }
 
   @Test
-  public void canUpdateConnectedPrecedingSucceedingTitle() throws InterruptedException,
-    ExecutionException, TimeoutException, MalformedURLException {
-
-    IndividualResource instance1Resource = createInstance("Title One", INSTANCE_TYPE_ID_TEXT);
-    IndividualResource instance2Resource = createInstance("Title Two", INSTANCE_TYPE_ID_TEXT);
+  public void canUpdateConnectedPrecedingSucceedingTitle() {
+    IndividualResource instance1Resource = createInstance("Title One");
+    IndividualResource instance2Resource = createInstance("Title Two");
     String instance1Id = instance1Resource.getId().toString();
     String instance2Id = instance2Resource.getId().toString();
 
@@ -115,10 +87,8 @@ public class PrecedingSucceedingTitleTest extends TestBase {
   }
 
   @Test
-  public void canUpdateUnconnectedPrecedingSucceedingTitle() throws InterruptedException,
-    ExecutionException, TimeoutException, MalformedURLException {
-
-    IndividualResource instance1Resource = createInstance("Title One", INSTANCE_TYPE_ID_TEXT);
+  public void canUpdateUnconnectedPrecedingSucceedingTitle() {
+    IndividualResource instance1Resource = createInstance("Title One");
     String instance1Id = instance1Resource.getId().toString();
     JsonArray identifiers = new JsonArray();
     identifiers.add(identifier(UUID_ISBN, "9781473619777"));
@@ -128,7 +98,7 @@ public class PrecedingSucceedingTitleTest extends TestBase {
 
     IndividualResource response = precedingSucceedingTitleClient.create(precedingSucceedingTitle.getJson());
 
-    IndividualResource instance2Resource = createInstance("Title Two", INSTANCE_TYPE_ID_TEXT);
+    IndividualResource instance2Resource = createInstance("Title Two");
     String instance2Id = instance2Resource.getId().toString();
     String newTitle = "New";
     String newHrid = "inst000000000133";
@@ -143,10 +113,8 @@ public class PrecedingSucceedingTitleTest extends TestBase {
   }
 
   @Test
-  public void canDeletePrecedingSucceedingTitle() throws InterruptedException,
-    ExecutionException, TimeoutException, MalformedURLException {
-
-    IndividualResource instanceResource = createInstance("Title One", INSTANCE_TYPE_ID_TEXT);
+  public void canDeletePrecedingSucceedingTitle() {
+    IndividualResource instanceResource = createInstance("Title One");
     JsonArray identifiers = new JsonArray();
     identifiers.add(identifier(UUID_ISBN, "9781473619777"));
 
@@ -162,10 +130,9 @@ public class PrecedingSucceedingTitleTest extends TestBase {
   }
 
   @Test
-  public void canGetPrecedingSucceedingTitleByQuery() throws InterruptedException,
-    ExecutionException, TimeoutException, MalformedURLException {
-    IndividualResource instance1Resource = createInstance("Title One", INSTANCE_TYPE_ID_TEXT);
-    IndividualResource instance2Resource = createInstance("Title Two", INSTANCE_TYPE_ID_TEXT);
+  public void canGetPrecedingSucceedingTitleByQuery() {
+    IndividualResource instance1Resource = createInstance("Title One");
+    IndividualResource instance2Resource = createInstance("Title Two");
     String instance1Id = instance1Resource.getId().toString();
     String instance2Id = instance2Resource.getId().toString();
     JsonArray identifiers = new JsonArray();
@@ -186,11 +153,9 @@ public class PrecedingSucceedingTitleTest extends TestBase {
   }
 
   @Test
-  public void cannotCreatePrecedingSucceedingTitleWithNonExistingPrecedingInstance()
-    throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
-
+  public void cannotCreatePrecedingSucceedingTitleWithNonExistingPrecedingInstance() {
     String nonExistingInstanceId = "14b65645-2e49-4a85-8dc1-43d444710570";
-    IndividualResource instanceResource = createInstance("Title One", INSTANCE_TYPE_ID_TEXT);
+    IndividualResource instanceResource = createInstance("Title One");
 
     PrecedingSucceedingTitle precedingSucceedingTitle = new PrecedingSucceedingTitle(
       nonExistingInstanceId, instanceResource.getId().toString(), null, null, null);
@@ -203,12 +168,10 @@ public class PrecedingSucceedingTitleTest extends TestBase {
   }
 
   @Test
-  public void cannotCreatePrecedingSucceedingTitleWithNonExistingSucceedingInstance()
-    throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
-
+  public void cannotCreatePrecedingSucceedingTitleWithNonExistingSucceedingInstance() {
     String nonExistingInstanceId = "14b65645-2e49-4a85-8dc1-43d444710570";
 
-    IndividualResource instance1Response = createInstance("Title One", INSTANCE_TYPE_ID_TEXT);
+    IndividualResource instance1Response = createInstance("Title One");
     JsonArray identifiers = new JsonArray();
     identifiers.add(identifier(UUID_ISBN, "9781473619777"));
 
@@ -223,9 +186,7 @@ public class PrecedingSucceedingTitleTest extends TestBase {
   }
 
   @Test
-  public void cannotCreatePrecedingSucceedingTitleWithEmptyPrecedingAndSucceedingInstanceId()
-    throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
-
+  public void cannotCreatePrecedingSucceedingTitleWithEmptyPrecedingAndSucceedingInstanceId() {
     JsonArray identifiers = new JsonArray();
     identifiers.add(identifier(UUID_ISBN, "9781473619777"));
 
@@ -240,19 +201,15 @@ public class PrecedingSucceedingTitleTest extends TestBase {
   }
 
   @Test
-  public void cannotGetByInvalidPrecedingSucceedingId() throws MalformedURLException,
-    InterruptedException, TimeoutException, ExecutionException {
-
+  public void cannotGetByInvalidPrecedingSucceedingId() {
     Response badParameterResponse = precedingSucceedingTitleClient.getByIdIfPresent("abc");
     assertThat(badParameterResponse.getStatusCode(), is(HttpResponseStatus.UNPROCESSABLE_ENTITY.code()));
     assertErrors(badParameterResponse, INVALID_UUID_ERROR_MESSAGE);
   }
 
   @Test
-  public void cannotPutByInvalidPrecedingSucceedingId() throws InterruptedException,
-    TimeoutException, ExecutionException, MalformedURLException {
-
-    IndividualResource instance1Resource = createInstance("Title One", INSTANCE_TYPE_ID_TEXT);
+  public void cannotPutByInvalidPrecedingSucceedingId() {
+    IndividualResource instance1Resource = createInstance("Title One");
 
     JsonArray identifiers = new JsonArray();
     identifiers.add(identifier(UUID_ISBN, "9781473619777"));
@@ -266,19 +223,17 @@ public class PrecedingSucceedingTitleTest extends TestBase {
   }
 
   @Test
-  public void cannotDeleteByInvalidPrecedingSucceedingId() throws InterruptedException,
-    TimeoutException, ExecutionException, MalformedURLException {
-
+  public void cannotDeleteByInvalidPrecedingSucceedingId() {
     Response badParameterResponse = precedingSucceedingTitleClient.deleteIfPresent("abc");
     assertThat(badParameterResponse.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
     assertThat(badParameterResponse.getBody(), is(INVALID_UUID_ERROR_MESSAGE));
   }
 
-  private IndividualResource createInstance(String title, String instanceTypeId)
-    throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
-    Instance instance = new Instance(title, "TEST", instanceTypeId);
+  private IndividualResource createInstance(String title) {
+    JsonObject instanceRequest = createInstanceRequest(UUID.randomUUID(), "TEST",
+      title, new JsonArray(), new JsonArray(), UUID_INSTANCE_TYPE, new JsonArray());
 
-    return instancesClient.create(instance.getJson());
+    return instancesClient.create(instanceRequest);
   }
 
   private void assertErrors(Response response, String message) {
@@ -286,9 +241,9 @@ public class PrecedingSucceedingTitleTest extends TestBase {
     assertThat(errors.getErrors().get(0).getMessage(), is(message));
   }
 
-  private void assertPrecedingSucceedingTitle(IndividualResource response, String precedingSucceedingTitleId,
-    String succeedingTitleId, String title, String hrid, JsonArray identifiers)
-    throws InterruptedException, ExecutionException, TimeoutException, MalformedURLException {
+  private void assertPrecedingSucceedingTitle(IndividualResource response,
+    String precedingSucceedingTitleId, String succeedingTitleId, String title,
+    String hrid, JsonArray identifiers) {
 
     Response getResponse = precedingSucceedingTitleClient.getById(response.getId());
     JsonObject precedingSucceedingTitleResponse = getResponse.getJson();

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -19,6 +19,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.UnaryOperator;
 
+import org.folio.HttpStatus;
 import org.folio.rest.jaxrs.model.InstanceType;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.support.IndividualResource;
@@ -225,13 +226,21 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   }
 
   protected static void createDefaultInstanceType() {
-    InstanceType it = new InstanceType();
-    it.withId(UUID_INSTANCE_TYPE.toString());
-    it.withCode("DIT");
-    it.withName("Default Instance Type");
-    it.withSource("local");
+    if (instanceTypeDoesNotAlreadyExist(UUID_INSTANCE_TYPE)) {
+      InstanceType it = new InstanceType();
+      it.withId(UUID_INSTANCE_TYPE.toString());
+      it.withCode("DIT");
+      it.withName("Default Instance Type");
+      it.withSource("local");
 
-    instanceTypesClient.create(JsonObject.mapFrom(it));
+      instanceTypesClient.create(JsonObject.mapFrom(it));
+    }
+  }
+
+  private static boolean instanceTypeDoesNotAlreadyExist(UUID id) {
+    Response response = instanceTypesClient.getById(id);
+
+    return response.getStatusCode() == HttpStatus.HTTP_NOT_FOUND.toInt();
   }
 
   protected void createItem(JsonObject itemToCreate) {

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -18,6 +18,8 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.UnaryOperator;
+
+import org.folio.rest.jaxrs.model.InstanceType;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.Response;
@@ -75,7 +77,6 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
 
   @BeforeClass
   public static void beforeAny() {
-
     StorageTestSuite.deleteAll(TENANT_ID, "preceding_succeeding_title");
     StorageTestSuite.deleteAll(TENANT_ID, "instance_relationship");
     StorageTestSuite.deleteAll(itemsStorageUrl(""));
@@ -148,7 +149,6 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   }
 
   protected static UUID createInstanceAndHoldingWithCallNumber(UUID holdingsPermanentLocationId) {
-
       UUID instanceId = UUID.randomUUID();
       instancesClient.create(instance(instanceId));
 
@@ -162,7 +162,6 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   }
 
   protected static UUID createInstanceAndHoldingWithCallNumberPrefix(UUID holdingsPermanentLocationId) {
-
     UUID instanceId = UUID.randomUUID();
     instancesClient.create(instance(instanceId));
 
@@ -176,7 +175,6 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   }
 
   protected static UUID createInstanceAndHoldingWithCallNumberSuffix(UUID holdingsPermanentLocationId) {
-
     UUID instanceId = UUID.randomUUID();
     instancesClient.create(instance(instanceId));
 
@@ -222,8 +220,19 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     return itemToCreate.mapTo(Item.class);
   }
 
-  protected void createItem(JsonObject itemToCreate) {
+  protected static void createDefaultInstanceType() {
+    if (instanceTypesClient.getAll()
+      .size() == 0) {
+      InstanceType it = new InstanceType();
+      it.withId(UUID_INSTANCE_TYPE.toString());
+      it.withCode("it code");
+      it.withName("it name");
+      it.withSource("tests");
+      instanceTypesClient.create(JsonObject.mapFrom(it));
+    }
+  }
 
+  protected void createItem(JsonObject itemToCreate) {
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
     client.post(itemsStorageUrl(""), itemToCreate, TENANT_ID,

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -79,6 +79,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   public static void beforeAny() {
     StorageTestSuite.deleteAll(TENANT_ID, "preceding_succeeding_title");
     StorageTestSuite.deleteAll(TENANT_ID, "instance_relationship");
+
     StorageTestSuite.deleteAll(itemsStorageUrl(""));
     StorageTestSuite.deleteAll(holdingsStorageUrl(""));
     StorageTestSuite.deleteAll(instancesStorageUrl(""));
@@ -90,11 +91,14 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     StorageTestSuite.deleteAll(locInstitutionStorageUrl(""));
     StorageTestSuite.deleteAll(loanTypesStorageUrl(""));
 
+    createDefaultInstanceType();
+
     MaterialTypesClient materialTypesClient = new MaterialTypesClient(client, materialTypesStorageUrl(""));
     journalMaterialTypeID = materialTypesClient.create("journal");
     journalMaterialTypeId = UUID.fromString(journalMaterialTypeID);
     bookMaterialTypeID = materialTypesClient.create("book");
     bookMaterialTypeId = UUID.fromString(bookMaterialTypeID);
+
     LoanTypesClient loanTypesClient = new LoanTypesClient(client, loanTypesStorageUrl(""));
     canCirculateLoanTypeID = loanTypesClient.create("Can Circulate");
     canCirculateLoanTypeId = UUID.fromString(canCirculateLoanTypeID);
@@ -221,15 +225,13 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   }
 
   protected static void createDefaultInstanceType() {
-    if (instanceTypesClient.getAll()
-      .size() == 0) {
-      InstanceType it = new InstanceType();
-      it.withId(UUID_INSTANCE_TYPE.toString());
-      it.withCode("it code");
-      it.withName("it name");
-      it.withSource("tests");
-      instanceTypesClient.create(JsonObject.mapFrom(it));
-    }
+    InstanceType it = new InstanceType();
+    it.withId(UUID_INSTANCE_TYPE.toString());
+    it.withCode("DIT");
+    it.withName("Default Instance Type");
+    it.withSource("local");
+
+    instanceTypesClient.create(JsonObject.mapFrom(it));
   }
 
   protected void createItem(JsonObject itemToCreate) {


### PR DESCRIPTION
Whilst reviewing pull requests, it became apparent that some tests (e.g. any in `ItemStorageTests` couldn't be executed individually, due to the tests not creating the default instance type.