### PR TITLE
MODINVSTOR-664: Publish single delete all event when all items/holdings/instances are removed.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -224,7 +224,7 @@ The event payload has following structure:
 {
   "old": {...}, // the instance/item before update or delete
   "new": {...}, // the instance/item after update or create
-  "type": "UPDATE|DELETE|CREATE", // type of the event
+  "type": "UPDATE|DELETE|CREATE|DELETE_ALL", // type of the event
   "tenant": "diku" // tenant name
 }
 ```
@@ -234,5 +234,28 @@ The event payload has following structure:
 Kafka partition key for all the events is instance id (for items it is retrieved from
 associated holding record).
 
-*Note for items:* the `new` and `old` records also includes `instanceId` property,
-on the same level with other item properties, which defined in the schema.
+## Domain events for items
+
+The `new` and `old` records also includes `instanceId` property,
+on the same level with other item properties, which defined in the schema:
+```javascript
+{
+  "instanceId": "<the instance id>",
+  // all other properties that defined in the schema
+}
+```
+
+## Domain events for delete all APIs
+
+There are delete all APIs for items instances and holding records. For such
+APIs we're issuing a special domain event:
+* Partition key: `00000000-0000-0000-0000-000000000000`
+* Event payload:
+```javascript
+{
+  "type": "DELETE_ALL",
+  "tenant": "<the tenant name>"
+  "old": null,
+  "new": null
+}
+```

--- a/src/main/java/org/folio/persist/HoldingsRepository.java
+++ b/src/main/java/org/folio/persist/HoldingsRepository.java
@@ -3,20 +3,14 @@ package org.folio.persist;
 import static org.folio.rest.impl.HoldingsStorageAPI.HOLDINGS_RECORD_TABLE;
 import static org.folio.rest.persist.PgUtil.postgresClient;
 
-import java.util.List;
 import java.util.Map;
 
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 
 import io.vertx.core.Context;
-import io.vertx.core.Future;
 
 public class HoldingsRepository extends AbstractRepository<HoldingsRecord> {
   public HoldingsRepository(Context context, Map<String, String> okapiHeaders) {
     super(postgresClient(context, okapiHeaders), HOLDINGS_RECORD_TABLE, HoldingsRecord.class);
-  }
-
-  public Future<List<HoldingsRecord>> getAll() {
-    return postgresClientFuturized.get(tableName, new HoldingsRecord());
   }
 }

--- a/src/main/java/org/folio/persist/ItemRepository.java
+++ b/src/main/java/org/folio/persist/ItemRepository.java
@@ -18,10 +18,6 @@ public class ItemRepository extends AbstractRepository<Item> {
     super(postgresClient(context, okapiHeaders), ITEM_TABLE, Item.class);
   }
 
-  public Future<List<Item>> getAll() {
-    return postgresClientFuturized.get(tableName, new Item());
-  }
-
   public Future<List<Item>> getItemsForHoldingRecord(String holdingRecordId) {
     final Criterion criterion = new Criterion(new Criteria().setJSONB(false)
       .addField("holdingsRecordId").setOperation("=").setVal(holdingRecordId));

--- a/src/main/java/org/folio/services/domainevent/AbstractDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/AbstractDomainEventPublisher.java
@@ -125,8 +125,8 @@ abstract class AbstractDomainEventPublisher<DomainType, EventType> {
   protected abstract Future<List<Pair<String, EventType>>> toInstanceIdEventTypePairs(
     Collection<DomainType> records);
 
-  private Future<Pair<String, EventType>> toInstanceIdEventTypePair(DomainType records) {
-    return toInstanceIdEventTypePairs(List.of(records))
+  private Future<Pair<String, EventType>> toInstanceIdEventTypePair(DomainType record) {
+    return toInstanceIdEventTypePairs(List.of(record))
       .map(list -> list.get(0));
   }
 

--- a/src/main/java/org/folio/services/domainevent/AbstractDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/AbstractDomainEventPublisher.java
@@ -86,7 +86,7 @@ abstract class AbstractDomainEventPublisher<DomainType, EventType> {
       }
 
       return toInstanceIdEventTypePair(record)
-        .compose(event -> domainEventService.publishRecordRemoved(event.getKey(), event.getRight()))
+        .compose(event -> domainEventService.publishRecordRemoved(event.getKey(), event.getValue()))
         .map(response);
     };
   }

--- a/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
@@ -7,6 +7,7 @@ import static org.folio.okapi.common.XOkapiHeaders.TENANT;
 import static org.folio.okapi.common.XOkapiHeaders.URL;
 import static org.folio.rest.tools.utils.TenantTool.tenantId;
 import static org.folio.services.domainevent.DomainEvent.createEvent;
+import static org.folio.services.domainevent.DomainEvent.deleteAllEvent;
 import static org.folio.services.domainevent.DomainEvent.deleteEvent;
 import static org.folio.services.domainevent.DomainEvent.updateEvent;
 import static org.folio.services.kafka.KafkaProducerServiceFactory.getKafkaProducerService;
@@ -27,6 +28,7 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 
 class CommonDomainEventPublisher<T> {
+  private static final String NULL_INSTANCE_ID = "00000000-0000-0000-0000-000000000000";
   private static final Logger log = getLogger(CommonDomainEventPublisher.class);
   private static final Set<String> FORWARDER_HEADERS = Set.of(URL.toLowerCase(),
     TENANT.toLowerCase());
@@ -83,15 +85,8 @@ class CommonDomainEventPublisher<T> {
     return publishMessage(instanceId, domainEvent);
   }
 
-  Future<Void> publishRecordsRemoved(List<Pair<String, T>> records) {
-    if (records.isEmpty()) {
-      return succeededFuture();
-    }
-
-    return all(records.stream()
-      .map(record -> publishRecordRemoved(record.getKey(), record.getValue()))
-      .collect(Collectors.toList()))
-      .map(notUsed -> null);
+  Future<Void> publishAllRecordsRemoved() {
+    return publishMessage(NULL_INSTANCE_ID, deleteAllEvent(getTenant()));
   }
 
   private Future<Void> publishMessage(String instanceId, DomainEvent<?> domainEvent) {

--- a/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
@@ -27,8 +27,8 @@ import org.folio.services.kafka.topic.KafkaTopic;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 
-class CommonDomainEventPublisher<T> {
-  private static final String NULL_INSTANCE_ID = "00000000-0000-0000-0000-000000000000";
+public class CommonDomainEventPublisher<T> {
+  public static final String NULL_INSTANCE_ID = "00000000-0000-0000-0000-000000000000";
   private static final Logger log = getLogger(CommonDomainEventPublisher.class);
   private static final Set<String> FORWARDER_HEADERS = Set.of(URL.toLowerCase(),
     TENANT.toLowerCase());

--- a/src/main/java/org/folio/services/domainevent/DomainEvent.java
+++ b/src/main/java/org/folio/services/domainevent/DomainEvent.java
@@ -2,6 +2,7 @@ package org.folio.services.domainevent;
 
 import static org.folio.services.domainevent.DomainEventType.CREATE;
 import static org.folio.services.domainevent.DomainEventType.DELETE;
+import static org.folio.services.domainevent.DomainEventType.DELETE_ALL;
 import static org.folio.services.domainevent.DomainEventType.UPDATE;
 
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -77,5 +78,9 @@ public class DomainEvent<T> {
 
   public static <T> DomainEvent<T> deleteEvent(T oldEntity, String tenant) {
     return new DomainEvent<>(oldEntity, null, DELETE, tenant);
+  }
+
+  public static <T> DomainEvent<T> deleteAllEvent(String tenant) {
+    return new DomainEvent<>(null, null, DELETE_ALL, tenant);
   }
 }

--- a/src/main/java/org/folio/services/domainevent/DomainEventType.java
+++ b/src/main/java/org/folio/services/domainevent/DomainEventType.java
@@ -1,5 +1,5 @@
 package org.folio.services.domainevent;
 
 public enum DomainEventType {
-  UPDATE, DELETE, CREATE
+  UPDATE, DELETE, CREATE, DELETE_ALL
 }

--- a/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
@@ -64,12 +64,8 @@ public class InstanceDomainEventPublisher {
     return domainEventService.publishRecordRemoved(oldEntity.getId(), oldEntity);
   }
 
-  public Future<Void> publishInstancesRemoved(List<Instance> records) {
-    final List<Pair<String, Instance>> instancesWithIdsList = records.stream()
-      .map(instance -> new ImmutablePair<>(instance.getId(), instance))
-      .collect(Collectors.toList());
-
-    return domainEventService.publishRecordsRemoved(instancesWithIdsList);
+  public Future<Void> publishAllInstancesRemoved() {
+    return domainEventService.publishAllRecordsRemoved();
   }
 
   public Function<Response, Future<Response>> publishInstancesCreatedOrUpdated(

--- a/src/main/java/org/folio/services/holding/HoldingsService.java
+++ b/src/main/java/org/folio/services/holding/HoldingsService.java
@@ -71,9 +71,8 @@ public class HoldingsService {
   }
 
   public Future<Void> deleteAllHoldings() {
-    return holdingsRepository.getAll()
-      .compose(allItems -> holdingsRepository.deleteAll()
-        .compose(notUsed -> domainEventPublisher.publishRemoved(allItems)));
+    return holdingsRepository.deleteAll()
+      .compose(notUsed -> domainEventPublisher.publishAllRemoved());
   }
 
   public Future<Response> updateHoldingRecord(String holdingId, HoldingsRecord holdingsRecord) {

--- a/src/main/java/org/folio/services/item/ItemService.java
+++ b/src/main/java/org/folio/services/item/ItemService.java
@@ -143,9 +143,8 @@ public class ItemService {
   }
 
   public Future<Void> deleteAllItems() {
-    return itemRepository.getAll()
-      .compose(allItems -> itemRepository.deleteAll()
-        .compose(notUsed -> domainEventService.publishRemoved(allItems)));
+    return itemRepository.deleteAll()
+      .compose(notUsed -> domainEventService.publishAllRemoved());
   }
 
   /**

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -43,6 +43,7 @@ import static org.folio.rest.support.ResponseHandler.text;
 import static org.folio.rest.support.http.InterfaceUrls.*;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertCreateEventForHolding;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertNoUpdateEventForHolding;
+import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveAllEventForHolding;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveEventForHolding;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertUpdateEventForHolding;
 import static org.folio.rest.support.matchers.PostgresErrorMessageMatchers.isMaximumSequenceValueError;
@@ -534,9 +535,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(allHoldings.size(), is(0));
 
-    createdHoldings.stream()
-      .map(IndividualResource::getJson)
-      .forEach(DomainEventAssertions::assertRemoveEventForHolding);
+    assertRemoveAllEventForHolding();
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -20,6 +20,7 @@ import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.*;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.builders.ItemRequestBuilder;
+import org.folio.rest.support.matchers.DomainEventAssertions;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -52,6 +53,7 @@ import static org.folio.rest.support.matchers.DateTimeMatchers.withinSecondsBefo
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertCreateEventForInstance;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertCreateEventForInstances;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertNoCreateEvent;
+import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveAllEventForInstance;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveEventForInstance;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertUpdateEventForInstance;
 import static org.folio.rest.support.matchers.PostgresErrorMessageMatchers.isMaximumSequenceValueError;
@@ -1456,9 +1458,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(allInstances.size(), is(0));
     assertThat(responseBody.getInteger(TOTAL_RECORDS_KEY), is(0));
 
-    assertRemoveEventForInstance(firstInstance.getJson());
-    assertRemoveEventForInstance(secondInstance.getJson());
-    assertRemoveEventForInstance(thirdInstance.getJson());
+    assertRemoveAllEventForInstance();
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -22,6 +22,7 @@ import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
 import static org.folio.rest.support.matchers.DateTimeMatchers.withinSecondsBeforeNow;
 import static org.folio.rest.support.matchers.DateTimeMatchers.withinSecondsBeforeNowAsString;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertCreateEventForItem;
+import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveAllEventForItem;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveEventForItem;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertUpdateEventForItem;
 import static org.folio.rest.support.matchers.PostgresErrorMessageMatchers.isMaximumSequenceValueError;
@@ -1804,7 +1805,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(allItems.size(), is(0));
     assertThat(responseBody.getInteger("totalRecords"), is(0));
 
-    createdItems.forEach(DomainEventAssertions::assertRemoveEventForItem);
+    assertRemoveAllEventForItem();
   }
 
   @Test

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -126,7 +126,9 @@ public final class FakeKafkaConsumer {
     final var oldOrNew = payload.containsKey("new")
       ? payload.getJsonObject("new") : payload.getJsonObject("old");
 
-    return instanceAndIdKey(message.getKey(), oldOrNew.getString("id"));
+    final var id = oldOrNew != null ? oldOrNew.getString("id") : null;
+
+    return instanceAndIdKey(message.getKey(), id);
   }
 
   private Map<String, String> consumerProperties() {

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -18,6 +18,7 @@ import static org.folio.rest.support.kafka.FakeKafkaConsumer.getItemEvents;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLastHoldingEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLastInstanceEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLastItemEvent;
+import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_INSTANCE_ID;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -34,7 +35,6 @@ import java.util.stream.Collectors;
 import org.folio.services.kafka.KafkaMessage;
 
 public final class DomainEventAssertions {
-  private static final String NULL_INSTANCE_ID = "00000000-0000-0000-0000-000000000000";
   private DomainEventAssertions() {}
 
   private static void assertCreateEvent(KafkaMessage<JsonObject> createEvent, JsonObject newRecord) {


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-664 - Publish single deleteAll message for items/holdings/instances.

## Changes:
* Publish DELETE_ALL event when all instances/items/holdings are being removed.