### PR TITLE
MODINVSTOR-657 Add limit query param to /instance-bulk/ids endpoint

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,6 +131,11 @@
       <version>1.19.0</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <version>2.6.0</version>
+    </dependency>
   </dependencies>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -131,11 +131,6 @@
       <version>1.19.0</version>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.kafka</groupId>
-      <artifactId>kafka-clients</artifactId>
-      <version>2.6.0</version>
-    </dependency>
   </dependencies>
 
   <properties>

--- a/ramls/record-bulk.raml
+++ b/ramls/record-bulk.raml
@@ -17,6 +17,7 @@ traits:
   orderable: !include raml-util/traits/orderable.raml
   searchable: !include raml-util/traits/searchable.raml
   validate: !include raml-util/traits/validation.raml
+  pageable: !include raml-util/traits/pageable.raml
 
 resourceTypes:
   collection-get: !include raml-util/rtypes/collection-get.raml
@@ -32,7 +33,8 @@ resourceTypes:
       description: Retrieve a list of record IDs.
       is: [
         searchable: {description: "with valid searchable fields", example: "name=aaa"},
-        validate
+        validate,
+        pageable
       ]
       queryParameters:
         field:

--- a/ramls/record-bulk.raml
+++ b/ramls/record-bulk.raml
@@ -49,3 +49,5 @@ resourceTypes:
           enum: [INSTANCE, HOLDING]
           default: INSTANCE
           required: false
+        limit:
+          default: 2147483647

--- a/src/main/java/org/folio/rest/impl/RecordBulkAPI.java
+++ b/src/main/java/org/folio/rest/impl/RecordBulkAPI.java
@@ -1,9 +1,10 @@
 package org.folio.rest.impl;
 
