### PR TITLE
MODINVSTOR-647: Refactor ItemStorageAPI and HoldingStorageAPI#put.

### DIFF
--- a/src/main/java/org/folio/rest/exceptions/BadRequestException.java
+++ b/src/main/java/org/folio/rest/exceptions/BadRequestException.java
@@ -1,0 +1,7 @@
+package org.folio.rest.exceptions;
+
+public final class BadRequestException extends InventoryProcessingException {
+  public BadRequestException(Object message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/folio/rest/exceptions/InventoryProcessingException.java
+++ b/src/main/java/org/folio/rest/exceptions/InventoryProcessingException.java
@@ -1,0 +1,9 @@
+package org.folio.rest.exceptions;
+
+import java.util.Objects;
+
+public abstract class InventoryProcessingException extends RuntimeException {
+  public InventoryProcessingException(Object message) {
+    super(Objects.toString(message));
+  }
+}

--- a/src/main/java/org/folio/rest/exceptions/InventoryProcessingException.java
+++ b/src/main/java/org/folio/rest/exceptions/InventoryProcessingException.java
@@ -3,7 +3,7 @@ package org.folio.rest.exceptions;
 import java.util.Objects;
 
 public abstract class InventoryProcessingException extends RuntimeException {
-  public InventoryProcessingException(Object message) {
+  protected InventoryProcessingException(Object message) {
     super(Objects.toString(message));
   }
 }

--- a/src/main/java/org/folio/rest/exceptions/NotFoundException.java
+++ b/src/main/java/org/folio/rest/exceptions/NotFoundException.java
@@ -1,0 +1,7 @@
+package org.folio.rest.exceptions;
+
+public class NotFoundException extends InventoryProcessingException {
+  public NotFoundException(Object message) {
+    super(message);
+  }
+}

--- a/src/main/java/org/folio/rest/exceptions/ValidationException.java
+++ b/src/main/java/org/folio/rest/exceptions/ValidationException.java
@@ -2,8 +2,8 @@ package org.folio.rest.exceptions;
 
 import org.folio.rest.jaxrs.model.Errors;
 
-public class ValidationException extends RuntimeException {
-  private final Errors errors;
+public final class ValidationException extends InventoryProcessingException {
+  private final transient Errors errors;
 
   public ValidationException(Errors errors) {
     super("Validation exception: " + errors);

--- a/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemBatchSyncAPI.java
@@ -1,79 +1,31 @@
 package org.folio.rest.impl;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import static io.vertx.core.Future.succeededFuture;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
-import java.util.Date;
 
 import javax.ws.rs.core.Response;
 
 import org.folio.rest.annotations.Validate;
-import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.jaxrs.model.ItemsPost;
 import org.folio.rest.jaxrs.resource.ItemStorageBatchSynchronous;
-import org.folio.rest.persist.PgUtil;
-import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.EndpointFailureHandler;
-import org.folio.rest.support.HridManager;
-import org.folio.rest.tools.utils.TenantTool;
-import org.folio.services.ItemEffectiveValuesService;
+import org.folio.services.item.ItemService;
+
 import io.vertx.core.AsyncResult;
-import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
 
 public class ItemBatchSyncAPI implements ItemStorageBatchSynchronous {
   @Validate
   @Override
   public void postItemStorageBatchSynchronous(boolean upsert, ItemsPost entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    final List<Item> items = entity.getItems();
-    final PostgresClient postgresClient = PostgresClient.getInstance(
-          vertxContext.owner(), TenantTool.tenantId(okapiHeaders));
-    final ItemEffectiveValuesService effectiveValuesService =
-      new ItemEffectiveValuesService(postgresClient);
 
-    // Currently, there is no method on CompositeFuture to accept List<Future<String>>
-    @SuppressWarnings("rawtypes")
-    final List<Future> futures = new ArrayList<>();
-    final HridManager hridManager = new HridManager(Vertx.currentContext(), postgresClient);
-
-    // add a last modified date to status on all created items
-    Date itemStatusDate = new java.util.Date();
-
-    for (Item item : items) {
-      item.getStatus().setDate(itemStatusDate);
-      futures.add(setHrid(item, hridManager));
-    }
-
-    CompositeFuture.all(futures)
-    .compose(result -> effectiveValuesService.populateEffectiveValues(items))
-    .onSuccess(result -> {
-      PgUtil.postSync(ItemStorageAPI.ITEM_TABLE, entity.getItems(),
-          StorageHelper.MAX_ENTITIES, upsert, okapiHeaders, vertxContext,
-          PostItemStorageBatchSynchronousResponse.class, asyncResultHandler);
-    })
-    .onFailure(EndpointFailureHandler.handleFailure(asyncResultHandler,
-          PostItemStorageBatchSynchronousResponse::respond422WithApplicationJson,
-          PostItemStorageBatchSynchronousResponse::respond500WithTextPlain));
-  }
-
-  private Future<Void> setHrid(Item item, HridManager hridManager) {
-    final Future<String> hridFuture;
-
-    if (isBlank(item.getHrid())) {
-      hridFuture = hridManager.getNextItemHrid();
-    } else {
-      hridFuture = Future.succeededFuture(item.getHrid());
-    }
-
-    return hridFuture.map(hrid -> {
-      item.setHrid(hrid);
-      return null;
-    });
+    new ItemService(vertxContext, okapiHeaders).createItems(entity.getItems(), upsert)
+      .onSuccess(response -> asyncResultHandler.handle(succeededFuture(response)))
+      .onFailure(EndpointFailureHandler.handleFailure(asyncResultHandler,
+        PostItemStorageBatchSynchronousResponse::respond422WithApplicationJson,
+        PostItemStorageBatchSynchronousResponse::respond500WithTextPlain));
   }
 }

--- a/src/main/java/org/folio/rest/support/EffectiveCallNumberComponentsUtil.java
+++ b/src/main/java/org/folio/rest/support/EffectiveCallNumberComponentsUtil.java
@@ -6,15 +6,18 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.jaxrs.model.EffectiveCallNumberComponents;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
+import org.folio.services.item.effectivevalues.ItemWithHolding;
 
 public final class EffectiveCallNumberComponentsUtil {
+  private EffectiveCallNumberComponentsUtil() {}
 
-  public static EffectiveCallNumberComponents buildComponents(HoldingsRecord holdings, Item item) {
-    return updateComponents(new EffectiveCallNumberComponents(), holdings, item);
+  public static ItemWithHolding setCallNumberComponents(ItemWithHolding itemWithHolding) {
+    return itemWithHolding.withEffectiveCallNumberComponents(buildComponents(itemWithHolding));
   }
 
-  private static EffectiveCallNumberComponents updateComponents(
-    EffectiveCallNumberComponents components, HoldingsRecord holdings, Item item) {
+  private static EffectiveCallNumberComponents buildComponents(ItemWithHolding itemWithHolding) {
+    final Item item = itemWithHolding.getItem();
+    final HoldingsRecord holdings = itemWithHolding.getHoldingsRecord();
 
     String updatedCallNumber = null;
     if (isNotBlank(item.getItemLevelCallNumber())) {
@@ -39,14 +42,12 @@ public final class EffectiveCallNumberComponentsUtil {
 
     String updatedCallNumberTypeId = StringUtils.firstNonBlank(
       item.getItemLevelCallNumberTypeId(),
-      holdings != null ? holdings.getCallNumberTypeId() : null
-    );
+      holdings != null ? holdings.getCallNumberTypeId() : null);
 
-    components.setCallNumber(updatedCallNumber);
-    components.setPrefix(updatedCallNumberPrefix);
-    components.setSuffix(updatedCallNumberSuffix);
-    components.setTypeId(updatedCallNumberTypeId);
-
-    return components;
+    return new EffectiveCallNumberComponents()
+      .withCallNumber(updatedCallNumber)
+      .withPrefix(updatedCallNumberPrefix)
+      .withSuffix(updatedCallNumberSuffix)
+      .withTypeId(updatedCallNumberTypeId);
   }
 }

--- a/src/main/java/org/folio/rest/support/EndpointFailureHandler.java
+++ b/src/main/java/org/folio/rest/support/EndpointFailureHandler.java
@@ -10,6 +10,7 @@ import javax.ws.rs.core.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.exceptions.BadRequestException;
+import org.folio.rest.exceptions.NotFoundException;
 import org.folio.rest.exceptions.ValidationException;
 import org.folio.rest.jaxrs.model.Errors;
 
@@ -55,6 +56,8 @@ public final class EndpointFailureHandler {
 
       if (error instanceof BadRequestException) {
         responseToReturn = textPlainResponse(400, error);
+      } else if (error instanceof NotFoundException) {
+        responseToReturn = textPlainResponse(404, error);
       } else if (error instanceof ValidationException) {
         final Errors errors = ((ValidationException) error).getErrors();
         responseToReturn = failedValidationResponse(errors);

--- a/src/main/java/org/folio/rest/support/EndpointFailureHandler.java
+++ b/src/main/java/org/folio/rest/support/EndpointFailureHandler.java
@@ -1,15 +1,19 @@
 package org.folio.rest.support;
 
+import static io.vertx.core.Future.succeededFuture;
+import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
+
 import java.util.function.Function;
 
 import javax.ws.rs.core.Response;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.rest.exceptions.BadRequestException;
 import org.folio.rest.exceptions.ValidationException;
 import org.folio.rest.jaxrs.model.Errors;
 
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 
 public final class EndpointFailureHandler {
@@ -18,10 +22,10 @@ public final class EndpointFailureHandler {
   private EndpointFailureHandler() {}
 
   public static void handleFailure(
-      Throwable error,
-      Handler<AsyncResult<Response>> asyncResultHandler,
-      Function<Errors, Response> validationHandler,
-      Function<String, Response> serverErrorHandler) {
+    Throwable error,
+    Handler<AsyncResult<Response>> asyncResultHandler,
+    Function<Errors, Response> validationHandler,
+    Function<String, Response> serverErrorHandler) {
 
     log.warn("Error occurred", error);
 
@@ -31,16 +35,44 @@ public final class EndpointFailureHandler {
     } else {
       response = serverErrorHandler.apply(error.getMessage());
     }
-    asyncResultHandler.handle(Future.succeededFuture(response));
+    asyncResultHandler.handle(succeededFuture(response));
   }
 
   /**
    * Use future.onError(handleFailure(asyncResultHandler, validationHandler, serverErrorHandler))
    */
   public static Handler<Throwable> handleFailure(
-      Handler<AsyncResult<Response>> asyncResultHandler,
-      Function<Errors, Response> validationHandler,
-      Function<String, Response> serverErrorHandler) {
+    Handler<AsyncResult<Response>> asyncResultHandler,
+    Function<Errors, Response> validationHandler,
+    Function<String, Response> serverErrorHandler) {
     return e -> handleFailure(e, asyncResultHandler, validationHandler, serverErrorHandler);
+  }
+
+  public static Handler<Throwable> handleFailure(Handler<AsyncResult<Response>> asyncResultHandler) {
+    return error -> {
+      log.error("An error occurred", error);
+      Response responseToReturn;
+
+      if (error instanceof BadRequestException) {
+        responseToReturn = textPlainResponse(400, error);
+      } else if (error instanceof ValidationException) {
+        final Errors errors = ((ValidationException) error).getErrors();
+        responseToReturn = failedValidationResponse(errors);
+      } else {
+        responseToReturn = textPlainResponse(500, error);
+      }
+
+      asyncResultHandler.handle(succeededFuture(responseToReturn));
+    };
+  }
+
+  private static Response textPlainResponse(int status, Throwable error) {
+    return Response.status(status).header(CONTENT_TYPE, "text/plain")
+      .entity(error.getMessage()).build();
+  }
+
+  private static Response failedValidationResponse(Object jsonEntity) {
+    return Response.status(422).header(CONTENT_TYPE, "application/json")
+      .entity(jsonEntity).build();
   }
 }

--- a/src/main/java/org/folio/rest/support/ItemEffectiveLocationUtil.java
+++ b/src/main/java/org/folio/rest/support/ItemEffectiveLocationUtil.java
@@ -2,6 +2,7 @@ package org.folio.rest.support;
 
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
+import org.folio.services.item.effectivevalues.ItemWithHolding;
 
 import static java.util.Objects.isNull;
 
@@ -9,7 +10,9 @@ public final class ItemEffectiveLocationUtil {
 
   private ItemEffectiveLocationUtil(){}
 
-  public static Item updateItemEffectiveLocation(Item item, HoldingsRecord holdingsRecord) {
+  public static ItemWithHolding updateItemEffectiveLocation(ItemWithHolding itemWithHolding) {
+    final Item item = itemWithHolding.getItem();
+    final HoldingsRecord holdingsRecord = itemWithHolding.getHoldingsRecord();
 
     if (isNull(item.getPermanentLocationId()) && isNull(item.getTemporaryLocationId())) {
       item.setEffectiveLocationId(isNull(holdingsRecord.getTemporaryLocationId()) ?
@@ -19,6 +22,6 @@ public final class ItemEffectiveLocationUtil {
         item.getPermanentLocationId() : item.getTemporaryLocationId());
     }
 
-    return item;
+    return itemWithHolding;
   }
 }

--- a/src/main/java/org/folio/rest/support/ResponseUtil.java
+++ b/src/main/java/org/folio/rest/support/ResponseUtil.java
@@ -1,0 +1,13 @@
+package org.folio.rest.support;
+
+import static org.folio.HttpStatus.HTTP_NO_CONTENT;
+
+import javax.ws.rs.core.Response;
+
+public final class ResponseUtil {
+  private ResponseUtil() {}
+
+  public static boolean isUpdateSuccessResponse(Response response) {
+    return response != null && response.getStatus() == HTTP_NO_CONTENT.toInt();
+  }
+}

--- a/src/main/java/org/folio/services/domainevent/BaseDomainEventService.java
+++ b/src/main/java/org/folio/services/domainevent/BaseDomainEventService.java
@@ -1,0 +1,80 @@
+package org.folio.services.domainevent;
+
+import static org.apache.logging.log4j.LogManager.getLogger;
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
+import static org.folio.services.domainevent.DomainEvent.createEvent;
+import static org.folio.services.domainevent.DomainEvent.deleteEvent;
+import static org.folio.services.domainevent.DomainEvent.updateEvent;
+import static org.folio.services.kafka.KafkaProducerServiceFactory.getKafkaProducerService;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.logging.log4j.Logger;
+import org.folio.services.kafka.topic.KafkaTopic;
+
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+
+class BaseDomainEventService<T> {
+  private static final Logger log = getLogger(BaseDomainEventService.class);
+
+  private final Context vertxContext;
+  private final Map<String, String> okapiHeaders;
+  private final KafkaTopic kafkaTopic;
+
+  BaseDomainEventService(Context vertxContext, Map<String, String> okapiHeaders,
+    KafkaTopic kafkaTopic) {
+
+    this.vertxContext = vertxContext;
+    this.okapiHeaders = okapiHeaders;
+    this.kafkaTopic = kafkaTopic;
+  }
+
+  Future<Void> recordUpdated(String instanceId, T oldRecord, T newRecord) {
+    final DomainEvent<T> domainEvent = updateEvent(oldRecord, newRecord, getTenant());
+
+    return sendMessage(instanceId, domainEvent);
+  }
+
+  Future<Void> recordCreated(String instanceId, T newRecord) {
+    final DomainEvent<T> domainEvent = createEvent(newRecord, getTenant());
+
+    return sendMessage(instanceId, domainEvent);
+  }
+
+  Future<Void> recordRemoved(String instanceId, T oldEntity) {
+    final DomainEvent<T> domainEvent = deleteEvent(oldEntity, getTenant());
+
+    return sendMessage(instanceId, domainEvent);
+  }
+
+  Future<Void> recordsRemoved(List<Pair<String, T>> records) {
+    return CompositeFuture.all(records.stream()
+      .map(record -> recordRemoved(record.getKey(), record.getValue()))
+      .collect(Collectors.toList()))
+      .map(notUsed -> null);
+  }
+
+  private Future<Void> sendMessage(String instanceId, DomainEvent<?> domainEvent) {
+    log.debug("Sending domain event [{}], payload [{}]",
+      instanceId, domainEvent);
+
+    return getKafkaProducerService(vertxContext.owner())
+      .sendMessage(instanceId, domainEvent, kafkaTopic)
+      .onComplete(result -> {
+        if (result.failed()) {
+          log.error("Unable to send domain event [{}], payload - [{}]",
+            instanceId, domainEvent, result.cause());
+        }
+      });
+  }
+
+  private String getTenant() {
+    return tenantId(okapiHeaders);
+  }
+}

--- a/src/main/java/org/folio/services/domainevent/DomainEvent.java
+++ b/src/main/java/org/folio/services/domainevent/DomainEvent.java
@@ -10,26 +10,26 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class DomainEvent {
+public class DomainEvent<T> {
   @JsonProperty("old")
-  private Object oldEntity;
+  private T oldEntity;
   @JsonProperty("new")
-  private Object newEntity;
+  private T newEntity;
   private DomainEventType type;
   private String tenant;
 
-  public DomainEvent(Object oldEntity, Object newEntity, DomainEventType type, String tenant) {
+  public DomainEvent(T oldEntity, T newEntity, DomainEventType type, String tenant) {
     this.oldEntity = oldEntity;
     this.newEntity = newEntity;
     this.type = type;
     this.tenant = tenant;
   }
 
-  public Object getOldEntity() {
+  public T getOldEntity() {
     return oldEntity;
   }
 
-  public void setOldEntity(Object oldEntity) {
+  public void setOldEntity(T oldEntity) {
     this.oldEntity = oldEntity;
   }
 
@@ -37,7 +37,7 @@ public class DomainEvent {
     return newEntity;
   }
 
-  public void setNewEntity(Object newEntity) {
+  public void setNewEntity(T newEntity) {
     this.newEntity = newEntity;
   }
 
@@ -67,15 +67,15 @@ public class DomainEvent {
       .toString();
   }
 
-  public static DomainEvent updateEvent(Object oldEntity, Object newEntity, String tenant) {
-    return new DomainEvent(oldEntity, newEntity, UPDATE, tenant);
+  public static <T> DomainEvent<T> updateEvent(T oldEntity, T newEntity, String tenant) {
+    return new DomainEvent<>(oldEntity, newEntity, UPDATE, tenant);
   }
 
-  public static DomainEvent createEvent(Object newEntity, String tenant) {
-    return new DomainEvent(null, newEntity, CREATE, tenant);
+  public static <T> DomainEvent<T> createEvent(T newEntity, String tenant) {
+    return new DomainEvent<>(null, newEntity, CREATE, tenant);
   }
 
-  public static DomainEvent deleteEvent(Object oldEntity, String tenant) {
-    return new DomainEvent(oldEntity, null, DELETE, tenant);
+  public static <T> DomainEvent<T> deleteEvent(T oldEntity, String tenant) {
+    return new DomainEvent<>(oldEntity, null, DELETE, tenant);
   }
 }

--- a/src/main/java/org/folio/services/domainevent/InstanceDomainEventService.java
+++ b/src/main/java/org/folio/services/domainevent/InstanceDomainEventService.java
@@ -1,76 +1,43 @@
 package org.folio.services.domainevent;
 
-
-import static org.apache.logging.log4j.LogManager.getLogger;
-import static org.folio.rest.tools.utils.TenantTool.tenantId;
-import static org.folio.services.domainevent.DomainEvent.createEvent;
-import static org.folio.services.domainevent.DomainEvent.deleteEvent;
-import static org.folio.services.domainevent.DomainEvent.updateEvent;
-import static org.folio.services.kafka.KafkaProducerServiceFactory.getKafkaProducerService;
 import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_INSTANCE;
 
-import java.util.Collection;
+import java.util.List;
 import java.util.Map;
-import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
 
-import org.apache.logging.log4j.Logger;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.folio.rest.jaxrs.model.Instance;
-import org.folio.services.kafka.KafkaProducerService;
 
 import io.vertx.core.Context;
-import io.vertx.core.Vertx;
+import io.vertx.core.Future;
 
 public class InstanceDomainEventService {
-  private static final Logger log = getLogger(InstanceDomainEventService.class);
+  private final BaseDomainEventService<Instance> domainEventService;
 
-  private final KafkaProducerService kafkaProducerService;
-  private final String tenant;
-
-  public InstanceDomainEventService(Vertx vertx, String tenant) {
-    this.kafkaProducerService = getKafkaProducerService(vertx);
-    this.tenant = tenant;
+  public InstanceDomainEventService(Context context, Map<String, String> okapiHeaders) {
+    domainEventService = new BaseDomainEventService<>(context, okapiHeaders,
+      INVENTORY_INSTANCE);
   }
 
-  public static InstanceDomainEventService createInstanceEventService(
-    Context context, Map<String, String> okapiHeaders) {
-
-    return new InstanceDomainEventService(context.owner(), tenantId(okapiHeaders));
+  public Future<Void> instanceUpdated(Instance oldRecord, Instance newRecord) {
+    return domainEventService.recordUpdated(oldRecord.getId(), oldRecord, newRecord);
   }
 
-  public CompletableFuture<Void> instanceUpdated(Instance oldInstance, Instance newInstance) {
-    final DomainEvent domainEvent = updateEvent(oldInstance, newInstance, tenant);
-
-    return sendMessage(oldInstance.getId(), domainEvent);
+  public Future<Void> instanceCreated(Instance newInstance) {
+    return domainEventService.recordCreated(newInstance.getId(), newInstance);
   }
 
-  public CompletableFuture<Void> instanceCreated(Instance newInstance) {
-    final DomainEvent domainEvent = createEvent(newInstance, tenant);
-
-    return sendMessage(newInstance.getId(), domainEvent);
+  public Future<Void> instanceRemoved(Instance oldEntity) {
+    return domainEventService.recordRemoved(oldEntity.getId(), oldEntity);
   }
 
-  public CompletableFuture<Void> instanceDeleted(Instance oldInstance) {
-    final DomainEvent domainEvent = deleteEvent(oldInstance, tenant);
+  public Future<Void> instancesRemoved(List<Instance> records) {
+    final List<Pair<String, Instance>> instancesWithIdsList = records.stream()
+      .map(instance -> new ImmutablePair<>(instance.getId(), instance))
+      .collect(Collectors.toList());
 
-    return sendMessage(oldInstance.getId(), domainEvent);
-  }
-
-  public CompletableFuture<Void> instancesDeleted(Collection<Instance> oldInstances) {
-    return CompletableFuture.allOf(oldInstances.stream()
-      .map(this::instanceDeleted)
-      .toArray(CompletableFuture[]::new));
-  }
-
-  private CompletableFuture<Void> sendMessage(String instanceId, DomainEvent domainEvent) {
-    log.debug("Sending domain event for instance [{}], payload [{}]",
-      instanceId, domainEvent);
-
-    return kafkaProducerService.sendMessage(instanceId, domainEvent, INVENTORY_INSTANCE)
-      .whenComplete((notUsed, error) -> {
-        if (error != null) {
-          log.error("Unable to send domain event for instance [{}], payload - [{}]",
-            instanceId, domainEvent, error);
-        }
-      });
+    return domainEventService.recordsRemoved(instancesWithIdsList);
   }
 }

--- a/src/main/java/org/folio/services/holding/HoldingsService.java
+++ b/src/main/java/org/folio/services/holding/HoldingsService.java
@@ -1,0 +1,128 @@
+package org.folio.services.holding;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static io.vertx.core.Promise.promise;
+import static java.lang.String.format;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.logging.log4j.LogManager.getLogger;
+import static org.folio.rest.impl.HoldingsStorageAPI.HOLDINGS_RECORD_TABLE;
+import static org.folio.rest.persist.PgUtil.postgresClient;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.logging.log4j.Logger;
+import org.folio.rest.exceptions.BadRequestException;
+import org.folio.rest.jaxrs.model.HoldingsRecord;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.SQLConnection;
+import org.folio.rest.support.HridManager;
+import org.folio.services.item.ItemService;
+import org.folio.services.persist.PostgresClientFuturized;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.core.Promise;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+
+public class HoldingsService {
+  private static final String WHERE_CLAUSE = "WHERE id = '%s'";
+  private static final Logger log = getLogger(HoldingsService.class);
+
+  private final PostgresClient postgresClient;
+  private final HridManager hridManager;
+  private final ItemService itemService;
+  private final PostgresClientFuturized postgresClientFuturized;
+
+  public HoldingsService(Context context, Map<String, String> okapiHeaders) {
+    itemService = new ItemService(context, okapiHeaders);
+    postgresClient = postgresClient(context, okapiHeaders);
+    hridManager = new HridManager(context, postgresClient);
+    postgresClientFuturized = new PostgresClientFuturized(postgresClient);
+  }
+
+  public Future<Void> updateHoldingRecord(String holdingId, HoldingsRecord holdingsRecord) {
+    return postgresClientFuturized.getById(HOLDINGS_RECORD_TABLE, holdingId, HoldingsRecord.class)
+      .compose(existingHoldingsRecord -> {
+        if (holdingsRecordFound(existingHoldingsRecord)) {
+          return updateHolding(existingHoldingsRecord, holdingsRecord);
+        } else {
+          return saveHolding(holdingsRecord);
+        }
+      });
+  }
+
+  private Future<Void> saveHolding(HoldingsRecord entity) {
+    final Future<String> hridFuture = isBlank(entity.getHrid())
+      ? hridManager.getNextHoldingsHrid() : succeededFuture(entity.getHrid());
+
+    return hridFuture
+      .map(entity::withHrid)
+      .compose(holdingsRecord -> postgresClientFuturized
+        .save(HOLDINGS_RECORD_TABLE, entity.getId(), entity))
+      .map(notUsed -> null);
+  }
+
+  private Future<Void> updateHolding(HoldingsRecord oldHoldings, HoldingsRecord newHoldings) {
+    return refuseIfHridChanged(oldHoldings, newHoldings)
+      .compose(notUsed -> {
+        final Promise<Void> overallResult = promise();
+
+        postgresClient.startTx(
+          connection -> updateHoldingInTransaction(connection, newHoldings)
+            .compose(updateRes -> itemService.updateItemsOnHoldingChanged(connection, newHoldings))
+            .onComplete(handleTransaction(connection, overallResult)));
+
+        return overallResult.future();
+      });
+  }
+
+  private Future<Void> updateHoldingInTransaction(
+    AsyncResult<SQLConnection> connection, HoldingsRecord entity) {
+
+    final Promise<RowSet<Row>> holdingsUpdateResult = promise();
+
+    postgresClient.update(connection, HOLDINGS_RECORD_TABLE, entity, "jsonb",
+      format(WHERE_CLAUSE, entity.getId()), false, holdingsUpdateResult);
+
+    return holdingsUpdateResult.future().map(notUsed -> null);
+  }
+
+  private Handler<AsyncResult<Void>> handleTransaction(
+    AsyncResult<SQLConnection> connection, Promise<Void> overallResult) {
+
+    return transactionResult -> {
+      if (transactionResult.succeeded()) {
+        postgresClient.endTx(connection, overallResult);
+      } else {
+        log.warn("Reverting transaction");
+        postgresClient.rollbackTx(connection, revertResult -> {
+          if (revertResult.failed()) {
+            log.warn("Unable to revert transaction", revertResult.cause());
+          }
+          overallResult.fail(transactionResult.cause());
+        });
+      }
+    };
+  }
+
+  private Future<HoldingsRecord> refuseIfHridChanged(
+    HoldingsRecord oldHolding, HoldingsRecord newHolding) {
+
+    if (Objects.equals(oldHolding.getHrid(), newHolding.getHrid())) {
+      return succeededFuture(oldHolding);
+    } else {
+      return failedFuture(new BadRequestException(format(
+        "The hrid field cannot be changed: new=%s, old=%s", newHolding.getHrid(),
+        oldHolding.getHrid())));
+    }
+  }
+
+  private boolean holdingsRecordFound(HoldingsRecord holdingsRecord) {
+    return holdingsRecord != null;
+  }
+}

--- a/src/main/java/org/folio/services/item/ItemService.java
+++ b/src/main/java/org/folio/services/item/ItemService.java
@@ -1,0 +1,220 @@
+package org.folio.services.item;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static io.vertx.core.Promise.promise;
+import static java.lang.String.format;
+import static java.util.Collections.emptyMap;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.logging.log4j.LogManager.getLogger;
+import static org.folio.rest.impl.HoldingsStorageAPI.ITEM_TABLE;
+import static org.folio.rest.impl.StorageHelper.MAX_ENTITIES;
+import static org.folio.rest.jaxrs.resource.ItemStorage.DeleteItemStorageItemsByItemIdResponse;
+import static org.folio.rest.jaxrs.resource.ItemStorage.PostItemStorageItemsResponse;
+import static org.folio.rest.jaxrs.resource.ItemStorage.PutItemStorageItemsByItemIdResponse;
+import static org.folio.rest.jaxrs.resource.ItemStorageBatchSynchronous.PostItemStorageBatchSynchronousResponse;
+import static org.folio.rest.persist.PgUtil.deleteById;
+import static org.folio.rest.persist.PgUtil.post;
+import static org.folio.rest.persist.PgUtil.postSync;
+import static org.folio.rest.persist.PgUtil.postgresClient;
+import static org.folio.rest.persist.PgUtil.put;
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.logging.log4j.Logger;
+import org.folio.rest.exceptions.BadRequestException;
+import org.folio.rest.jaxrs.model.HoldingsRecord;
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.SQLConnection;
+import org.folio.rest.support.EffectiveCallNumberComponentsUtil;
+import org.folio.rest.support.HridManager;
+import org.folio.rest.support.ItemEffectiveLocationUtil;
+import org.folio.services.ItemEffectiveValuesService;
+import org.folio.services.item.effectivevalues.ItemWithHolding;
+import org.folio.services.persist.PostgresClientFuturized;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.CompositeFuture;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+
+public class ItemService {
+  private static final Logger log = getLogger(ItemService.class);
+  private static final String WHERE_CLAUSE = "WHERE id = '%s'";
+
+  private final PostgresClient postgresClient;
+  private final HridManager hridManager;
+  private final ItemEffectiveValuesService effectiveValuesService;
+  private final Context vertxContext;
+  private final Map<String, String> okapiHeaders;
+  private final PostgresClientFuturized postgresClientFuturized;
+
+  public ItemService(Context vertxContext, Map<String, String> okapiHeaders) {
+    this.vertxContext = vertxContext;
+    this.okapiHeaders = okapiHeaders;
+    postgresClient = postgresClient(vertxContext, okapiHeaders);
+    hridManager = new HridManager(vertxContext, postgresClient);
+    effectiveValuesService = new ItemEffectiveValuesService(postgresClient);
+    postgresClientFuturized = new PostgresClientFuturized(postgresClient);
+  }
+
+  public Future<Response> createItem(Item entity) {
+    entity.getStatus().setDate(new Date());
+
+    return getHrid(entity).map(entity::withHrid)
+      .compose(effectiveValuesService::populateEffectiveValues)
+      .compose(itemWithHolding -> {
+        final Promise<Response> postResponse = promise();
+
+        post(ITEM_TABLE, itemWithHolding.getItem(), okapiHeaders, vertxContext,
+          PostItemStorageItemsResponse.class, postResponse);
+
+        return postResponse.future();
+      });
+  }
+
+  public Future<Response> createItems(List<Item> items, boolean upsert) {
+    final Date itemStatusDate = new java.util.Date();
+
+    @SuppressWarnings("all")
+    final List<Future> setHridFutures = items.stream()
+      .map(item -> {
+        item.getStatus().setDate(itemStatusDate);
+        return getHrid(item).map(item::withHrid);
+      }).collect(Collectors.toList());
+
+    final Set<String> itemIds = items.stream()
+      .map(Item::getId)
+      .collect(Collectors.toSet());
+
+    return CompositeFuture.all(setHridFutures)
+      .compose(result -> effectiveValuesService.populateEffectiveValues(items))
+      .compose(itemWithHoldings -> {
+        if (!upsert) {
+          return succeededFuture(new ImmutablePair<>(itemWithHoldings, emptyMap()));
+        }
+
+        return postgresClientFuturized.getById(ITEM_TABLE, itemIds, Item.class)
+          .map(existingItems -> new ImmutablePair<>(itemWithHoldings, existingItems));
+      }).compose(pair -> {
+        // Used for logging now, will be updated soon to send domain events.
+        log.info("Items that will be updated - {} ", pair.getRight().keySet());
+
+        final Promise<Response> postSyncResult = promise();
+
+        postSync(ITEM_TABLE, items, MAX_ENTITIES, upsert, okapiHeaders, vertxContext,
+          PostItemStorageBatchSynchronousResponse.class, postSyncResult);
+
+        return postSyncResult.future();
+      });
+  }
+
+  public Future<Response> updateItem(String itemId, Item newItem) {
+    return postgresClientFuturized.getById(ITEM_TABLE, itemId, Item.class)
+      .compose(oldItem -> refuseWhenHridChanged(oldItem, newItem))
+      .compose(oldItem -> effectiveValuesService.populateEffectiveValues(newItem)
+        .compose(itemWithHolding -> {
+          final Promise<Response> putResult = promise();
+
+          put(ITEM_TABLE, newItem, itemId, okapiHeaders, vertxContext,
+            PutItemStorageItemsByItemIdResponse.class, putResult);
+
+          return putResult.future();
+        }));
+  }
+
+  public Future<Response> deleteItem(String itemId) {
+    return postgresClientFuturized.getById(ITEM_TABLE, itemId, Item.class)
+      .compose(item -> {
+        final Promise<Response> deleteResult = promise();
+        deleteById(ITEM_TABLE, itemId, okapiHeaders, vertxContext,
+          DeleteItemStorageItemsByItemIdResponse.class, deleteResult);
+
+        return deleteResult.future();
+      });
+  }
+
+  public Future<Void> deleteAllItems() {
+    final String removeAllQuery = format("DELETE FROM %s_mod_inventory_storage.item",
+      tenantId(okapiHeaders));
+
+    return postgresClientFuturized.get(ITEM_TABLE, new Item())
+      .compose(allItems -> postgresClientFuturized.execute(removeAllQuery))
+      .map(notUsed -> null);
+  }
+
+  public Future<Void> updateItemsOnHoldingChanged(AsyncResult<SQLConnection> connection,
+    HoldingsRecord holdingsRecord) {
+
+    final Item sample = new Item().withHoldingsRecordId(holdingsRecord.getId());
+    return postgresClientFuturized.get(ITEM_TABLE, sample)
+      .compose(items -> updateEffectiveCallNumbersAndLocation(connection, items, holdingsRecord))
+      .map(notUsed -> null);
+  }
+
+  private Future<RowSet<Row>> updateEffectiveCallNumbersAndLocation(
+    AsyncResult<SQLConnection> connectionResult, List<Item> items, HoldingsRecord holdingsRecord) {
+
+    final Promise<RowSet<Row>> allItemsUpdated = promise();
+    final List<Function<SQLConnection, Future<RowSet<Row>>>> batchFactories = items.stream()
+      .map(item -> new ItemWithHolding(item, holdingsRecord))
+      .map(EffectiveCallNumberComponentsUtil::setCallNumberComponents)
+      .map(ItemEffectiveLocationUtil::updateItemEffectiveLocation)
+      .map(itemWithHolding -> updateSingleItemBatchFactory(itemWithHolding.getItemId(),
+        itemWithHolding.getItem()))
+      .collect(Collectors.toList());
+
+    final SQLConnection connection = connectionResult.result();
+    Future<RowSet<Row>> lastUpdate = succeededFuture();
+    for (Function<SQLConnection, Future<RowSet<Row>>> factory : batchFactories) {
+      lastUpdate = lastUpdate.compose(prev -> factory.apply(connection));
+    }
+
+    lastUpdate.onComplete(allItemsUpdated);
+    return allItemsUpdated.future();
+  }
+
+  private <T> Function<SQLConnection, Future<RowSet<Row>>> updateSingleItemBatchFactory(
+    String id, T entity) {
+
+    return connection -> {
+      final Promise<RowSet<Row>> updateResultFuture = promise();
+      final Future<SQLConnection> connectionResult = succeededFuture(connection);
+
+      postgresClient.update(connectionResult, ITEM_TABLE, entity, "jsonb",
+        format(WHERE_CLAUSE, id), false, updateResultFuture);
+
+      return updateResultFuture.future();
+    };
+  }
+
+  private Future<Item> refuseWhenHridChanged(Item oldItem, Item newItem) {
+    if (Objects.equals(newItem.getHrid(), oldItem.getHrid())) {
+      return succeededFuture(oldItem);
+    } else {
+      log.warn("HRID has been changed for item {}", oldItem.getId());
+      return failedFuture(new BadRequestException(format(
+        "The hrid field cannot be changed: new=%s, old=%s", newItem.getHrid(),
+        oldItem.getHrid())));
+    }
+  }
+
+  private Future<String> getHrid(Item entity) {
+    return isBlank(entity.getHrid())
+      ? hridManager.getNextItemHrid() : succeededFuture(entity.getHrid());
+  }
+}

--- a/src/main/java/org/folio/services/item/effectivevalues/ItemWithHolding.java
+++ b/src/main/java/org/folio/services/item/effectivevalues/ItemWithHolding.java
@@ -1,0 +1,39 @@
+package org.folio.services.item.effectivevalues;
+
+import org.folio.rest.jaxrs.model.EffectiveCallNumberComponents;
+import org.folio.rest.jaxrs.model.HoldingsRecord;
+import org.folio.rest.jaxrs.model.Item;
+
+public final class ItemWithHolding {
+  private final Item item;
+  private final HoldingsRecord holdingsRecord;
+
+  public ItemWithHolding(Item item, HoldingsRecord holdingsRecord) {
+    this.item = item;
+    this.holdingsRecord = holdingsRecord;
+  }
+
+  public ItemWithHolding withEffectiveCallNumberComponents(EffectiveCallNumberComponents components) {
+    return withItem(item.withEffectiveCallNumberComponents(components));
+  }
+
+  public String getItemId() {
+    return item.getId();
+  }
+
+  public String getInstanceId() {
+    return holdingsRecord.getInstanceId();
+  }
+
+  public Item getItem() {
+    return this.item;
+  }
+
+  public HoldingsRecord getHoldingsRecord() {
+    return this.holdingsRecord;
+  }
+
+  public ItemWithHolding withItem(Item item) {
+    return new ItemWithHolding(item, this.holdingsRecord);
+  }
+}

--- a/src/main/java/org/folio/services/kafka/KafkaProducerService.java
+++ b/src/main/java/org/folio/services/kafka/KafkaProducerService.java
@@ -1,15 +1,16 @@
 package org.folio.services.kafka;
 
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Promise.promise;
 import static io.vertx.kafka.client.producer.KafkaProducerRecord.create;
 import static org.folio.dbschema.ObjectMapperTool.getMapper;
-import static org.folio.rest.support.CompletableFutureUtil.mapFutureResultToJavaFuture;
-
-import java.util.concurrent.CompletableFuture;
 
 import org.folio.services.kafka.topic.KafkaTopic;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import io.vertx.kafka.client.producer.RecordMetadata;
@@ -24,21 +25,21 @@ public class KafkaProducerService {
   /**
    * @throws IllegalArgumentException if unable to serialize the value to string.
    */
-  public CompletableFuture<Void> sendMessage(String entityId, Object value, KafkaTopic kafkaTopic) {
+  public Future<Void> sendMessage(String entityId, Object value, KafkaTopic kafkaTopic) {
     try {
       final String payload = getMapper().writeValueAsString(value);
       return sendMessage(entityId, payload, kafkaTopic.getTopicName());
     } catch (JsonProcessingException ex) {
-      throw new IllegalArgumentException("Unable to deserialize message", ex);
+      return failedFuture(new IllegalArgumentException("Unable to deserialize message", ex));
     }
   }
 
-  public CompletableFuture<Void> sendMessage(String key, String value, String topic) {
-    final CompletableFuture<RecordMetadata> result = new CompletableFuture<>();
+  public Future<Void> sendMessage(String key, String value, String topic) {
+    final Promise<RecordMetadata> result = promise();
     final KafkaProducerRecord<String, String> kafkaRecord = create(topic, key, value);
 
-    kafkaProducer.send(kafkaRecord, mapFutureResultToJavaFuture(result));
+    kafkaProducer.send(kafkaRecord, result);
 
-    return result.thenApply(rm -> null);
+    return result.future().map(notUsed -> null);
   }
 }

--- a/src/main/java/org/folio/services/persist/PostgresClientFuturized.java
+++ b/src/main/java/org/folio/services/persist/PostgresClientFuturized.java
@@ -1,0 +1,64 @@
+package org.folio.services.persist;
+
+import static io.vertx.core.Promise.promise;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.interfaces.Results;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+
+public class PostgresClientFuturized {
+  private final PostgresClient postgresClient;
+
+  public PostgresClientFuturized(PostgresClient postgresClient) {
+    this.postgresClient = postgresClient;
+  }
+
+  public <T> Future<String> save(String table, String id, T entity) {
+    final Promise<String> saveResult = promise();
+    postgresClient.save(table, id, entity, saveResult);
+
+    return saveResult.future();
+  }
+
+  public <T> Future<T> getById(String tableName, String id, Class<T> type) {
+    final Promise<T> getByIdResult = promise();
+
+    postgresClient.getById(tableName, id, type, getByIdResult);
+
+    return getByIdResult.future();
+  }
+
+  public <T> Future<List<T>> get(String tableName, T sample) {
+    final Promise<Results<T>> getAllItemsResult = promise();
+
+    postgresClient.get(tableName, sample, false, getAllItemsResult);
+
+    return getAllItemsResult.future().map(Results::getResults);
+  }
+
+  public Future<RowSet<Row>> execute(String query) {
+    final Promise<RowSet<Row>> removeAllResult = promise();
+
+    postgresClient.execute(query, removeAllResult);
+
+    return removeAllResult.future();
+  }
+
+  public <T> Future<Map<String, T>> getById(String tableName, Collection<String> ids, Class<T> type) {
+    final Promise<Map<String, T>> promise = promise();
+
+    postgresClient.getById(tableName, new JsonArray(new ArrayList<>(ids)), type, promise);
+
+    return promise.future();
+  }
+}

--- a/src/main/java/org/folio/services/persist/PostgresClientFuturized.java
+++ b/src/main/java/org/folio/services/persist/PostgresClientFuturized.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.interfaces.Results;
 
@@ -38,12 +39,20 @@ public class PostgresClientFuturized {
     return getByIdResult.future();
   }
 
-  public <T> Future<List<T>> get(String tableName, T sample) {
+  public <T> Future<List<T>> get(String tableName, T object) {
     final Promise<Results<T>> getAllItemsResult = promise();
 
-    postgresClient.get(tableName, sample, false, getAllItemsResult);
+    postgresClient.get(tableName, object, false, getAllItemsResult);
 
     return getAllItemsResult.future().map(Results::getResults);
+  }
+
+  public <T> Future<List<T>> get(String tableName, Class<T> type, Criterion criterion) {
+    final Promise<Results<T>> getItemsResult = promise();
+
+    postgresClient.get(tableName, type, criterion, false, getItemsResult);
+
+    return getItemsResult.future().map(Results::getResults);
   }
 
   public Future<RowSet<Row>> execute(String query) {

--- a/src/test/java/org/folio/services/kafka/KafkaProducerServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/KafkaProducerServiceTest.java
@@ -4,6 +4,7 @@ import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_INSTANCE;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
 import org.junit.Test;
@@ -16,7 +17,7 @@ public class KafkaProducerServiceTest {
   public void canThrowJacksonExceptionWhenCannotParseObject(){
     final var producer = new KafkaProducerService(mock(KafkaProducer.class));
 
-    assertThrows("Unable to deserialize message", IllegalArgumentException.class,
+    assertThrows("Unable to deserialize message", ExecutionException.class,
       () -> producer.sendMessage("id", new Object(), INVENTORY_INSTANCE)
       .toCompletionStage().toCompletableFuture().get(1, TimeUnit.SECONDS));
   }

--- a/src/test/java/org/folio/services/kafka/KafkaProducerServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/KafkaProducerServiceTest.java
@@ -18,6 +18,6 @@ public class KafkaProducerServiceTest {
 
     assertThrows("Unable to deserialize message", IllegalArgumentException.class,
       () -> producer.sendMessage("id", new Object(), INVENTORY_INSTANCE)
-      .get(1, TimeUnit.SECONDS));
+      .toCompletionStage().toCompletableFuture().get(1, TimeUnit.SECONDS));
   }
 }


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-647 - Refactor ItemStorageAPI and HoldingsStorageAPI before implementing domain events.

### Changes:
* Always retrieve holdings record for item on create or update (was if required - it is now required for domain events to set instance id)- see [ItemEffectiveValuesService](https://github.com/folio-org/mod-inventory-storage/pull/561/files#diff-e47d87f2ed99e78767a00a57c7f2f46c76b05dc951615c9fbf76e7b374241d82)
* Use chaining for item storage create/update/delete methods to reduce amount of callbacks and move the logic to a [service](https://github.com/folio-org/mod-inventory-storage/pull/561/files#diff-78dff0242682c91208ab3b3ce644115ee6d3cb522c0697639db65927241547fe) class;
* Use chaining for holding storage update methods to reduce method complexity and move the logic to a [service](https://github.com/folio-org/mod-inventory-storage/pull/561/files#diff-78dff0242682c91208ab3b3ce644115ee6d3cb522c0697639db65927241547fe) class;
* Implement a universal method failure [handler](https://github.com/folio-org/mod-inventory-storage/pull/561/files#diff-8165ed6658b51988a2fecb167e2c8ffcabef28ea476571d35ccb5198953b93f0R52);
* Move some reusable logic from `InstanceDomainEventService` into a [base](https://github.com/folio-org/mod-inventory-storage/pull/561/files#diff-45002c1862725beb32f1ce3800bb9c15554a2438e5ef00b0f8e70ad62c791fe2) class;
* Introduce [`PostgresClientFuturized`](https://github.com/folio-org/mod-inventory-storage/pull/561/files#diff-812193d5f52200c22cd3ea57b333a085ae71a4f8eadfb70b4a39a8842c202fc2) class - that delegates the logic to the postgres client but returns a Future instead using a callback. 