### PR TITLE
Fix Kafka topics created when module is disabled MODINVSTOR-691

### DIFF
--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -83,36 +83,19 @@ public class TenantRefAPI extends TenantAPI {
     return res;
   }
 
-  @Override
-  @Validate
-  public void postTenant(TenantAttributes tenantAttributes, Map<String, String> headers,
-    Handler<AsyncResult<Response>> handler, Context context) {
-
-    // have to create topics before tenant init,
-    // because on init we can create sample/ref data which
-    // has to be sent to the queue as well
-    new KafkaAdminClientService(context.owner())
-      .createKafkaTopics(tenantAttributes)
-      .onComplete(topicCreateResult -> {
-        if (topicCreateResult.failed()) {
-          log.error("Unable to create kafka topics", topicCreateResult.cause());
-          handler.handle(succeededFuture(PostTenantResponse
-            .respond500WithTextPlain(topicCreateResult.cause().getMessage())));
-        } else {
-          super.postTenant(tenantAttributes, headers, handler, context);
-        }
-      });
-  }
-
   @Validate
   @Override
   Future<Integer> loadData(TenantAttributes attributes, String tenantId,
                            Map<String, String> headers, Context vertxContext) {
-    return super.loadData(attributes, tenantId, headers, vertxContext)
+    // create topics before loading data
+    return
+      new KafkaAdminClientService(vertxContext.owner())
+        .createKafkaTopics(attributes)
+        .compose(x ->super.loadData(attributes, tenantId, headers, vertxContext))
         .compose(superRecordsLoaded -> {
           try {
             List<URL> urls = TenantLoading.getURLsFromClassPathDir(
-                REFERENCE_LEAD + "/service-points");
+              REFERENCE_LEAD + "/service-points");
             servicePoints = new LinkedList<>();
             for (URL url : urls) {
               InputStream stream = url.openStream();
@@ -138,9 +121,9 @@ public class TenantRefAPI extends TenantAPI {
           tl.add("instance-relationships", "instance-storage/instance-relationships");
           if (servicePoints != null) {
             tl.withFilter(this::servicePointUserFilter)
-                .withPostOnly()
-                .withAcceptStatus(422)
-                .add("users", "service-points-users");
+              .withPostOnly()
+              .withAcceptStatus(422)
+              .add("users", "service-points-users");
           }
           return tl.perform(attributes, headers, vertxContext, superRecordsLoaded);
         });

--- a/src/main/java/org/folio/services/kafka/topic/KafkaAdminClientService.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaAdminClientService.java
@@ -2,7 +2,6 @@ package org.folio.services.kafka.topic;
 
 import static io.vertx.core.Future.succeededFuture;
 import static io.vertx.kafka.admin.KafkaAdminClient.create;
-import static org.apache.commons.lang.BooleanUtils.isTrue;
 import static org.apache.logging.log4j.LogManager.getLogger;
 import static org.folio.services.kafka.KafkaConfigHelper.getKafkaProperties;
 
@@ -35,11 +34,6 @@ public class KafkaAdminClientService {
   }
 
   public Future<Void> createKafkaTopics(TenantAttributes tenantAttributes) {
-    if (isTrue(tenantAttributes.getPurge())) {
-      log.info("Purge is true, skipping topics creation...");
-      return succeededFuture();
-    }
-
     final KafkaAdminClient kafkaAdminClient = clientFactory.get();
     return createKafkaTopics(kafkaAdminClient).onComplete(result -> {
       if (result.succeeded()) {

--- a/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -62,18 +62,6 @@ public class KafkaAdminClientServiceTest {
       }));
   }
 
-  @Test
-  public void shouldNotCreateTopicsIfPurge(TestContext testContext) {
-    final KafkaAdminClient mockClient = mock(KafkaAdminClient.class);
-    when(mockClient.listTopics()).thenReturn(succeededFuture(allTopics));
-    when(mockClient.createTopics(anyList())).thenReturn(succeededFuture());
-    when(mockClient.close()).thenReturn(succeededFuture());
-
-    createKafkaTopicsAsync(mockClient, true)
-      .onComplete(testContext.asyncAssertSuccess(
-        notUsed -> verifyNoInteractions(mockClient)));
-  }
-
   private Future<Void> createKafkaTopicsAsync(KafkaAdminClient mockClient, Boolean purge) {
     return new KafkaAdminClientService(() -> mockClient)
       .createKafkaTopics(new TenantAttributes().withPurge(purge));


### PR DESCRIPTION
Use loadData and create the topis before any other things are loaded.
With this, we don't need to override postTenant anymore which is
discouraged.