### PR TITLE
MODINVSTOR-644: Send domain events on instance batch create/upsert 

### DIFF
--- a/src/main/java/org/folio/persist/InstanceRepository.java
+++ b/src/main/java/org/folio/persist/InstanceRepository.java
@@ -1,0 +1,17 @@
+package org.folio.persist;
+
+import static org.folio.rest.impl.InstanceStorageAPI.INSTANCE_TABLE;
+import static org.folio.rest.persist.PgUtil.postgresClient;
+
+import java.util.Map;
+
+import org.folio.rest.jaxrs.model.Instance;
+
+import io.vertx.core.Context;
+
+public class InstanceRepository extends AbstractRepository<Instance> {
+
+  public InstanceRepository(Context context, Map<String, String> okapiHeaders) {
+    super(postgresClient(context, okapiHeaders), INSTANCE_TABLE, Instance.class);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/InstanceBatchSyncAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceBatchSyncAPI.java
@@ -1,75 +1,31 @@
 package org.folio.rest.impl;
 
-import static org.apache.commons.lang3.StringUtils.isBlank;
-import static org.folio.rest.support.StatusUpdatedDateGenerator.generateStatusUpdatedDate;
+import static io.vertx.core.Future.succeededFuture;
 
-import io.vertx.core.AsyncResult;
-import io.vertx.core.CompositeFuture;
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Handler;
-import io.vertx.core.Vertx;
-
-import org.folio.rest.annotations.Validate;
-import org.folio.rest.jaxrs.model.Instance;
-import org.folio.rest.jaxrs.model.InstancesPost;
-import org.folio.rest.jaxrs.resource.InstanceStorageBatchSynchronous;
-import org.folio.rest.persist.PgUtil;
-import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.support.HridManager;
-import org.folio.rest.tools.utils.TenantTool;
+import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.InstancesPost;
+import org.folio.rest.jaxrs.resource.InstanceStorageBatchSynchronous;
+import org.folio.services.instance.InstanceService;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
 
 public class InstanceBatchSyncAPI implements InstanceStorageBatchSynchronous {
   @Validate
   @Override
   public void postInstanceStorageBatchSynchronous(boolean upsert, InstancesPost entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    final List<Instance> instances = entity.getInstances();
-    final PostgresClient postgresClient = PostgresClient.getInstance(
-          vertxContext.owner(), TenantTool.tenantId(okapiHeaders));
-    // Currently, there is no method on CompositeFuture to accept List<Future<String>>
-    @SuppressWarnings("rawtypes")
-    final List<Future> futures = new ArrayList<>();
-    final HridManager hridManager = new HridManager(Vertx.currentContext(), postgresClient);
 
-    final String statusUpdatedDate = generateStatusUpdatedDate();
-    for (Instance instance : instances) {
-      futures.add(setHrid(instance, hridManager));
-      instance.setStatusUpdatedDate(statusUpdatedDate);
-    }
-
-    CompositeFuture.all(futures)
-    .onSuccess(ar -> {
-      PgUtil.postSync(InstanceStorageAPI.INSTANCE_TABLE, entity.getInstances(),
-          StorageHelper.MAX_ENTITIES, upsert, okapiHeaders, vertxContext,
-          InstanceStorageBatchSynchronous.PostInstanceStorageBatchSynchronousResponse.class,
-          asyncResultHandler);
-    })
-    .onFailure(cause -> {
-      asyncResultHandler.handle(
-          Future.succeededFuture(PostInstanceStorageBatchSynchronousResponse
-              .respond500WithTextPlain(cause.getMessage())));
-    });
-  }
-
-  private Future<Void> setHrid(Instance instance, HridManager hridManager) {
-    final Future<String> hridFuture;
-
-    if (isBlank(instance.getHrid())) {
-      hridFuture = hridManager.getNextInstanceHrid();
-    } else {
-      hridFuture = Future.succeededFuture(instance.getHrid());
-    }
-
-    return hridFuture.map(hrid -> {
-      instance.setHrid(hrid);
-      return null;
-    });
+    new InstanceService(vertxContext, okapiHeaders).createInstances(
+      entity.getInstances(), upsert)
+      .onSuccess(response -> asyncResultHandler.handle(succeededFuture(response)))
+      .onFailure(cause -> asyncResultHandler.handle(succeededFuture(
+        PostInstanceStorageBatchSynchronousResponse.respond500WithTextPlain(
+          cause.getMessage()))));
   }
 }

--- a/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
@@ -1,22 +1,37 @@
 package org.folio.services.domainevent;
 
+import static io.vertx.core.Future.succeededFuture;
+import static org.apache.logging.log4j.LogManager.getLogger;
+import static org.folio.rest.support.ResponseUtil.isCreateSuccessResponse;
 import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_INSTANCE;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import javax.ws.rs.core.Response;
+
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.commons.lang3.tuple.Triple;
+import org.apache.logging.log4j.Logger;
+import org.folio.persist.InstanceRepository;
 import org.folio.rest.jaxrs.model.Instance;
+import org.folio.services.batch.BatchOperationContext;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 
 public class InstanceDomainEventPublisher {
+  private static final Logger log = getLogger(InstanceDomainEventPublisher.class);
+
+  private final InstanceRepository instanceRepository;
   private final CommonDomainEventPublisher<Instance> domainEventService;
 
   public InstanceDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
+    instanceRepository = new InstanceRepository(context, okapiHeaders);
     domainEventService = new CommonDomainEventPublisher<>(context, okapiHeaders,
       INVENTORY_INSTANCE);
   }
@@ -29,6 +44,21 @@ public class InstanceDomainEventPublisher {
     return domainEventService.publishRecordCreated(newInstance.getId(), newInstance);
   }
 
+  public Future<Void> publishInstancesCreated(List<Instance> instances) {
+    if (instances.isEmpty()) {
+      log.info("No instances were created, skipping event sending");
+      return succeededFuture();
+    }
+
+    log.info("[{}] instances were created, sending events for them", instances.size());
+
+    final var createdInstancesPairs = instances.stream()
+      .map(instance -> new ImmutablePair<>(instance.getId(), instance))
+      .collect(Collectors.<Pair<String, Instance>>toList());
+
+    return domainEventService.publishRecordsCreated(createdInstancesPairs);
+  }
+
   public Future<Void> publishInstanceRemoved(Instance oldEntity) {
     return domainEventService.publishRecordRemoved(oldEntity.getId(), oldEntity);
   }
@@ -39,5 +69,44 @@ public class InstanceDomainEventPublisher {
       .collect(Collectors.toList());
 
     return domainEventService.publishRecordsRemoved(instancesWithIdsList);
+  }
+
+  public Function<Response, Future<Response>> publishInstancesCreatedOrUpdated(
+    BatchOperationContext<Instance> batchOperation) {
+
+    return response -> {
+      if (!isCreateSuccessResponse(response)) {
+        log.warn("Instance create/update failed, skipping event publishing");
+        return succeededFuture(response);
+      }
+
+      log.info("Instances created {}, instances updated {}",
+        batchOperation.getRecordsToBeCreated().size(),
+        batchOperation.getExistingRecordsBeforeUpdate().size());
+
+      return publishInstancesCreated(batchOperation.getRecordsToBeCreated())
+        .compose(notUsed -> publishInstancesUpdated(batchOperation.getExistingRecordsBeforeUpdate()))
+        .map(response);
+    };
+  }
+
+  private Future<Void> publishInstancesUpdated(List<Instance> oldInstances) {
+    log.info("[{}] instances were updated, sending events for them", oldInstances.size());
+
+    return instanceRepository.getById(oldInstances, Instance::getId)
+      .map(updatedInstances -> mapOldInstancesToUpdated(updatedInstances, oldInstances))
+      .compose(domainEventService::publishRecordsUpdated);
+  }
+
+  private List<Triple<String, Instance, Instance>> mapOldInstancesToUpdated(
+    Map<String, Instance> updatedInstancesMap, List<Instance> oldInstances) {
+
+    return oldInstances.stream()
+      .map(instance -> {
+        final String instanceId = instance.getId();
+        final Instance newInstance = updatedInstancesMap.get(instanceId);
+
+        return new ImmutableTriple<>(instanceId, instance, newInstance);
+      }).collect(Collectors.toList());
   }
 }

--- a/src/main/java/org/folio/services/instance/InstanceService.java
+++ b/src/main/java/org/folio/services/instance/InstanceService.java
@@ -1,0 +1,105 @@
+package org.folio.services.instance;
+
+import static io.vertx.core.CompositeFuture.all;
+import static io.vertx.core.Future.succeededFuture;
+import static io.vertx.core.Promise.promise;
+import static java.util.Collections.emptyList;
+import static java.util.stream.Collectors.toList;
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.folio.rest.impl.InstanceStorageAPI.INSTANCE_TABLE;
+import static org.folio.rest.impl.StorageHelper.MAX_ENTITIES;
+import static org.folio.rest.jaxrs.resource.InstanceStorageBatchSynchronous.PostInstanceStorageBatchSynchronousResponse;
+import static org.folio.rest.persist.PgUtil.postSync;
+import static org.folio.rest.persist.PgUtil.postgresClient;
+import static org.folio.rest.support.StatusUpdatedDateGenerator.generateStatusUpdatedDate;
+
+import java.util.List;
+import java.util.Map;
+
+import javax.ws.rs.core.Response;
+
+import org.folio.persist.InstanceRepository;
+import org.folio.rest.jaxrs.model.Instance;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.support.HridManager;
+import org.folio.services.batch.BatchOperationContext;
+import org.folio.services.domainevent.InstanceDomainEventPublisher;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+
+public class InstanceService {
+  private final HridManager hridManager;
+  private final Context vertxContext;
+  private final Map<String, String> okapiHeaders;
+  private final InstanceDomainEventPublisher domainEventPublisher;
+  private final InstanceRepository instanceRepository;
+
+  public InstanceService(Context vertxContext, Map<String, String> okapiHeaders) {
+    this.vertxContext = vertxContext;
+    this.okapiHeaders = okapiHeaders;
+
+    final PostgresClient postgresClient = postgresClient(vertxContext, okapiHeaders);
+    hridManager = new HridManager(vertxContext, postgresClient);
+    domainEventPublisher = new InstanceDomainEventPublisher(vertxContext, okapiHeaders);
+    instanceRepository = new InstanceRepository(vertxContext, okapiHeaders);
+  }
+
+  public Future<Response> createInstances(List<Instance> instances, boolean upsert) {
+    final String statusUpdatedDate = generateStatusUpdatedDate();
+
+    @SuppressWarnings("rawtypes")
+    final List<Future> setHridFutures = instances.stream()
+      .map(instance -> {
+        instance.setStatusUpdatedDate(statusUpdatedDate);
+        return getHrid(instance).map(instance::withHrid);
+      }).collect(toList());
+
+    return all(setHridFutures)
+      .compose(notUsed -> buildBatchOperationContext(upsert, instances))
+      .compose(batchOperation -> {
+        final Promise<Response> postResult = promise();
+
+        // Can use instances list here directly because the class is stateful
+        postSync(INSTANCE_TABLE, instances, MAX_ENTITIES, upsert, okapiHeaders,
+          vertxContext, PostInstanceStorageBatchSynchronousResponse.class, postResult);
+
+        return postResult.future()
+          .compose(domainEventPublisher.publishInstancesCreatedOrUpdated(batchOperation));
+      });
+  }
+
+  private Future<BatchOperationContext<Instance>> buildBatchOperationContext(
+    boolean upsert, List<Instance> allInstances) {
+
+    if (!upsert) {
+      return succeededFuture(new BatchOperationContext<>(allInstances, emptyList(), emptyList()));
+    }
+
+    return instanceRepository.getById(allInstances, Instance::getId)
+      .map(foundInstances -> {
+        final var instancesToBeCreated = allInstances.stream()
+          .filter(instance -> !foundInstances.containsKey(instance.getId()))
+          .collect(toList());
+
+        // new representations for existing instances
+        final var instancesToBeUpdated = allInstances.stream()
+          .filter(instance -> foundInstances.containsKey(instance.getId()))
+          .collect(toList());
+
+        // old (existing) instance representations before applying update
+        final var existingRecordsBeforeUpdate = instancesToBeUpdated.stream()
+          .map(instances -> foundInstances.get(instances.getId()))
+          .collect(toList());
+
+        return new BatchOperationContext<>(instancesToBeCreated, instancesToBeUpdated,
+          existingRecordsBeforeUpdate);
+      });
+  }
+
+  private Future<String> getHrid(Instance instance) {
+    return isBlank(instance.getHrid())
+      ? hridManager.getNextInstanceHrid() : succeededFuture(instance.getHrid());
+  }
+}

--- a/src/main/resources/kafka-topics.json
+++ b/src/main/resources/kafka-topics.json
@@ -2,7 +2,7 @@
   "topics": [
     {
       "name": "inventory.instance",
-      "numPartitions": 1,
+      "numPartitions": 50,
       "replicationFactor": 1
     },
     {

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -15,9 +15,12 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public final class DomainEventAssertions {
@@ -72,6 +75,19 @@ public final class DomainEventAssertions {
     await().until(() -> getInstanceEvents(instanceId).size() > 0);
 
     assertCreateEvent(getFirstInstanceEvent(instanceId), instance);
+  }
+
+  public static void assertCreateEventForInstances(JsonArray instances) {
+    assertCreateEventForInstances(instances.stream()
+      .map(obj -> (JsonObject) obj)
+      .collect(Collectors.toList()));
+  }
+
+  public static void assertCreateEventForInstances(List<JsonObject> instances) {
+    instances.forEach(instance -> {
+      final String instanceId = instance.getString("id");
+      assertCreateEvent(getFirstInstanceEvent(instanceId), instance);
+    });
   }
 
   public static void assertRemoveEventForInstance(JsonObject instance) {


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-644 - Domain events sending in inventory-storage for instance [batch APIs]

### Changes:
* Introduce `InstanceRepository` class;
* Send domain events on instance batch create (covers both batch-sync new API and instances/batch - deprecated API).
* Set `50` as replication factor for `inventory.instance` topic.