### PR TITLE
Add virtual link-field "materialType" to item schema

### DIFF
--- a/ramls/item.json
+++ b/ramls/item.json
@@ -265,6 +265,18 @@
       "type": "string",
       "description": "Material type, term. Define what type of thing the item is."
     },
+    "materialType": {
+      "description": "Item's material type",
+      "type": "object",
+      "folio:$ref": "materialtype.json",
+      "javaType": "org.folio.rest.jaxrs.model.materialTypeVirtual",
+      "readonly": true,
+      "folio:isVirtual": true,
+      "folio:linkBase": "material-types",
+      "folio:linkFromField": "materialTypeId",
+      "folio:linkToField": "id",
+      "folio:includedElement": "mtypes.0"
+    },
     "permanentLoanTypeId": {
       "type": "string",
       "description": "The permanent loan type, is the default loan type for a given item. Loan types are tenant-defined."


### PR DESCRIPTION
This is for mod-graphql's benefit, and is needed for ZF-26.