### PR TITLE
MODINVSTOR-614: Do not call asyncHandler when response is being updated directly.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,12 @@
       <artifactId>commons-lang3</artifactId>
       <version>3.9</version>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <version>3.0.0</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/src/main/java/org/folio/rest/impl/AbstractInstanceRecordsAPI.java
+++ b/src/main/java/org/folio/rest/impl/AbstractInstanceRecordsAPI.java
@@ -109,7 +109,6 @@ public abstract class AbstractInstanceRecordsAPI {
               return;
             }
             response.end();
-            asyncResultHandler.handle(Future.succeededFuture());
           });
         }).handler(row -> {
           response.write(createJsonFromRow(row));


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-614 - inventory-storage crashes after grabbing all available DB connections.


### Purpose:

Seems we don't need to call async handler when we're updating the response directly. RMB does not call the async jhandler as well for streaming see  https://github.com/folio-org/raml-module-builder/blob/master/domain-models-runtime/src/main/java/org/folio/rest/persist/PgUtil.java#L556, there is no asynHandler param being passed.