-import java.util.Map;
-
-import javax.ws.rs.core.Response;
-
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import io.vertx.ext.web.RoutingContext;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.CQL2PgJSON;
@@ -15,11 +16,8 @@ import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.support.RecordID;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.ext.web.RoutingContext;
+import javax.ws.rs.core.Response;
+import java.util.Map;
 
 public class RecordBulkAPI implements org.folio.rest.jaxrs.resource.RecordBulk {
   public static final String INSTANCE_TABLE = "instance";
@@ -28,33 +26,31 @@ public class RecordBulkAPI implements org.folio.rest.jaxrs.resource.RecordBulk {
 
   private static final Logger LOG = LogManager.getLogger();
 
-  private CQLWrapper getCQL(String query, String table) throws FieldException {
+  private CQLWrapper getCQL(String query, String table, int limit, int offset) throws FieldException {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON(table + ".jsonb");
     return new CQLWrapper(cql2pgJson, query);
   }
 
   @Validate
   @Override
-  public void getRecordBulkIds(RecordBulkIdsGetField field,
-        RecordBulkIdsGetRecordType recordType, String query, String lang,
-        RoutingContext routingContext, Map<String, String> okapiHeaders,
-        Handler<AsyncResult<Response>> asyncResultHandler,
-        Context vertxContext) {
-
-    try {
-      if (recordType.toString().equalsIgnoreCase(HOLDING_TYPE)) {
-        CQLWrapper wrapper = getCQL(query, HOLDING_TABLE);
-        PgUtil.streamGet(HOLDING_TABLE, RecordID.class, wrapper, null,
-          "ids", routingContext, okapiHeaders, vertxContext);
-      } else {
-        CQLWrapper wrapper = getCQL(query, INSTANCE_TABLE);
-        PgUtil.streamGet(INSTANCE_TABLE, RecordID.class, wrapper, null,
-          "ids", routingContext, okapiHeaders, vertxContext);
+  public void getRecordBulkIds(RecordBulkIdsGetField field, RecordBulkIdsGetRecordType recordType, String query,
+                               int offset, int limit, String lang, RoutingContext routingContext,
+                               Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+                               Context vertxContext) {
+      try {
+        if (recordType.toString().equalsIgnoreCase(HOLDING_TYPE)) {
+          CQLWrapper wrapper = getCQL(query, HOLDING_TABLE, limit, offset);
+          PgUtil.streamGet(HOLDING_TABLE, RecordID.class, wrapper, null,
+            "ids", routingContext, okapiHeaders, vertxContext);
+        } else {
+          CQLWrapper wrapper = getCQL(query, INSTANCE_TABLE, limit, offset);
+          PgUtil.streamGet(INSTANCE_TABLE, RecordID.class, wrapper, null,
+            "ids", routingContext, okapiHeaders, vertxContext);
+        }
+      } catch (Exception e) {
+        LOG.error(e.getMessage(), e);
+        asyncResultHandler.handle(Future.succeededFuture(GetRecordBulkIdsResponse
+          .respond500WithTextPlain(e.getMessage())));
       }
-    } catch (Exception e) {
-      LOG.error(e.getMessage(), e);
-      asyncResultHandler.handle(Future.succeededFuture(GetRecordBulkIdsResponse
-        .respond500WithTextPlain(e.getMessage())));
-    }
   }
 }

--- a/src/main/java/org/folio/rest/impl/RecordBulkAPI.java
+++ b/src/main/java/org/folio/rest/impl/RecordBulkAPI.java
@@ -12,6 +12,8 @@ import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.RecordBulkIdsGetField;
 import org.folio.rest.jaxrs.model.RecordBulkIdsGetRecordType;
+import org.folio.rest.persist.Criteria.Limit;
+import org.folio.rest.persist.Criteria.Offset;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.cql.CQLWrapper;
 import org.folio.rest.support.RecordID;
@@ -28,29 +30,33 @@ public class RecordBulkAPI implements org.folio.rest.jaxrs.resource.RecordBulk {
 
   private CQLWrapper getCQL(String query, String table, int limit, int offset) throws FieldException {
     CQL2PgJSON cql2pgJson = new CQL2PgJSON(table + ".jsonb");
-    return new CQLWrapper(cql2pgJson, query);
+    return new CQLWrapper(cql2pgJson, query)
+      .setLimit(new Limit(limit))
+      .setOffset(new Offset(offset));
   }
 
   @Validate
   @Override
-  public void getRecordBulkIds(RecordBulkIdsGetField field, RecordBulkIdsGetRecordType recordType, String query,
-                               int offset, int limit, String lang, RoutingContext routingContext,
-                               Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
-                               Context vertxContext) {
-      try {
-        if (recordType.toString().equalsIgnoreCase(HOLDING_TYPE)) {
-          CQLWrapper wrapper = getCQL(query, HOLDING_TABLE, limit, offset);
-          PgUtil.streamGet(HOLDING_TABLE, RecordID.class, wrapper, null,
-            "ids", routingContext, okapiHeaders, vertxContext);
-        } else {
-          CQLWrapper wrapper = getCQL(query, INSTANCE_TABLE, limit, offset);
-          PgUtil.streamGet(INSTANCE_TABLE, RecordID.class, wrapper, null,
-            "ids", routingContext, okapiHeaders, vertxContext);
-        }
-      } catch (Exception e) {
-        LOG.error(e.getMessage(), e);
-        asyncResultHandler.handle(Future.succeededFuture(GetRecordBulkIdsResponse
-          .respond500WithTextPlain(e.getMessage())));
+  public void getRecordBulkIds(RecordBulkIdsGetField field,
+        RecordBulkIdsGetRecordType recordType, String query, int offset,
+        int limit, String lang, RoutingContext routingContext,
+        Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+        Context vertxContext) {
+
+    try {
+      if (recordType.toString().equalsIgnoreCase(HOLDING_TYPE)) {
+        CQLWrapper wrapper = getCQL(query, HOLDING_TABLE, limit, offset);
+        PgUtil.streamGet(HOLDING_TABLE, RecordID.class, wrapper, null,
+          "ids", routingContext, okapiHeaders, vertxContext);
+      } else {
+        CQLWrapper wrapper = getCQL(query, INSTANCE_TABLE, limit, offset);
+        PgUtil.streamGet(INSTANCE_TABLE, RecordID.class, wrapper, null,
+          "ids", routingContext, okapiHeaders, vertxContext);
       }
+    } catch (Exception e) {
+      LOG.error(e.getMessage(), e);
+      asyncResultHandler.handle(Future.succeededFuture(GetRecordBulkIdsResponse
+        .respond500WithTextPlain(e.getMessage())));
+    }
   }
 }

--- a/src/main/java/org/folio/rest/impl/RecordBulkAPI.java
+++ b/src/main/java/org/folio/rest/impl/RecordBulkAPI.java
@@ -42,7 +42,6 @@ public class RecordBulkAPI implements org.folio.rest.jaxrs.resource.RecordBulk {
         int offset, String lang, RoutingContext routingContext,
         Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
         Context vertxContext) {
-
     try {
       if (recordType.toString().equalsIgnoreCase(HOLDING_TYPE)) {
         CQLWrapper wrapper = getCQL(query, HOLDING_TABLE, limit, offset);

--- a/src/main/java/org/folio/rest/impl/RecordBulkAPI.java
+++ b/src/main/java/org/folio/rest/impl/RecordBulkAPI.java
@@ -38,8 +38,8 @@ public class RecordBulkAPI implements org.folio.rest.jaxrs.resource.RecordBulk {
   @Validate
   @Override
   public void getRecordBulkIds(RecordBulkIdsGetField field,
-        RecordBulkIdsGetRecordType recordType, String query, int offset,
-        int limit, String lang, RoutingContext routingContext,
+        RecordBulkIdsGetRecordType recordType, int limit, String query,
+        int offset, String lang, RoutingContext routingContext,
         Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
         Context vertxContext) {
 

--- a/src/test/java/org/folio/rest/api/RecordBulkTest.java
+++ b/src/test/java/org/folio/rest/api/RecordBulkTest.java
@@ -94,6 +94,28 @@ public class RecordBulkTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  public void canGetInstanceBulkOfIdWithLimitAndOffset()
+    throws MalformedURLException,
+    InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    int totalMoons = 20;
+    int expectedMatches = totalMoons;
+    Map<String, JsonObject> moons = manyMoons(totalMoons,
+      RecordBulkIdsGetField.ID);
+    createManyMoons(moons);
+
+    CompletableFuture<Response> getCompleted = new CompletableFuture<>();
+    URL getInstanceUrl = recordBulkUrl("/ids?type=idlimit=20&offset=10");
+
+    client.get(getInstanceUrl, TENANT_ID, json(getCompleted));
+
+    Response response = getCompleted.get(5, SECONDS);
+    validateMoonsResponse(response, expectedMatches, moons);
+  }
+
+  @Test
   public void canGetInstanceBulkOfIdWithQueryExact()
       throws MalformedURLException,
       InterruptedException,
@@ -174,6 +196,25 @@ public class RecordBulkTest extends TestBaseWithInventoryUtil {
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
     URL getInstanceUrl = recordBulkUrl("/ids?recordType=HOLDING");
+
+    client.get(getInstanceUrl, TENANT_ID, json(getCompleted));
+
+    Response response = getCompleted.get(5, SECONDS);
+    validateHoldingsResponse(response, holdingIds, totalHoldingsIds);
+  }
+
+  @Test
+  public void canGetHoldingsBulkOfIdWithLimitAndOffset()
+    throws MalformedURLException,
+    InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    int totalHoldingsIds = 20;
+    List<String> holdingIds = createAndGetHoldingsIds(totalHoldingsIds);
+
+    CompletableFuture<Response> getCompleted = new CompletableFuture<>();
+    URL getInstanceUrl = recordBulkUrl("/ids?recordType=HOLDING&limit=20&offset=10");
 
     client.get(getInstanceUrl, TENANT_ID, json(getCompleted));
 

--- a/src/test/java/org/folio/rest/api/RecordBulkTest.java
+++ b/src/test/java/org/folio/rest/api/RecordBulkTest.java
@@ -214,7 +214,7 @@ public class RecordBulkTest extends TestBaseWithInventoryUtil {
     List<String> holdingIds = createAndGetHoldingsIds(totalHoldingsIds);
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
-    URL getInstanceUrl = recordBulkUrl("/ids?recordType=HOLDING&limit=20&offset=10");
+    URL getInstanceUrl = recordBulkUrl("/ids?recordType=HOLDING");
 
     client.get(getInstanceUrl, TENANT_ID, json(getCompleted));
 

--- a/src/test/java/org/folio/rest/api/RecordBulkTest.java
+++ b/src/test/java/org/folio/rest/api/RecordBulkTest.java
@@ -90,7 +90,7 @@ public class RecordBulkTest extends TestBaseWithInventoryUtil {
     client.get(getInstanceUrl, TENANT_ID, json(getCompleted));
 
     Response response = getCompleted.get(5, SECONDS);
-    validateMoonsResponseWithTotal(response, 5, moons);
+    validateMoonsResponseWithTotal(response, expectedMatches, moons);
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/RecordBulkTest.java
+++ b/src/test/java/org/folio/rest/api/RecordBulkTest.java
@@ -219,7 +219,7 @@ public class RecordBulkTest extends TestBaseWithInventoryUtil {
     client.get(getInstanceUrl, TENANT_ID, json(getCompleted));
 
     Response response = getCompleted.get(5, SECONDS);
-    validateHoldingsResponse(response, holdingIds.subList(0, 5), 5);
+    validateHoldingsResponse(response, holdingIds, 5);
   }
 
   private void validateMoonsResponseWithTotal(Response response, int expectedMatches,

--- a/src/test/java/org/folio/rest/api/RecordBulkTest.java
+++ b/src/test/java/org/folio/rest/api/RecordBulkTest.java
@@ -107,7 +107,7 @@ public class RecordBulkTest extends TestBaseWithInventoryUtil {
     createManyMoons(moons);
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
-    URL getInstanceUrl = recordBulkUrl("/ids?type=idlimit=20&offset=10");
+    URL getInstanceUrl = recordBulkUrl("/ids?type=id&limit=20&offset=0");
 
     client.get(getInstanceUrl, TENANT_ID, json(getCompleted));
 
@@ -152,7 +152,7 @@ public class RecordBulkTest extends TestBaseWithInventoryUtil {
     createManyMoons(moons);
 
     String query = urlEncode("keyword all \"Moon #1*\"");
-    URL getInstanceUrl = recordBulkUrl("/ids?type=id&query=" + query);
+    URL getInstanceUrl = recordBulkUrl("/ids?type=id&limit=20&offset=0&query=" + query);
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
     client.get(getInstanceUrl, TENANT_ID, json(getCompleted));
@@ -214,7 +214,7 @@ public class RecordBulkTest extends TestBaseWithInventoryUtil {
     List<String> holdingIds = createAndGetHoldingsIds(totalHoldingsIds);
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
-    URL getInstanceUrl = recordBulkUrl("/ids?recordType=HOLDING");
+    URL getInstanceUrl = recordBulkUrl("/ids?recordType=HOLDING&limit=20&offset=0");
 
     client.get(getInstanceUrl, TENANT_ID, json(getCompleted));
 


### PR DESCRIPTION
Moved ticket to mod-inventory-storage project https://issues.folio.org/browse/MODINVSTOR-657

## Approach
Add offset&&limit query params to /instance-bulk/ids endpoint
Update RecordBulkAPI class and unit tests
## Important to know
If the request contains offset&&limit query params then the response will contain the incorrect value of "totalRecords" that doesn't correspond to the actual amount of records in JSON. It happens because of the wrong building count query without limit and offset in PostgresClient.buildQueryHelper method. At the same time, the same method builds select query with limit and offset.  