### PR TITLE
Fix MODINVSTOR-675 (ERROR: cannot replace existing key).

### DIFF
--- a/src/main/resources/templates/db_scripts/populateRetainLeadingZeroesSetting.sql
+++ b/src/main/resources/templates/db_scripts/populateRetainLeadingZeroesSetting.sql
@@ -4,6 +4,8 @@ UPDATE ${myuniversity}_${mymodule}.hrid_settings
   SET jsonb = (SELECT jsonb_insert(jsonb, '{commonRetainLeadingZeroes}','true', true)
                FROM ${myuniversity}_${mymodule}.hrid_settings
                WHERE id = 'a501f2a8-5b31-48b2-874d-2191e48db8cd')
-WHERE id = 'a501f2a8-5b31-48b2-874d-2191e48db8cd';
+WHERE id = 'a501f2a8-5b31-48b2-874d-2191e48db8cd'
+     AND (SELECT jsonb::json->'commonRetainLeadingZeroes'
+      FROM ${myuniversity}_${mymodule}.hrid_settings WHERE id = 'a501f2a8-5b31-48b2-874d-2191e48db8cd') IS NULL;
 
 END TRANSACTION;

--- a/src/main/resources/templates/db_scripts/populateRetainLeadingZeroesSetting.sql
+++ b/src/main/resources/templates/db_scripts/populateRetainLeadingZeroesSetting.sql
@@ -4,8 +4,6 @@ UPDATE ${myuniversity}_${mymodule}.hrid_settings
   SET jsonb = (SELECT jsonb_insert(jsonb, '{commonRetainLeadingZeroes}','true', true)
                FROM ${myuniversity}_${mymodule}.hrid_settings
                WHERE id = 'a501f2a8-5b31-48b2-874d-2191e48db8cd')
-WHERE id = 'a501f2a8-5b31-48b2-874d-2191e48db8cd'
-     AND (SELECT jsonb::json->'commonRetainLeadingZeroes'
-      FROM ${myuniversity}_${mymodule}.hrid_settings WHERE id = 'a501f2a8-5b31-48b2-874d-2191e48db8cd') IS NULL;
+WHERE id = 'a501f2a8-5b31-48b2-874d-2191e48db8cd' and jsonb->>'commonRetainLeadingZeroes' is NULL;
 
 END TRANSACTION;

--- a/src/test/java/org/folio/rest/api/RetainLeadingZeroesMigrationScriptTest.java
+++ b/src/test/java/org/folio/rest/api/RetainLeadingZeroesMigrationScriptTest.java
@@ -29,6 +29,7 @@ public class RetainLeadingZeroesMigrationScriptTest extends MigrationTestBase {
     Assert.assertFalse(withoutLeadingZeroes.containsKey(LEADING_ZEROES_PROPERTY));
 
     executeMultipleSqlStatements(MIGRATION_SCRIPT);
+    executeMultipleSqlStatements(MIGRATION_SCRIPT); //check 2nd run MODINVSTOR-675
 
     result = executeSql(String.format(SQL_GET_HRID_SETTINGS, getSchemaName()));
     Assert.assertNotNull(result);


### PR DESCRIPTION
## Purpose
Fix "ERROR: cannot replace existing key" during update operation in the SQL script.

## Approach
Added addition check in the SQL script.

## Learning
[MODINVSTOR-675](https://issues.folio.org/browse/MODINVSTOR-675)