### PR TITLE
MODINVSTOR-654: Propagate okapi headers to kafka events

### DIFF
--- a/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
@@ -17,6 +17,7 @@ import java.util.stream.Collectors;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.Logger;
+import org.folio.services.kafka.KafkaMessage;
 import org.folio.services.kafka.topic.KafkaTopic;
 
 import io.vertx.core.Context;
@@ -89,11 +90,12 @@ class CommonDomainEventPublisher<T> {
   }
 
   private Future<Void> publishMessage(String instanceId, DomainEvent<?> domainEvent) {
-    log.debug("Sending domain event [{}], payload [{}]",
-      instanceId, domainEvent);
+    log.debug("Sending domain event [{}], payload [{}]", instanceId, domainEvent);
 
     return getKafkaProducerService(vertxContext.owner())
-      .sendMessage(instanceId, domainEvent, kafkaTopic)
+      .sendMessage(KafkaMessage.builder()
+        .key(instanceId).payload(domainEvent).topic(kafkaTopic)
+        .headers(okapiHeaders).build())
       .onComplete(result -> {
         if (result.failed()) {
           log.error("Unable to send domain event [{}], payload - [{}]",

--- a/src/main/java/org/folio/services/kafka/KafkaMessage.java
+++ b/src/main/java/org/folio/services/kafka/KafkaMessage.java
@@ -1,0 +1,23 @@
+package org.folio.services.kafka;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.folio.services.kafka.topic.KafkaTopic;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public final class KafkaMessage<T> {
+  private final T payload;
+  private final String key;
+  private final KafkaTopic topic;
+  @Builder.Default
+  private final Map<String, String> headers = new HashMap<>();
+
+  public <V> KafkaMessage<V> withPayload(V payload) {
+    return new KafkaMessage<>(payload, key, topic, headers);
+  }
+}

--- a/src/main/java/org/folio/services/kafka/KafkaMessage.java
+++ b/src/main/java/org/folio/services/kafka/KafkaMessage.java
@@ -5,19 +5,71 @@ import java.util.Map;
 
 import org.folio.services.kafka.topic.KafkaTopic;
 
-import lombok.Builder;
-import lombok.Getter;
-
-@Builder
-@Getter
 public final class KafkaMessage<T> {
   private final T payload;
   private final String key;
   private final KafkaTopic topic;
-  @Builder.Default
-  private final Map<String, String> headers = new HashMap<>();
+  private final Map<String, String> headers;
+
+  private KafkaMessage(T payload, String key, KafkaTopic topic, Map<String, String> headers) {
+    this.payload = payload;
+    this.key = key;
+    this.topic = topic;
+    this.headers = new HashMap<>(headers);
+  }
+
+  public static <T> KafkaMessageBuilder<T> builder() {
+    return new KafkaMessageBuilder<>();
+  }
 
   public <V> KafkaMessage<V> withPayload(V payload) {
     return new KafkaMessage<>(payload, key, topic, headers);
+  }
+
+  public T getPayload() {
+    return this.payload;
+  }
+
+  public String getKey() {
+    return this.key;
+  }
+
+  public KafkaTopic getTopic() {
+    return this.topic;
+  }
+
+  public Map<String, String> getHeaders() {
+    return this.headers;
+  }
+
+  public static class KafkaMessageBuilder<T> {
+    private T payload;
+    private String key;
+    private KafkaTopic topic;
+    private final Map<String, String> headers = new HashMap<>();
+
+    public KafkaMessageBuilder<T> payload(T payload) {
+      this.payload = payload;
+      return this;
+    }
+
+    public KafkaMessageBuilder<T> key(String key) {
+      this.key = key;
+      return this;
+    }
+
+    public KafkaMessageBuilder<T> topic(KafkaTopic topic) {
+      this.topic = topic;
+      return this;
+    }
+
+    public KafkaMessageBuilder<T> headers(Map<String, String> headers) {
+      this.headers.putAll(headers);
+      return this;
+    }
+
+    public KafkaMessage<T> build() {
+      return new KafkaMessage<>(payload, key, topic, headers);
+    }
   }
 }

--- a/src/main/java/org/folio/services/kafka/KafkaProducerService.java
+++ b/src/main/java/org/folio/services/kafka/KafkaProducerService.java
@@ -5,14 +5,11 @@ import static io.vertx.core.Promise.promise;
 import static io.vertx.kafka.client.producer.KafkaProducerRecord.create;
 import static org.folio.dbschema.ObjectMapperTool.getMapper;
 
-import org.folio.services.kafka.topic.KafkaTopic;
-
 import com.fasterxml.jackson.core.JsonProcessingException;
 
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.kafka.client.producer.KafkaProducer;
-import io.vertx.kafka.client.producer.KafkaProducerRecord;
 import io.vertx.kafka.client.producer.RecordMetadata;
 
 public class KafkaProducerService {
@@ -25,18 +22,21 @@ public class KafkaProducerService {
   /**
    * @throws IllegalArgumentException if unable to serialize the value to string.
    */
-  public Future<Void> sendMessage(String entityId, Object value, KafkaTopic kafkaTopic) {
+  public Future<Void> sendMessage(KafkaMessage<?> message) {
     try {
-      final String payload = getMapper().writeValueAsString(value);
-      return sendMessage(entityId, payload, kafkaTopic.getTopicName());
+      final String payload = getMapper().writeValueAsString(message.getPayload());
+      return sendMessageInternal(message.withPayload(payload));
     } catch (JsonProcessingException ex) {
       return failedFuture(new IllegalArgumentException("Unable to deserialize message", ex));
     }
   }
 
-  public Future<Void> sendMessage(String key, String value, String topic) {
+  private Future<Void> sendMessageInternal(KafkaMessage<String> message) {
     final Promise<RecordMetadata> result = promise();
-    final KafkaProducerRecord<String, String> kafkaRecord = create(topic, key, value);
+    final var kafkaRecord = create(message.getTopic().getTopicName(), message.getKey(),
+      message.getPayload());
+
+    message.getHeaders().forEach(kafkaRecord::addHeader);
 
     kafkaProducer.send(kafkaRecord, result);
 

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -1,5 +1,7 @@
 package org.folio.services.kafka.topic;
 
+import java.util.stream.Stream;
+
 public enum KafkaTopic {
   INVENTORY_INSTANCE("inventory.instance"),
   INVENTORY_ITEM("inventory.item");
@@ -12,5 +14,12 @@ public enum KafkaTopic {
 
   public String getTopicName() {
     return topicName;
+  }
+
+  public static KafkaTopic forName(String name) {
+    return Stream.of(values())
+      .filter(value -> value.getTopicName().equals(name))
+      .findFirst()
+      .orElse(null);
   }
 }

--- a/src/test/java/org/folio/rest/support/HttpClient.java
+++ b/src/test/java/org/folio/rest/support/HttpClient.java
@@ -6,6 +6,7 @@ import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
+import static org.folio.okapi.common.XOkapiHeaders.TOKEN;
 
 import java.net.URL;
 import java.util.concurrent.CompletableFuture;
@@ -24,6 +25,7 @@ import io.vertx.ext.web.client.WebClient;
 public class HttpClient {
   private static final Logger LOG = LogManager.getLogger();
 
+  public static final String DUMMY_USER_TOKEN = "1.2.3";
   private static final String TENANT_HEADER = "X-Okapi-Tenant";
   private static final String X_OKAPI_URL = "X-Okapi-Url";
   private static final String X_OKAPI_URL_TO = "X-Okapi-Url-to";
@@ -48,6 +50,7 @@ public class HttpClient {
       String baseUrl = format("%s://%s", url.getProtocol(), url.getAuthority());
       request.putHeader(X_OKAPI_URL, baseUrl);
       request.putHeader(X_OKAPI_URL_TO, baseUrl);
+      request.putHeader(TOKEN, DUMMY_USER_TOKEN);
     }
     request.putHeader(ACCEPT, APPLICATION_JSON + ", " + TEXT_PLAIN);
   }

--- a/src/test/java/org/folio/rest/support/HttpClient.java
+++ b/src/test/java/org/folio/rest/support/HttpClient.java
@@ -6,7 +6,6 @@ import static javax.ws.rs.core.HttpHeaders.CONTENT_TYPE;
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON;
 import static javax.ws.rs.core.MediaType.TEXT_PLAIN;
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
-import static org.folio.okapi.common.XOkapiHeaders.TOKEN;
 
 import java.net.URL;
 import java.util.concurrent.CompletableFuture;
@@ -25,7 +24,6 @@ import io.vertx.ext.web.client.WebClient;
 public class HttpClient {
   private static final Logger LOG = LogManager.getLogger();
 
-  public static final String DUMMY_USER_TOKEN = "1.2.3";
   private static final String TENANT_HEADER = "X-Okapi-Tenant";
   private static final String X_OKAPI_URL = "X-Okapi-Url";
   private static final String X_OKAPI_URL_TO = "X-Okapi-Url-to";
@@ -50,7 +48,6 @@ public class HttpClient {
       String baseUrl = format("%s://%s", url.getProtocol(), url.getAuthority());
       request.putHeader(X_OKAPI_URL, baseUrl);
       request.putHeader(X_OKAPI_URL_TO, baseUrl);
-      request.putHeader(TOKEN, DUMMY_USER_TOKEN);
     }
     request.putHeader(ACCEPT, APPLICATION_JSON + ", " + TEXT_PLAIN);
   }

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -4,12 +4,10 @@ import static io.vertx.core.MultiMap.caseInsensitiveMultiMap;
 import static java.util.UUID.fromString;
 import static org.awaitility.Awaitility.await;
 import static org.folio.okapi.common.XOkapiHeaders.TENANT;
-import static org.folio.okapi.common.XOkapiHeaders.TOKEN;
 import static org.folio.okapi.common.XOkapiHeaders.URL;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.folio.rest.api.StorageTestSuite.storageUrl;
 import static org.folio.rest.api.TestBase.holdingsClient;
-import static org.folio.rest.support.HttpClient.DUMMY_USER_TOKEN;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getFirstInstanceEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getFirstItemEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getInstanceEvents;
@@ -66,8 +64,8 @@ public final class DomainEventAssertions {
   private static void assertHeaders(Map<String, String> headers) {
     final MultiMap caseInsensitiveMap = caseInsensitiveMultiMap().addAll(headers);
 
+    assertEquals(caseInsensitiveMap.size(), 2);
     assertEquals(caseInsensitiveMap.get(TENANT), TENANT_ID);
-    assertEquals(caseInsensitiveMap.get(TOKEN), DUMMY_USER_TOKEN);
     assertEquals(caseInsensitiveMap.get(URL), storageUrl("").toString());
   }
 

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -1,9 +1,15 @@
 package org.folio.rest.support.matchers;
 
+import static io.vertx.core.MultiMap.caseInsensitiveMultiMap;
 import static java.util.UUID.fromString;
 import static org.awaitility.Awaitility.await;
+import static org.folio.okapi.common.XOkapiHeaders.TENANT;
+import static org.folio.okapi.common.XOkapiHeaders.TOKEN;
+import static org.folio.okapi.common.XOkapiHeaders.URL;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
+import static org.folio.rest.api.StorageTestSuite.storageUrl;
 import static org.folio.rest.api.TestBase.holdingsClient;
+import static org.folio.rest.support.HttpClient.DUMMY_USER_TOKEN;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getFirstInstanceEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getFirstItemEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getInstanceEvents;
@@ -14,49 +20,68 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
+import org.folio.services.kafka.KafkaMessage;
+
+import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonObject;
 
 public final class DomainEventAssertions {
   private DomainEventAssertions() {}
 
-  private static void assertCreateEvent(JsonObject createEvent, JsonObject newRecord) {
-    assertThat(createEvent.getString("type"), is("CREATE"));
-    assertThat(createEvent.getString("tenant"), is(TENANT_ID));
-    assertThat(createEvent.getJsonObject("old"), nullValue());
-    assertThat(createEvent.getJsonObject("new"), is(newRecord));
+  private static void assertCreateEvent(KafkaMessage<JsonObject> createEvent, JsonObject newRecord) {
+    assertThat(createEvent.getPayload().getString("type"), is("CREATE"));
+    assertThat(createEvent.getPayload().getString("tenant"), is(TENANT_ID));
+    assertThat(createEvent.getPayload().getJsonObject("old"), nullValue());
+    assertThat(createEvent.getPayload().getJsonObject("new"), is(newRecord));
+
+    assertHeaders(createEvent.getHeaders());
   }
 
-  private static void assertRemoveEvent(JsonObject deleteEvent, JsonObject record) {
-    assertThat(deleteEvent.getString("type"), is("DELETE"));
-    assertThat(deleteEvent.getString("tenant"), is(TENANT_ID));
-    assertThat(deleteEvent.getJsonObject("new"), nullValue());
-    assertThat(deleteEvent.getJsonObject("old"), is(record));
+  private static void assertRemoveEvent(KafkaMessage<JsonObject> deleteEvent, JsonObject record) {
+    assertThat(deleteEvent.getPayload().getString("type"), is("DELETE"));
+    assertThat(deleteEvent.getPayload().getString("tenant"), is(TENANT_ID));
+    assertThat(deleteEvent.getPayload().getJsonObject("new"), nullValue());
+    assertThat(deleteEvent.getPayload().getJsonObject("old"), is(record));
+
+    assertHeaders(deleteEvent.getHeaders());
   }
 
   private static void assertUpdateEvent(
-    JsonObject updateEvent, JsonObject oldRecord, JsonObject newRecord) {
+    KafkaMessage<JsonObject> updateEvent, JsonObject oldRecord, JsonObject newRecord) {
 
-    assertThat(updateEvent.getString("type"), is("UPDATE"));
-    assertThat(updateEvent.getString("tenant"), is(TENANT_ID));
-    assertThat(updateEvent.getJsonObject("old"), is(oldRecord));
-    assertThat(updateEvent.getJsonObject("new"), is(newRecord));
+    assertThat(updateEvent.getPayload().getString("type"), is("UPDATE"));
+    assertThat(updateEvent.getPayload().getString("tenant"), is(TENANT_ID));
+    assertThat(updateEvent.getPayload().getJsonObject("old"), is(oldRecord));
+    assertThat(updateEvent.getPayload().getJsonObject("new"), is(newRecord));
+
+    assertHeaders(updateEvent.getHeaders());
+  }
+
+  private static void assertHeaders(Map<String, String> headers) {
+    final MultiMap caseInsensitiveMap = caseInsensitiveMultiMap().addAll(headers);
+
+    assertEquals(caseInsensitiveMap.get(TENANT), TENANT_ID);
+    assertEquals(caseInsensitiveMap.get(TOKEN), DUMMY_USER_TOKEN);
+    assertEquals(caseInsensitiveMap.get(URL), storageUrl("").toString());
   }
 
   public static void assertNoUpdateEvent(String instanceId) {
     await().atLeast(1, TimeUnit.SECONDS);
 
-    final JsonObject updateMessage  = getLastInstanceEvent(instanceId);
+    final JsonObject updateMessage  = getLastInstanceEvent(instanceId).getPayload();
     assertThat(updateMessage.getString("type"), not(is("UPDATE")));
   }
 
   public static void assertNoRemoveEvent(String instanceId) {
     await().atLeast(1, TimeUnit.SECONDS);
 
-    final JsonObject updateMessage  = getLastInstanceEvent(instanceId);
+    final JsonObject updateMessage  = getLastInstanceEvent(instanceId).getPayload();
     assertThat(updateMessage.getString("type"), not(is("DELETE")));
   }
 
@@ -96,8 +121,7 @@ public final class DomainEventAssertions {
 
     await().until(() -> getItemEvents(instanceIdForItem, itemId).size() > 0);
 
-    final JsonObject message = getFirstItemEvent(instanceIdForItem, itemId);
-    assertCreateEvent(message, item);
+    assertCreateEvent(getFirstItemEvent(instanceIdForItem, itemId), item);
   }
 
   public static void assertRemoveEventForItem(JsonObject item) {
@@ -106,9 +130,7 @@ public final class DomainEventAssertions {
 
     await().until(() -> getItemEvents(instanceIdForItem, itemId).size() > 1);
 
-    final JsonObject message = getLastItemEvent(instanceIdForItem, itemId);
-
-    assertRemoveEvent(message, item);
+    assertRemoveEvent(getLastItemEvent(instanceIdForItem, itemId), item);
   }
 
   public static void assertUpdateEventForItem(JsonObject oldItem, JsonObject newItem) {
@@ -117,9 +139,7 @@ public final class DomainEventAssertions {
 
     await().until(() -> getItemEvents(instanceIdForItem, itemId).size() > 0);
 
-    final JsonObject message = getLastItemEvent(instanceIdForItem, itemId);
-
-    assertUpdateEvent(message, oldItem, newItem);
+    assertUpdateEvent(getLastItemEvent(instanceIdForItem, itemId), oldItem, newItem);
   }
 
   private static String getInstanceIdForItem(JsonObject newItem) {

--- a/src/test/java/org/folio/services/kafka/KafkaProducerServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/KafkaProducerServiceTest.java
@@ -17,8 +17,11 @@ public class KafkaProducerServiceTest {
   public void canThrowJacksonExceptionWhenCannotParseObject(){
     final var producer = new KafkaProducerService(mock(KafkaProducer.class));
 
+    final KafkaMessage<Object> message = KafkaMessage.builder()
+      .key("id").payload(new Object()).topic(INVENTORY_INSTANCE).build();
+
     assertThrows("Unable to deserialize message", ExecutionException.class,
-      () -> producer.sendMessage("id", new Object(), INVENTORY_INSTANCE)
-      .toCompletionStage().toCompletableFuture().get(1, TimeUnit.SECONDS));
+      () -> producer.sendMessage(message).toCompletionStage().toCompletableFuture()
+        .get(1, TimeUnit.SECONDS));
   }
 }


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-654 - Propagate okapi request headers to kafka messages.

## Changes:
* Introduce KafkaMessage class that holds topic, instanceId, payload and headers to send.
* Send okapi url and tenant headers for kafka message.
* Adjust FakeKafkaConsumer to use `KafkaMessage` class so that we will be able to verify headers as well as payload.
* Verify that okapi headers are received in event consumer.