### PR TITLE
MODINVSTOR-630: Delete StorageHelper.completeFuture(T)

### DIFF
--- a/src/main/java/org/folio/rest/impl/HoldingsBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsBatchSyncAPI.java
@@ -61,7 +61,7 @@ public class HoldingsBatchSyncAPI implements HoldingsStorageBatchSynchronous {
     if (isBlank(holdingsRecord.getHrid())) {
       hridFuture = hridManager.getNextHoldingsHrid();
     } else {
-      hridFuture = StorageHelper.completeFuture(holdingsRecord.getHrid());
+      hridFuture = Future.succeededFuture(holdingsRecord.getHrid());
     }
 
     return hridFuture.map(hrid -> {

--- a/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
@@ -440,7 +440,7 @@ public class HoldingsStorageAPI implements HoldingsStorage {
       final HridManager hridManager = new HridManager(vertxContext, postgresClient);
       hridFuture = hridManager.getNextHoldingsHrid();
     } else {
-      hridFuture = StorageHelper.completeFuture(entity.getHrid());
+      hridFuture = Future.succeededFuture(entity.getHrid());
     }
 
     return hridFuture;

--- a/src/main/java/org/folio/rest/impl/InstanceBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceBatchSyncAPI.java
@@ -64,7 +64,7 @@ public class InstanceBatchSyncAPI implements InstanceStorageBatchSynchronous {
     if (isBlank(instance.getHrid())) {
       hridFuture = hridManager.getNextInstanceHrid();
     } else {
-      hridFuture = StorageHelper.completeFuture(instance.getHrid());
+      hridFuture = Future.succeededFuture(instance.getHrid());
     }
 
     return hridFuture.map(hrid -> {

--- a/src/main/java/org/folio/rest/impl/InstanceStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceStorageAPI.java
@@ -135,7 +135,7 @@ public class InstanceStorageAPI implements InstanceStorage {
             final HridManager hridManager = new HridManager(vertxContext, postgresClient);
             hridFuture = hridManager.getNextInstanceHrid();
           } else {
-            hridFuture = StorageHelper.completeFuture(entity.getHrid());
+            hridFuture = Future.succeededFuture(entity.getHrid());
           }
 
           hridFuture.map(hrid -> {

--- a/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
@@ -68,7 +68,7 @@ public class ItemBatchSyncAPI implements ItemStorageBatchSynchronous {
     if (isBlank(item.getHrid())) {
       hridFuture = hridManager.getNextItemHrid();
     } else {
-      hridFuture = StorageHelper.completeFuture(item.getHrid());
+      hridFuture = Future.succeededFuture(item.getHrid());
     }
 
     return hridFuture.map(hrid -> {

--- a/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
@@ -64,7 +64,7 @@ public class ItemStorageAPI implements ItemStorage {
           StorageHelper.postgresClient(vertxContext, okapiHeaders));
       hridFuture = hridManager.getNextItemHrid();
     } else {
-      hridFuture = StorageHelper.completeFuture(entity.getHrid());
+      hridFuture = Future.succeededFuture(entity.getHrid());
     }
 
     final ItemEffectiveValuesService effectiveValuesService =

--- a/src/main/java/org/folio/rest/impl/StorageHelper.java
+++ b/src/main/java/org/folio/rest/impl/StorageHelper.java
@@ -1,8 +1,6 @@
 package org.folio.rest.impl;
 
 import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
 import java.util.Map;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -64,12 +62,5 @@ public final class StorageHelper {
   protected static PostgresClient postgresClient(Context vertxContext, Map<String, String> okapiHeaders) {
     return PostgresClient.getInstance(vertxContext.owner(), TenantTool.tenantId(okapiHeaders));
   }
-
-  public static <T> Future<T> completeFuture(T id) {
-    Promise<T> p = Promise.promise();
-    p.complete(id);
-    return p.future();
-  }
-
 
 }

--- a/src/test/java/org/folio/rest/api/HridSettingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HridSettingsStorageTest.java
@@ -19,7 +19,6 @@ import java.util.concurrent.TimeoutException;
 import io.vertx.sqlclient.Row;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.rest.impl.StorageHelper;
 import org.folio.rest.jaxrs.model.HridSetting;
 import org.folio.rest.jaxrs.model.HridSettings;
 import org.folio.rest.persist.PostgresClient;
@@ -448,7 +447,7 @@ public class HridSettingsStorageTest extends TestBase {
                       is(originalHridSettings.getItems().getPrefix()));
                   assertThat(currentHridSettings.getItems().getStartNumber(),
                       is(originalHridSettings.getItems().getStartNumber()));
-                  return StorageHelper.completeFuture(currentHridSettings);
+                  return Future.succeededFuture(currentHridSettings);
                 })
                 .onComplete(promise);
           });
@@ -481,6 +480,6 @@ public class HridSettingsStorageTest extends TestBase {
 
   private Future<String> validateHrid(String hrid, String expectedValue, TestContext testContext) {
     testContext.assertEquals(expectedValue, hrid);
-    return StorageHelper.completeFuture(hrid);
+    return Future.succeededFuture(hrid);
   }
 }


### PR DESCRIPTION
Replace StorageHelper.completeFuture(T) by Future.succeededFuture(T).

It duplicates the Vert.x method:
https://github.com/eclipse-vertx/vert.x/blob/4.0.0.CR2/src/main/java/io/vertx/core/Future.java#L59-L72