### PR TITLE
MODINVSTOR-521: Determine shelving order for existing items during upgrade

### DIFF
--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -122,6 +122,6 @@ public class TenantRefAPI extends TenantAPI {
           }
           return tl.perform(attributes, headers, vertxContext, superRecordsLoaded);
         }).compose(loaded -> ShelvingOrderUpdate
-          .getInstance().updateItems(attributes, headers, vertxContext));
+          .getInstance().startUpdatingOfItems(attributes, headers, vertxContext));
   }
 }

--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.support.ShelvingOrderUpdate;
 import org.folio.rest.tools.utils.TenantLoading;
 import org.folio.services.kafka.topic.KafkaAdminClientService;
 
@@ -120,6 +121,7 @@ public class TenantRefAPI extends TenantAPI {
               .add("users", "service-points-users");
           }
           return tl.perform(attributes, headers, vertxContext, superRecordsLoaded);
-        });
+        }).compose(loaded -> ShelvingOrderUpdate
+          .getInstance().updateItems(attributes, headers, vertxContext));
   }
 }

--- a/src/main/java/org/folio/rest/support/CompletableFutureUtil.java
+++ b/src/main/java/org/folio/rest/support/CompletableFutureUtil.java
@@ -1,12 +1,7 @@
 package org.folio.rest.support;
 
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-
 import io.vertx.core.AsyncResult;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -27,21 +22,6 @@ public final class CompletableFutureUtil {
         future.completeExceptionally(result.cause());
       }
     };
-  }
-
-  public static <T> T getFutureResult(Future<T> future) {
-    log.info("Started \"getFutureResult\", future: {} ...", future);
-    return getFutureResult(future.toCompletionStage().toCompletableFuture());
-  }
-
-  public static <T> T getFutureResult(CompletableFuture<T> completableFuture) {
-    log.info("Started \"getFutureResult\", completableFuture: {} ...", completableFuture);
-    try {
-      return completableFuture.get(TIMEOUT, TimeUnit.SECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      log.error("Error occurs in getFutureResult: {}", e.getMessage());
-      throw new RuntimeException(e);
-    }
   }
 
 }

--- a/src/main/java/org/folio/rest/support/CompletableFutureUtil.java
+++ b/src/main/java/org/folio/rest/support/CompletableFutureUtil.java
@@ -1,11 +1,22 @@
 package org.folio.rest.support;
 
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import io.vertx.core.AsyncResult;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public final class CompletableFutureUtil {
+
+  private static final Logger log = LogManager.getLogger();
+
+  public static final long TIMEOUT = 180;
+
   private CompletableFutureUtil() {}
 
   public static <T> Handler<AsyncResult<T>> mapFutureResultToJavaFuture(CompletableFuture<T> future) {
@@ -17,4 +28,20 @@ public final class CompletableFutureUtil {
       }
     };
   }
+
+  public static <T> T getFutureResult(Future<T> future) {
+    log.info("Started \"getFutureResult\", future: {} ...", future);
+    return getFutureResult(future.toCompletionStage().toCompletableFuture());
+  }
+
+  public static <T> T getFutureResult(CompletableFuture<T> completableFuture) {
+    log.info("Started \"getFutureResult\", completableFuture: {} ...", completableFuture);
+    try {
+      return completableFuture.get(TIMEOUT, TimeUnit.SECONDS);
+    } catch (InterruptedException | ExecutionException | TimeoutException e) {
+      log.error("Error occurs in getFutureResult: {}", e.getMessage());
+      throw new RuntimeException(e);
+    }
+  }
+
 }

--- a/src/main/java/org/folio/rest/support/EffectiveCallNumberComponentsUtil.java
+++ b/src/main/java/org/folio/rest/support/EffectiveCallNumberComponentsUtil.java
@@ -2,16 +2,15 @@ package org.folio.rest.support;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.jaxrs.model.EffectiveCallNumberComponents;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.services.CallNumberUtils;
-
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 public final class EffectiveCallNumberComponentsUtil {
 
@@ -19,6 +18,12 @@ public final class EffectiveCallNumberComponentsUtil {
 
   public static void setCallNumberComponents(Item item, HoldingsRecord hr) {
     item.setEffectiveCallNumberComponents(buildComponents(item, hr));
+  }
+
+  public static Item getCalculateAndSetEffectiveShelvingOrder(Item item) {
+    // Calculate item's shelving order
+    calculateAndSetEffectiveShelvingOrder(item);
+    return item;
   }
 
   public static void calculateAndSetEffectiveShelvingOrder(Item item) {
@@ -35,12 +40,11 @@ public final class EffectiveCallNumberComponentsUtil {
           .map(StringUtils::trim)
           .collect(Collectors.joining(" "))
       );
-//      String suffixValue = Objects.toString(item.getEffectiveCallNumberComponents().getSuffix(), "").trim();
-      String suffixValue =
-        Objects.toString(Optional.ofNullable(item.getEffectiveCallNumberComponents())
-          .orElse(new EffectiveCallNumberComponents()).getSuffix(), "")
-          .trim();
 
+      String suffixValue =
+          Objects.toString(Optional.ofNullable(item.getEffectiveCallNumberComponents())
+              .orElse(new EffectiveCallNumberComponents()).getSuffix(), "")
+              .trim();
       String nonNullableSuffixValue = suffixValue.isEmpty() ? "" : " " + suffixValue;
 
       item.setEffectiveShelvingOrder(

--- a/src/main/java/org/folio/rest/support/EffectiveCallNumberComponentsUtil.java
+++ b/src/main/java/org/folio/rest/support/EffectiveCallNumberComponentsUtil.java
@@ -2,15 +2,16 @@ package org.folio.rest.support;
 
 import static org.apache.commons.lang3.StringUtils.isNotBlank;
 
-import java.util.Objects;
-import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.folio.rest.jaxrs.model.EffectiveCallNumberComponents;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.services.CallNumberUtils;
+
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class EffectiveCallNumberComponentsUtil {
 
@@ -42,9 +43,10 @@ public final class EffectiveCallNumberComponentsUtil {
       );
 
       String suffixValue =
-          Objects.toString(Optional.ofNullable(item.getEffectiveCallNumberComponents())
-              .orElse(new EffectiveCallNumberComponents()).getSuffix(), "")
-              .trim();
+        Objects.toString(Optional.ofNullable(item.getEffectiveCallNumberComponents())
+          .orElse(new EffectiveCallNumberComponents()).getSuffix(), "")
+          .trim();
+
       String nonNullableSuffixValue = suffixValue.isEmpty() ? "" : " " + suffixValue;
 
       item.setEffectiveShelvingOrder(

--- a/src/main/java/org/folio/rest/support/ShelvingOrderUpdate.java
+++ b/src/main/java/org/folio/rest/support/ShelvingOrderUpdate.java
@@ -24,7 +24,7 @@ import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 
-public class ShelvingOrderUpdate extends Versioned {
+public class ShelvingOrderUpdate {
 
   private static final Logger log = LogManager.getLogger();
 
@@ -52,15 +52,17 @@ public class ShelvingOrderUpdate extends Versioned {
   private static final String OPERATION_STATUS_ITEMS_UPDATES_SUCCESSFUL = "Items updates completed successfully";
   private static final String OPERATION_STATUS_ITEMS_UPDATES_FAILED = "Items updates failed";
 
+  private Versioned versionChecker;
 
   private int updateBunchSize;
   private Map<UUID, String> itemsShelvingOrderMap;
   private Map<UUID, Item> itemsMap;
 
   public ShelvingOrderUpdate(int updateBunchSize) {
-    super();
+    this.versionChecker = new Versioned() { };
+    this.versionChecker.setFromModuleVersion(FROM_VERSION_SHELVING_ORDER);
     this.updateBunchSize = updateBunchSize;
-    setFromModuleVersion(FROM_VERSION_SHELVING_ORDER);
+
     itemsShelvingOrderMap = new LinkedHashMap<>();
     itemsMap = new LinkedHashMap<>();
   }
@@ -69,7 +71,7 @@ public class ShelvingOrderUpdate extends Versioned {
     Promise<String> promise = Promise.promise();
 
     String fromModuleVersion = attributes.getModuleFrom().trim();
-    if (StringUtils.isBlank(fromModuleVersion) || isNewForThisInstall(fromModuleVersion)) {
+    if (StringUtils.isBlank(fromModuleVersion) || versionChecker.isNewForThisInstall(fromModuleVersion)) {
       // Update items only for versions before the expected
       promise.fail(OPERATION_STATUS_VERSION_MISMATCH);
     } else {

--- a/src/main/java/org/folio/rest/support/ShelvingOrderUpdate.java
+++ b/src/main/java/org/folio/rest/support/ShelvingOrderUpdate.java
@@ -1,0 +1,186 @@
+package org.folio.rest.support;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.Tuple;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.dbschema.Versioned;
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
+
+public class ShelvingOrderUpdate extends Versioned {
+
+  private static final Logger log = LogManager.getLogger();
+
+  private static final String SQL_EXISTS_ITEMS_TO_UPDATE = new StringBuilder()
+      .append("SELECT EXISTS (SELECT null FROM item WHERE not (jsonb ? 'effectiveShelvingOrder'))")
+      .toString();
+
+  private static final String SQL_SELECT_ITEMS = new StringBuilder()
+      .append("SELECT id AS \"id\", ")
+      .append("jsonb AS \"itemJson\" ")
+      .append("FROM item WHERE not (jsonb ? 'effectiveShelvingOrder') ")
+      .append(" FOR UPDATE ")
+      .append("LIMIT $1").toString();
+
+
+  private static final String SQL_UPDATE_ITEMS = new StringBuilder()
+      .append("UPDATE ITEM ")
+      .append("SET jsonb = $1 ")
+      .append("WHERE id = $2").toString();
+
+  // Defines version threshold where this property was introduces from
+  private static final String FROM_VERSION_SHELVING_ORDER = "19.5.0";
+
+  private static final String OPERATION_STATUS_VERSION_MISMATCH = "Module version isn't expected";
+  private static final String OPERATION_STATUS_ITEMS_UPDATES_SUCCESSFUL = "Items updates completed successfully";
+  private static final String OPERATION_STATUS_ITEMS_UPDATES_FAILED = "Items updates failed";
+
+
+  private int updateBunchSize;
+  private Map<UUID, String> itemsShelvingOrderMap;
+  private Map<UUID, Item> itemsMap;
+
+  public ShelvingOrderUpdate(int updateBunchSize) {
+    super();
+    this.updateBunchSize = updateBunchSize;
+    setFromModuleVersion(FROM_VERSION_SHELVING_ORDER);
+    itemsShelvingOrderMap = new LinkedHashMap<>();
+    itemsMap = new LinkedHashMap<>();
+  }
+
+  public Future<String> updateItems(TenantAttributes attributes, Map<String, String> headers, Context vertxContext) {
+    Promise<String> promise = Promise.promise();
+
+    String fromModuleVersion = attributes.getModuleFrom().trim();
+    if (StringUtils.isBlank(fromModuleVersion) || isNewForThisInstall(fromModuleVersion)) {
+      // Update items only for versions before the expected
+      promise.fail(OPERATION_STATUS_VERSION_MISMATCH);
+    } else {
+      PostgresClient postgresClient =  PgUtil.postgresClient(vertxContext, headers);
+
+      hasItemsToUpdate(vertxContext.owner(), postgresClient)
+          .onSuccess(itemsExists -> {
+            log.warn("Items update started");
+          }).onFailure(h -> {
+            log.info("No items for update");
+      });
+    }
+
+    return promise.future();
+  }
+
+  private Future<Boolean> hasItemsToUpdate(Vertx vertx, PostgresClient postgresClient) {
+    Promise<Boolean> promise = Promise.promise();
+
+    postgresClient.execute(SQL_EXISTS_ITEMS_TO_UPDATE, ar -> {
+      if (ar.succeeded()) {
+        RowSet<Row> rows = ar.result();
+        boolean itemsExists = rows.iterator().next().getBoolean(0);
+        promise.complete(itemsExists);
+
+        fetchAndUpdatesItems(vertx, postgresClient)
+            .onSuccess(h -> hasItemsToUpdate(vertx, postgresClient))
+            .onFailure(h -> log.warn("Current items updates failed: "  + h.getMessage()));
+
+      } else {
+        promise.fail("Failure: " + ar.cause().getMessage());
+      }
+    });
+
+    return promise.future();
+  }
+
+  private Future<Integer> fetchAndUpdatesItems(Vertx vertx, PostgresClient postgresClient) {
+    Promise<Integer> promise = Promise.promise();
+
+    vertx.setTimer(500L, timer -> {
+      itemsShelvingOrderMap.clear();
+
+      postgresClient.getConnection(ar -> {
+
+        if (ar.failed()) {
+          promise.fail("Connection acquiring failure : " + ar.cause().getMessage());
+        } else {
+
+          PgConnection conn = ar.result();
+          // Starts a new transaction (acquiring and updating of items performs in single transaction)
+          conn.begin()
+              .compose(tx -> conn
+
+                  // Acquiring current bunch of items
+                .preparedQuery(SQL_SELECT_ITEMS)
+                .execute(Tuple.of(updateBunchSize))
+                .compose(itemsRows -> {
+                  final Promise<RowSet<Row>> promiseOfUpdateItems = Promise.promise();
+
+                  // Read items and fill them into data structures for further processing
+                  List<Item> itemList = new ArrayList<>();
+                  itemsRows.forEach(row -> {
+                    UUID itemId = row.getUUID("id");
+                    JsonObject itemJsonObject = row.getJsonObject("itemJson");
+                    Item item = itemJsonObject.mapTo(Item.class);
+                    itemList.add(item);
+                    itemsMap.put(itemId, item);
+                  });
+
+                  // Calculate items shelving order
+                  Map<UUID, JsonObject> updatedItemsMap = itemList.stream()
+                      .map(EffectiveCallNumberComponentsUtil::getCalculateAndSetEffectiveShelvingOrder)
+                      .collect(Collectors.toMap(item -> UUID.fromString(item.getId()), JsonObject::mapFrom));
+
+                  // Prepare items update parameters
+                  List<Tuple> itemsUpdateParams = new ArrayList<>();
+                  updatedItemsMap.entrySet().stream()
+                      .map(entry -> itemsUpdateParams.add(Tuple.of(entry.getValue(), entry.getKey())))
+                      .collect(Collectors.toList());
+
+                  // Updates of items
+                  conn
+                      .preparedQuery(SQL_UPDATE_ITEMS)
+                      .executeBatch(itemsUpdateParams, res -> {
+                        if (res.succeeded()) {
+                          int updatedItemsCount = res.result().iterator().next().getInteger(0);
+                          log.info("There were {} items updated", updatedItemsCount);
+                          promiseOfUpdateItems.complete(res.result());
+                        } else {
+                          log.error("Items updates failed {}", res.cause());
+                          promiseOfUpdateItems.fail(res.cause().getMessage());
+                        }
+                      });
+
+                  return promiseOfUpdateItems.future();
+                }
+              )
+                  // Finish transaction
+              .compose(res3 -> tx.commit())
+              .eventually(v -> conn.close())
+                  .onSuccess(h -> log.info("Items update transaction succeeded"))
+                  .onFailure(h -> log.error("Items update transaction filed: {}", h.getMessage())));
+
+        } // Connection acquired successfully
+
+      }); // Eof getConnection scope
+
+     }); // Eof vert.x timer scope
+
+    return promise.future();
+  }
+
+}

--- a/src/main/java/org/folio/rest/support/ShelvingOrderUpdate.java
+++ b/src/main/java/org/folio/rest/support/ShelvingOrderUpdate.java
@@ -58,7 +58,7 @@ public class ShelvingOrderUpdate {
   private Versioned versionChecker;
   private int rowsBunchSize;
   private AtomicInteger totalUpdatedRows;
-  private Handler<AsyncResult<Boolean>> completionHandler;
+//  private Handler<AsyncResult<Boolean>> completionHandler;
 
   public static ShelvingOrderUpdate getInstance() {
     return getInstance(DEF_FETCH_SIZE);
@@ -83,15 +83,15 @@ public class ShelvingOrderUpdate {
     this.totalUpdatedRows = new AtomicInteger(0);
   }
 
-  public void setCompletionHandler(Handler<AsyncResult<Boolean>> handler) {
-    log.info("getCompletionHandler set up: {}", handler);
-    completionHandler = handler;
-  }
+//  public void setCompletionHandler(Handler<AsyncResult<Boolean>> handler) {
+//    log.info("getCompletionHandler set up: {}", handler);
+//    completionHandler = handler;
+//  }
 
-  public Handler<AsyncResult<Boolean>> getCompletionHandler() {
-    log.info("getCompletionHandler acquired: {}", completionHandler);
-    return completionHandler;
-  }
+//  public Handler<AsyncResult<Boolean>> getCompletionHandler() {
+//    log.info("getCompletionHandler acquired: {}", completionHandler);
+//    return completionHandler;
+//  }
 
   /**
    * Entry routine of items updates. Invokes the process recursively until no items to update
@@ -105,13 +105,13 @@ public class ShelvingOrderUpdate {
       Context vertxContext) {
 
     // Set completion handler promise for notifying if update performed or not
-    final Promise<Boolean> completionHandlerPromise = Promise.promise();
-    if (!Objects.isNull(getCompletionHandler())) {
-      log.info("Setting completionHandler {} to promise: {}", getCompletionHandler(), completionHandlerPromise);
-      getCompletionHandler().handle(completionHandlerPromise.future());
-    } else {
-      log.info("Setting completionHandler skipped, it's a null: {}", getCompletionHandler());
-    }
+//    final Promise<Boolean> completionHandlerPromise = Promise.promise();
+//    if (!Objects.isNull(getCompletionHandler())) {
+//      log.info("Setting completionHandler {} to promise: {}", getCompletionHandler(), completionHandlerPromise);
+//      getCompletionHandler().handle(completionHandlerPromise.future());
+//    } else {
+//      log.info("Setting completionHandler skipped, it's a null: {}", getCompletionHandler());
+//    }
 
     final Promise<Integer> updateItemsPromise = Promise.promise();
     final Vertx vertx = vertxContext.owner();
@@ -137,12 +137,12 @@ public class ShelvingOrderUpdate {
               log.info("Items update with shelving order property completed in {} seconds",
                   (System.currentTimeMillis() - startTime) / 1000);
               updateItemsPromise.complete(totalUpdatedRows.get());
-              completionHandlerPromise.complete((totalUpdatedRows.get() > 0));
+//              completionHandlerPromise.complete((totalUpdatedRows.get() > 0));
             }
           })
           .onFailure(h -> {
             updateItemsPromise.fail(h.getCause());
-            completionHandlerPromise.fail(h.getCause());
+//            completionHandlerPromise.fail(h.getCause());
             log.error("Error updating items: {}", h.getCause().getMessage());
           });
 
@@ -150,7 +150,7 @@ public class ShelvingOrderUpdate {
       log.info("Module isn't eligible for upgrade, just exit.");
       // Not allowed to perform items updates, just returns
       updateItemsPromise.complete(0);
-      completionHandlerPromise.complete(Boolean.FALSE);
+//      completionHandlerPromise.complete(Boolean.FALSE);
     }
 
     return updateItemsPromise.future();

--- a/src/main/java/org/folio/rest/support/ShelvingOrderUpdate.java
+++ b/src/main/java/org/folio/rest/support/ShelvingOrderUpdate.java
@@ -101,7 +101,7 @@ public class ShelvingOrderUpdate {
    * @param vertxContext
    * @return
    */
-  public Future<Integer> updateItems(TenantAttributes attributes, Map<String, String> headers,
+  public Future<Integer> startUpdatingOfItems(TenantAttributes attributes, Map<String, String> headers,
       Context vertxContext) {
 
     // Set completion handler promise for notifying if update performed or not
@@ -164,7 +164,7 @@ public class ShelvingOrderUpdate {
    * @param postgresClient
    * @return
    */
-  private Future<Integer> fetchAndUpdatesItems(Vertx vertx, PostgresClient postgresClient) {
+  public Future<Integer> fetchAndUpdatesItems(Vertx vertx, PostgresClient postgresClient) {
     log.info("The routine of \"fetchAndUpdatesItems\" has started");
     Promise<Integer> fetchAndUpdatePromise = Promise.promise();
 
@@ -233,7 +233,7 @@ public class ShelvingOrderUpdate {
    * @param rowSet
    * @return
    */
-  private Future<List<Item>> aggregateRow2List(RowSet<Row> rowSet) {
+  public Future<List<Item>> aggregateRow2List(RowSet<Row> rowSet) {
     log.info("Invoking of aggregateRow2List, rows size: {}", rowSet.size());
     Promise<List<Item>> promise = Promise.promise();
 
@@ -257,7 +257,7 @@ public class ShelvingOrderUpdate {
    * 
    * @return
    */
-  private Future<Map<UUID, JsonObject>> calculateShelvingOrder(List<Item> itemList) {
+  public Future<Map<UUID, JsonObject>> calculateShelvingOrder(List<Item> itemList) {
     log.info("Invoking of calculateShelvingOrder, itemList size: {}",
         Optional.ofNullable(itemList).orElse(new ArrayList<>()).size());
 
@@ -274,7 +274,7 @@ public class ShelvingOrderUpdate {
    * @param itemIdMap
    * @return
    */
-  private Future<List<Tuple>> prepareItemsUpdate(Map<UUID, JsonObject> itemIdMap) {
+  public Future<List<Tuple>> prepareItemsUpdate(Map<UUID, JsonObject> itemIdMap) {
     log.info("Invoking of prepareItemsUpdate");
 
     List<Tuple> itemsUpdateParams = new ArrayList<>();
@@ -292,7 +292,7 @@ public class ShelvingOrderUpdate {
    * @param connection
    * @return
    */
-  private Future<Integer> updateItems(List<Tuple> itemsParams, PgConnection connection) {
+  public Future<Integer> updateItems(List<Tuple> itemsParams, PgConnection connection) {
     log.info("Invoking of updateItems, itemsParams size: {}", itemsParams.size());
     log.info("Items parameters for update SQL: {}",
         StringUtils.defaultIfBlank(itemsParams.stream().map(Tuple::toString).collect(Collectors.joining(",")),

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -237,7 +237,7 @@ public class StorageTestSuite {
     .get(20, TimeUnit.SECONDS);
   }
 
-  static void prepareTenant(String tenantId, String moduleFrom, String moduleTo, boolean loadSample)
+  public static void prepareTenant(String tenantId, String moduleFrom, String moduleTo, boolean loadSample)
     throws InterruptedException,
     ExecutionException,
     TimeoutException {
@@ -255,7 +255,7 @@ public class StorageTestSuite {
     tenantOp(tenantId, jo);
   }
 
-  static void prepareTenant(String tenantId, boolean loadSample)
+  public static void prepareTenant(String tenantId, boolean loadSample)
       throws InterruptedException,
       ExecutionException,
       TimeoutException {

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -262,7 +262,7 @@ public class StorageTestSuite {
     prepareTenant(tenantId, null, "mod-inventory-storage-1.0.0", loadSample);
   }
 
-  static void removeTenant(String tenantId) throws InterruptedException, ExecutionException, TimeoutException {
+  public static void removeTenant(String tenantId) throws InterruptedException, ExecutionException, TimeoutException {
 
     JsonObject jo = new JsonObject();
     jo.put("purge", Boolean.TRUE);

--- a/src/test/java/org/folio/services/CallNumberUtilsTest.java
+++ b/src/test/java/org/folio/services/CallNumberUtilsTest.java
@@ -48,20 +48,67 @@ public class CallNumberUtilsTest extends TestCase {
     String copy,
     String suffix
   ) {
+    Item item = prepareAnItem(prefix, callNumber, volume, enumeration, chronology, copy, suffix);
+    HoldingsRecord holdingsRecord = new HoldingsRecord();
+    EffectiveCallNumberComponentsUtil.setCallNumberComponents(item, holdingsRecord);
+    EffectiveCallNumberComponentsUtil.calculateAndSetEffectiveShelvingOrder(item);
 
+    assertThat(item.getEffectiveShelvingOrder(),is (desiredShelvingOrder));
+  }  
+  
+  @Parameters({
+    "PN 12 A6,PN12 .A6,,PN2 .A6,,,,,",
+    "PN 12 A6 V 13 NO 12 41999,PN2 .A6 v.3 no.2 1999,,PN2 .A6,v. 3,no. 2,1999,,",
+    "PN 12 A6 41999,PN12 .A6 41999,,PN2 .A6 1999,,,,,",
+    "PN 12 A6 41999 CD,PN12 .A6 41999 CD,,PN2 .A6 1999,,,,,CD",
+    "PN 12 A6 41999 12,PN12 .A6 41999 C.12,,PN2 .A6 1999,,,,2,",
+    "PN 12 A69 41922 12,PN12 .A69 41922 C.12,,PN2 .A69,,,1922,2,",
+    "PN 12 A69 NO 12,PN12 .A69 NO.12,,PN2 .A69,,no. 2,,,",
+    "PN 12 A69 NO 12 41922 11,PN12 .A69 NO.12 41922 C.11,,PN2 .A69,,no. 2,1922,1,",
+    "PN 12 A69 NO 12 41922 12,PN12 .A69 NO.12 41922 C.12,Wordsworth,PN2 .A69,,no. 2,1922,2,",
+    "PN 12 A69 V 11 NO 11,PN12 .A69 V.11 NO.11,,PN2 .A69,v.1,no. 1,,,",
+    "PN 12 A69 V 11 NO 11 +,PN12 .A69 V.11 NO.11 +,Over,PN2 .A69,v.1,no. 1,,,+",
+    "PN 12 A69 V 11 NO 11 41921,PN12 .A69 V.11 NO.11 41921,,PN2 .A69,v.1,no. 1,1921,,",
+    "PR 49199.3 41920 L33 41475 A6,PR 49199.3 41920 .L33 41475 .A6,,PR9199.3 1920 .L33 1475 .A6,,,,,",
+    "PQ 42678 K26 P54,PQ 42678 .K26 P54,,PQ2678.K26 P54,,,,,",
+    "PQ 48550.21 R57 V5 41992,PQ 48550.21 .R57 V15 41992,,PQ8550.21.R57 V5 1992,,,,,",
+    "PQ 48550.21 R57 V5 41992,PQ 48550.21 .R57 V15 41992,,PQ8550.21.R57 V5,,,1992,,",
+    "PR 3919 L33 41990,PR 3919 .L33 41990,,PR919 .L33 1990,,,,,",
+    "PR 49199 A39,PR 49199 .A39,,PR9199 .A39,,,,,",
+    "PR 49199.48 B3,PR 49199.48 .B3,,PR9199.48 .B3,,,,,"
+  })
+  @Test
+  public void shouldReturnsItemsWithShelvingNumber(
+    String desiredShelvingOrder,
+    String initiallyDesiredShelvesOrder,
+    String prefix,
+    String callNumber,
+    String volume,
+    String enumeration,
+    String chronology,
+    String copy,
+    String suffix
+  ) {
+    Item item = prepareAnItem(prefix, callNumber, volume, enumeration, chronology, copy, suffix);
+    HoldingsRecord holdingsRecord = new HoldingsRecord();
+    EffectiveCallNumberComponentsUtil.setCallNumberComponents(item, holdingsRecord);
+
+    assertThat(EffectiveCallNumberComponentsUtil.getCalculateAndSetEffectiveShelvingOrder(item)
+      .getEffectiveShelvingOrder(), is(desiredShelvingOrder));
+  }
+  
+  private Item prepareAnItem(String callNumberPrefix, String callNumber, String volume,
+      String enumeration, String chronology, String copyNumber, String callNumberSuffix) {
     Item item = new Item();
-    item.setItemLevelCallNumberPrefix(prefix);
+    item.setItemLevelCallNumberPrefix(callNumberPrefix);
     item.setItemLevelCallNumber(callNumber);
     item.setVolume(volume);
     item.setEnumeration(enumeration);
     item.setChronology(chronology);
-    item.setCopyNumber(copy);
-    item.setItemLevelCallNumberSuffix(suffix);
+    item.setCopyNumber(copyNumber);
+    item.setItemLevelCallNumberSuffix(callNumberSuffix);
 
-    HoldingsRecord holdingsRecord = new HoldingsRecord();
-    EffectiveCallNumberComponentsUtil.setCallNumberComponents(item,holdingsRecord);
-    EffectiveCallNumberComponentsUtil.calculateAndSetEffectiveShelvingOrder(item);
-
-    assertThat(item.getEffectiveShelvingOrder(),is (desiredShelvingOrder));
+    return item;
   }
+  
 }

--- a/src/test/java/org/folio/services/ShelvingOrderUpdateTest.java
+++ b/src/test/java/org/folio/services/ShelvingOrderUpdateTest.java
@@ -1,5 +1,8 @@
 package org.folio.services;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 import static org.folio.rest.api.StorageTestSuite.removeTenant;
 import static org.folio.rest.api.StorageTestSuite.tenantOp;
 
@@ -8,40 +11,93 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.folio.rest.api.TestBase;
 import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.support.ShelvingOrderUpdate;
 
 @RunWith(VertxUnitRunner.class)
 public class ShelvingOrderUpdateTest extends TestBase {
 
   private static final Logger log = LogManager.getLogger();
 
-  private static final String FROM_MODULE_EXPECTED_VALUE = "mod-inventory-storage-20.1.0";
-  private static final String FROM_MODULE_UNEXPECTED_VALUE = "mod-inventory-storage-21.0.0";
-  private static final String BASE_MODULE_VALUE = "mod-inventory-storage-1.0.0";
+  private static final String VERSION_WITH_SHELVING_ORDER = "mod-inventory-storage-20.1.0";
+  private static final String FROM_MODULE_DO_UPGRADE = "mod-inventory-storage-19.9.0";
+  private static final String FROM_MODULE_SKIP_UPGRADE = "mod-inventory-storage-20.2.0";
 
   private static String defaultTenant;
+  private static ShelvingOrderUpdate shelvingOrderUpdate;
 
   @BeforeClass
   @SneakyThrows
   public static void beforeClass(TestContext context) {
+    shelvingOrderUpdate = ShelvingOrderUpdate.getInstance();
     defaultTenant = generateTenantValue();
     tenantOp(defaultTenant,
-        JsonObject.mapFrom(new TenantAttributes().withModuleTo((BASE_MODULE_VALUE))));
+        JsonObject.mapFrom(new TenantAttributes().withModuleTo((VERSION_WITH_SHELVING_ORDER))));
   }
 
   @AfterClass
   @SneakyThrows
   public static void afterClass(TestContext context) {
     deleteTenant(defaultTenant);
+  }
+
+  @Test
+  public void checkingShouldPassForOlderModuleVersions() {
+    shelvingOrderUpdate = ShelvingOrderUpdate.getInstance();
+    defaultTenant = generateTenantValue();
+
+    final TenantAttributes tenantAttributes = getTenantAttributes(FROM_MODULE_DO_UPGRADE);
+    boolean result = shelvingOrderUpdate.isAllowedToUpdate(tenantAttributes);
+    assertTrue("Module version eligible to upgrade", result);
+  }
+
+  @Test
+  public void checkingShouldFailForNewerModuleVersions() {
+    shelvingOrderUpdate = ShelvingOrderUpdate.getInstance();
+    defaultTenant = generateTenantValue();
+
+    final TenantAttributes tenantAttributes = getTenantAttributes(FROM_MODULE_SKIP_UPGRADE);
+    boolean result = shelvingOrderUpdate.isAllowedToUpdate(tenantAttributes);
+    assertFalse("Module version isn't eligible to upgrade", result);
+  }
+
+  @Test
+  public void checkingShouldFailForEmptyModuleVersionPassed() {
+    shelvingOrderUpdate = ShelvingOrderUpdate.getInstance();
+    defaultTenant = generateTenantValue();
+
+    final TenantAttributes tenantAttributes = getTenantAttributes(StringUtils.EMPTY);
+    boolean result = shelvingOrderUpdate.isAllowedToUpdate(tenantAttributes);
+    assertFalse("Empty module version isn't eligible to upgrade", result);
+  }
+
+  @Test
+  public void checkingShouldFailForNullModuleVersionPassed() {
+    shelvingOrderUpdate = ShelvingOrderUpdate.getInstance();
+    defaultTenant = generateTenantValue();
+
+    final TenantAttributes tenantAttributes = getTenantAttributes(null);
+    boolean result = shelvingOrderUpdate.isAllowedToUpdate(tenantAttributes);
+    assertFalse("Empty module version isn't eligible to upgrade", result);
+  }
+
+  @Test
+  public void checkingShouldFailForMissedModuleVersionPassed() {
+    shelvingOrderUpdate = ShelvingOrderUpdate.getInstance();
+    defaultTenant = generateTenantValue();
+
+    final TenantAttributes tenantAttributes = new TenantAttributes();
+    boolean result = shelvingOrderUpdate.isAllowedToUpdate(tenantAttributes);
+    assertFalse("Request without specified module version isn't eligible to upgrade", result);
   }
 
   @Test
@@ -53,8 +109,8 @@ public class ShelvingOrderUpdateTest extends TestBase {
     initTenant(tenant);
     log.info("Tenant initialization finished");
 
-    log.info("Module upgrade started, fromModuleVersion: {}", FROM_MODULE_EXPECTED_VALUE);
-    postTenantOperation(tenant, FROM_MODULE_EXPECTED_VALUE);
+    log.info("Module upgrade started, fromModuleVersion: {}", FROM_MODULE_DO_UPGRADE);
+    postTenantOperation(tenant, FROM_MODULE_DO_UPGRADE);
     log.info("Module upgrade completed");
 
     log.info("Tenant deletion started: {}", tenant);
@@ -62,7 +118,6 @@ public class ShelvingOrderUpdateTest extends TestBase {
     log.info("Tenant deletion finished");
   }
 
-  @Ignore
   @Test
   public void shouldFailItemsUpdateForUnexpectedModuleVersion() {
     String tenant = generateTenantValue();
@@ -72,8 +127,8 @@ public class ShelvingOrderUpdateTest extends TestBase {
     initTenant(tenant);
     log.info("Tenant initialization finished");
 
-    log.info("Module upgrade started, fromModuleVersion: {}", FROM_MODULE_UNEXPECTED_VALUE);
-    postTenantOperation(tenant, FROM_MODULE_UNEXPECTED_VALUE);
+    log.info("Module upgrade started, fromModuleVersion: {}", FROM_MODULE_SKIP_UPGRADE);
+    postTenantOperation(tenant, FROM_MODULE_SKIP_UPGRADE);
     log.info("Module upgrade completed");
 
     log.info("Tenant deletion started: {}", tenant);
@@ -81,15 +136,21 @@ public class ShelvingOrderUpdateTest extends TestBase {
     log.info("Tenant deletion finished");
   }
 
+  private static TenantAttributes getTenantAttributes(String moduleFrom) {
+    return new TenantAttributes()
+        .withModuleTo(VERSION_WITH_SHELVING_ORDER)
+        .withModuleFrom(moduleFrom);
+  }
+
   private static String generateTenantValue() {
     String tenant = String.format("tenant_%s", RandomStringUtils.randomAlphanumeric(7));
-    log.info("*** net tenant generated: {}", tenant);
+    log.info("New tenant generated: {}", tenant);
     return tenant;
   }
 
   @SneakyThrows
   private static void postTenantOperation(String tenant, String fromModuleValue) {
-    tenantOp(tenant, JsonObject.mapFrom(new TenantAttributes().withModuleFrom(fromModuleValue)));
+    tenantOp(tenant, JsonObject.mapFrom(getTenantAttributes(fromModuleValue)));
   }
 
   @SneakyThrows
@@ -99,7 +160,8 @@ public class ShelvingOrderUpdateTest extends TestBase {
 
   @SneakyThrows
   private void initTenant(String tenant) {
-    tenantOp(tenant, JsonObject.mapFrom(new TenantAttributes().withModuleTo(BASE_MODULE_VALUE)));
+    tenantOp(tenant,
+        JsonObject.mapFrom(new TenantAttributes().withModuleTo(VERSION_WITH_SHELVING_ORDER)));
   }
 
 }

--- a/src/test/java/org/folio/services/ShelvingOrderUpdateTest.java
+++ b/src/test/java/org/folio/services/ShelvingOrderUpdateTest.java
@@ -6,24 +6,34 @@ import static org.junit.Assert.assertTrue;
 import static org.folio.rest.api.StorageTestSuite.removeTenant;
 import static org.folio.rest.api.StorageTestSuite.tenantOp;
 
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
+import io.vertx.pgclient.PgConnection;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.helpers.LocalRowSet;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import org.folio.rest.api.TestBase;
 import org.folio.rest.jaxrs.model.TenantAttributes;
 import org.folio.rest.support.ShelvingOrderUpdate;
+import org.mockito.Mockito;
+import org.mockito.stubbing.Answer;
 
 @RunWith(VertxUnitRunner.class)
 public class ShelvingOrderUpdateTest extends TestBase {
@@ -34,6 +44,19 @@ public class ShelvingOrderUpdateTest extends TestBase {
   private static final String FROM_MODULE_DO_UPGRADE = "mod-inventory-storage-19.9.0";
   private static final String FROM_MODULE_SKIP_UPGRADE = "mod-inventory-storage-20.2.0";
 
+  private static String SQL_UPDATE_REMOVE_ITEMS_PROPERTY = new StringBuilder()
+      .append("UPDATE item ")
+      .append("SET jsonb = jsonb - 'effectiveShelvingOrder' ").toString();
+
+  private static String SQL_SELECT_ITEMS_COUNT = new StringBuilder()
+      .append("SELECT COUNT(*) AS cnt ")
+      .append("FROM item ").toString();
+
+  private static String SQL_SELECT_ITEMS_AMOUNT_FOR_UPDATE = new StringBuilder()
+      .append("SELECT COUNT(*) AS cnt ")
+      .append("FROM item ")
+      .append("WHERE NOT (jsonb ? 'effectiveShelvingOrder') ").toString();
+
   private static String defaultTenant;
   private static ShelvingOrderUpdate shelvingOrderUpdate;
 
@@ -42,20 +65,20 @@ public class ShelvingOrderUpdateTest extends TestBase {
   public static void beforeClass(TestContext context) {
     shelvingOrderUpdate = ShelvingOrderUpdate.getInstance();
     defaultTenant = generateTenantValue();
-    tenantOp(defaultTenant,
-        JsonObject.mapFrom(new TenantAttributes().withModuleTo((VERSION_WITH_SHELVING_ORDER))));
+
+    log.info("Default tenant initialization started: {}", defaultTenant);
+    initTenant(defaultTenant, VERSION_WITH_SHELVING_ORDER);
+    log.info("Default tenant initialization finished");
   }
 
   @AfterClass
   @SneakyThrows
   public static void afterClass(TestContext context) {
-    deleteTenant(defaultTenant);
+    removeTenant(defaultTenant);
   }
 
   @Test
   public void checkingShouldPassForOlderModuleVersions() {
-    defaultTenant = generateTenantValue();
-
     final TenantAttributes tenantAttributes = getTenantAttributes(FROM_MODULE_DO_UPGRADE);
     boolean result = shelvingOrderUpdate.isAllowedToUpdate(tenantAttributes);
     assertTrue("Module version eligible to upgrade", result);
@@ -63,8 +86,6 @@ public class ShelvingOrderUpdateTest extends TestBase {
 
   @Test
   public void checkingShouldFailForNewerModuleVersions() {
-    defaultTenant = generateTenantValue();
-
     final TenantAttributes tenantAttributes = getTenantAttributes(FROM_MODULE_SKIP_UPGRADE);
     boolean result = shelvingOrderUpdate.isAllowedToUpdate(tenantAttributes);
     assertFalse("Module version isn't eligible to upgrade", result);
@@ -72,8 +93,6 @@ public class ShelvingOrderUpdateTest extends TestBase {
 
   @Test
   public void checkingShouldFailForEmptyModuleVersionPassed() {
-    defaultTenant = generateTenantValue();
-
     final TenantAttributes tenantAttributes = getTenantAttributes(StringUtils.EMPTY);
     boolean result = shelvingOrderUpdate.isAllowedToUpdate(tenantAttributes);
     assertFalse("Empty module version isn't eligible to upgrade", result);
@@ -81,8 +100,6 @@ public class ShelvingOrderUpdateTest extends TestBase {
 
   @Test
   public void checkingShouldFailForNullModuleVersionPassed() {
-    defaultTenant = generateTenantValue();
-
     final TenantAttributes tenantAttributes = getTenantAttributes(null);
     boolean result = shelvingOrderUpdate.isAllowedToUpdate(tenantAttributes);
     assertFalse("Empty module version isn't eligible to upgrade", result);
@@ -90,8 +107,6 @@ public class ShelvingOrderUpdateTest extends TestBase {
 
   @Test
   public void checkingShouldFailForMissedModuleVersionPassed() {
-    defaultTenant = generateTenantValue();
-
     final TenantAttributes tenantAttributes = new TenantAttributes();
     boolean result = shelvingOrderUpdate.isAllowedToUpdate(tenantAttributes);
     assertFalse("Request without specified module version isn't eligible to upgrade", result);
@@ -99,61 +114,99 @@ public class ShelvingOrderUpdateTest extends TestBase {
 
   @Test
   public void shouldSucceedItemsUpdateForExpectedModuleVersion() {
-    String tenant = generateTenantValue();
-    log.info("Tenant generated: {}", tenant);
+    log.info("The test \"shouldSucceedItemsUpdateForExpectedModuleVersion\" started...");
+//    String tenant = generateTenantValue();
+//    log.info("Tenant generated: {}", tenant);
+//
+//    log.info("Tenant initialization started: {}", tenant);
+//    initTenant(tenant, VERSION_WITH_SHELVING_ORDER);
+//    log.info("Tenant initialization finished");
 
-    log.info("Tenant initialization started: {}", tenant);
-    initTenant(tenant);
-    log.info("Tenant initialization finished");
+    // Check total items
+    RowSet<Row> result = executeSql(SQL_SELECT_ITEMS_COUNT);
+    int itemsTotal = result.iterator().next().getInteger(0);
+    log.info("There are {} items total", itemsTotal);
 
-    Future<Boolean> operationFutureResult = doModuleUpgrade(tenant, FROM_MODULE_DO_UPGRADE);
-    log.info("!!!!!! 1) operationFutureResult: {}, operationFutureResult.succeeded: {}, operationFutureResult.result: {} ", operationFutureResult, operationFutureResult.succeeded(), operationFutureResult.result());
-    shelvingOrderUpdate.setCompletionHandler(null);
-    //assertTrue("Items update should succeed", operationFutureResult.result());
+    // Prepare items for update
+    removeItemsProperty((defaultTenant));
 
-    log.info("Tenant deletion started: {}", tenant);
-    deleteTenant(tenant);
-    log.info("Tenant deletion finished");
+    // Check amount of items for update
+    int expectedItemsCountForUpdate = getItemsForUpdateCount();
+    log.info("There are {} items to update", expectedItemsCountForUpdate);
+    assertTrue("The are expected items for update", expectedItemsCountForUpdate > 0);
+
+    // Get operation result
+    boolean operationResult = doModuleUpgrade(defaultTenant, FROM_MODULE_DO_UPGRADE);
+    log.info("The result of doModuleUpgrade execution", operationResult);
+
+    // Check amount of items after update
+    int expectedItemsCountAfterUpdate = getItemsForUpdateCount();
+    log.info("There are {} items after update", expectedItemsCountAfterUpdate);
+    assertTrue("No items should remain after update", expectedItemsCountAfterUpdate == 0);
+
+//    log.info("Tenant deletion started: {}", tenant);
+//    deleteTenant(tenant);
+//    log.info("Tenant deletion finished");
+    log.info("The test \"shouldSucceedItemsUpdateForExpectedModuleVersion\" finished");
   }
 
   @Test
   public void shouldFailItemsUpdateForUnexpectedModuleVersion() {
-    String tenant = generateTenantValue();
-    log.info("Tenant generated: {}", tenant);
+    log.info("The test \"shouldFailItemsUpdateForUnexpectedModuleVersion\" started...");
+//    String tenant = generateTenantValue();
+//    log.info("Tenant generated: {}", tenant);
+//
+//    log.info("Tenant initialization started: {}", tenant);
+//    initTenant(tenant, VERSION_WITH_SHELVING_ORDER);
+//    log.info("Tenant initialization finished");
 
-    log.info("Tenant initialization started: {}", tenant);
-    initTenant(tenant);
-    log.info("Tenant initialization finished");
+    // Check total items
+    RowSet<Row> result = executeSql(SQL_SELECT_ITEMS_COUNT);
+    int itemsTotal = result.iterator().next().getInteger(0);
+    log.info("There are {} items total", itemsTotal);
 
-    Future<Boolean> operationFutureResult = doModuleUpgrade(tenant, FROM_MODULE_SKIP_UPGRADE);
-    log.info("!!!!!! 2) operationFutureResult: {}, operationFutureResult.succeeded: {}, operationFutureResult.result: {} ", operationFutureResult, operationFutureResult.succeeded(), operationFutureResult.result());
-    shelvingOrderUpdate.setCompletionHandler(null);
-    //assertFalse("Items update should skipped", operationFutureResult.succeeded());
+    // Prepare items for update
+    removeItemsProperty((defaultTenant));
 
-    log.info("Tenant deletion started: {}", tenant);
-    deleteTenant(tenant);
-    log.info("Tenant deletion finished");
+    // Check amount of items for update
+    int expectedItemsCountForUpdate = getItemsForUpdateCount();
+    log.info("There are {} items to update", expectedItemsCountForUpdate);
+    assertTrue("The are expected items for update", expectedItemsCountForUpdate > 0);
+
+    // Get operation result
+    boolean operationResult = doModuleUpgrade(defaultTenant, FROM_MODULE_SKIP_UPGRADE);
+    log.info("The result of doModuleUpgrade execution: {}", operationResult);
+
+    // Check amount of items after update
+    int expectedItemsCountAfterUpdate = getItemsForUpdateCount();
+    log.info("There are {} items after update", expectedItemsCountAfterUpdate);
+    assertTrue("No items should remain after update", expectedItemsCountAfterUpdate == 0);
+
+//    log.info("Tenant deletion started: {}", tenant);
+//    deleteTenant(tenant);
+//    log.info("Tenant deletion finished");
+    log.info("The test \"shouldFailItemsUpdateForUnexpectedModuleVersion\" finished");
   }
 
-  private Future<Boolean> doModuleUpgrade(String tenant, String fromModuleVersion) {
-    Promise<Boolean> promise = Promise.promise();
-    shelvingOrderUpdate.setCompletionHandler(promise);
+  @Ignore
+  @Test
+  public void acquiringOfConnectionShouldFail() {
+    PostgresClient postgresClient =  Mockito.mock(PostgresClient.class);
+    AsyncResult<PgConnection> asyncResult = Mockito.mock(AsyncResult.class);
 
-    // Trigger operation
-    log.info("Module upgrade started, fromModuleVersion: {}", fromModuleVersion);
-    postTenantOperation(tenant, fromModuleVersion);
+    Mockito.doAnswer((Answer<AsyncResult<PgConnection>>) invocationOnMock -> {
+      //((Handler<AsyncResult<PgConnection>>) invocationOnMock.getArgument(0)).handle(asyncResult);
+      throw new RuntimeException("Connection can't be acquired by testing purposes");
+    }).when(postgresClient).getConnection(Mockito.any());
 
-    promise.future().onComplete(h -> {
-      log.info("Module upgrade completed");
-      if (h.succeeded()) {
-        log.info("Items updates occurred: {}", h.result());
-      } else {
-        log.info("Items updates failed: {}", h.cause().getMessage());
-      }
-    });
-    return promise.future();
+    // Try to execute processing
+    Future<Integer> future = shelvingOrderUpdate.fetchAndUpdatesItems(Vertx.vertx(), postgresClient);
+    assertTrue("Connection acquiring should fail", future.failed());
   }
 
+  /*
+  * Internal purposes functions below
+  */
   private static TenantAttributes getTenantAttributes(String moduleFrom) {
     return new TenantAttributes().withModuleTo(VERSION_WITH_SHELVING_ORDER)
         .withModuleFrom(moduleFrom);
@@ -171,14 +224,82 @@ public class ShelvingOrderUpdateTest extends TestBase {
   }
 
   @SneakyThrows
-  private static void deleteTenant(String tenant) {
-    removeTenant(tenant);
+  private static void initTenant(String tenant, String initialModuleVersion) {
+    tenantOp(tenant,
+        JsonObject.mapFrom(new TenantAttributes().withModuleTo(initialModuleVersion)));
+  }
+
+  private static PostgresClient getPostgresClient(String tenant) {
+    return PostgresClient.getInstance(Vertx.vertx(), tenant);
+  }
+
+  private boolean doModuleUpgrade(String tenant, String fromModuleVersion) {
+    log.info("Started execution of the doModuleUpgrade ...");
+    final Promise<Boolean> result = Promise.promise();
+    shelvingOrderUpdate.setCompletionHandler(result);
+
+    // Initiate post tenant operation
+    log.info("Module upgrade started, fromModuleVersion: {}", fromModuleVersion);
+    postTenantOperation(tenant, fromModuleVersion);
+
+    result.future().onComplete(ar -> {
+      log.info("doModuleUpgrade post tenant operation completed");
+      shelvingOrderUpdate.setCompletionHandler(null);
+      if (ar.succeeded()) {
+        log.info("doModuleUpgrade post tenant operation succeed : {}", ar.result());
+      } else {
+        log.info("doModuleUpgrade post tenant operation failed: {}", ar.cause().getMessage());
+      }
+    });
+
+    log.info("Finished execution of the doModuleUpgrade");
+    return get(result.future());
   }
 
   @SneakyThrows
-  private void initTenant(String tenant) {
-    tenantOp(tenant,
-        JsonObject.mapFrom(new TenantAttributes().withModuleTo(VERSION_WITH_SHELVING_ORDER)));
+  private RowSet<Row> executeSql(String sql) {
+    log.info("Started executeSql: {}", sql);
+    final Promise<RowSet<Row>> result = Promise.promise();
+
+    if (StringUtils.isBlank(sql)) {
+      result.complete(new LocalRowSet(0));
+      return get(result.future());
+    }
+
+    getPostgresClient(defaultTenant).execute(sql, executeResult -> {
+      if (executeResult.failed()) {
+        result.fail(executeResult.cause());
+        log.info("Error: {}", executeResult.cause().getMessage());
+      } else {
+        result.complete(executeResult.result());
+        log.info("Successfully executed: {}", executeResult.result());
+      }
+    });
+
+    log.info("Finished executeSql: {}", result.future());
+    return get(result.future());
   }
+
+  private int getItemsForUpdateCount() {
+    log.info("Starting of the getItemsForUpdateCount...");
+
+    RowSet<Row> result = executeSql(SQL_SELECT_ITEMS_AMOUNT_FOR_UPDATE);
+    int itemsCount = result.iterator().next().getInteger(0);
+
+    log.info("There are {} items ready for updates", itemsCount);
+    log.info("Finishing of the getItemsForUpdateCount");
+    return itemsCount;
+}
+
+  private int removeItemsProperty(String tenant) {
+    log.info("Starting of the removeItemsProperty...");
+
+    RowSet<Row> result = executeSql(SQL_UPDATE_REMOVE_ITEMS_PROPERTY);
+    int itemsAffected = result.rowCount();
+
+    log.info("There were {} items updates", itemsAffected);
+    log.info("Finishing of the removeItemsProperty");
+    return itemsAffected;
+ }
 
 }

--- a/src/test/java/org/folio/services/ShelvingOrderUpdateTest.java
+++ b/src/test/java/org/folio/services/ShelvingOrderUpdateTest.java
@@ -54,7 +54,7 @@ public class ShelvingOrderUpdateTest extends TestBase {
     log.info("Tenant initialization finished");
 
     log.info("Module upgrade started, fromModuleVersion: {}", FROM_MODULE_EXPECTED_VALUE);
-//    postTenantOperation(tenant, FROM_MODULE_EXPECTED_VALUE);
+    postTenantOperation(tenant, FROM_MODULE_EXPECTED_VALUE);
     log.info("Module upgrade completed");
 
     log.info("Tenant deletion started: {}", tenant);
@@ -73,7 +73,7 @@ public class ShelvingOrderUpdateTest extends TestBase {
     log.info("Tenant initialization finished");
 
     log.info("Module upgrade started, fromModuleVersion: {}", FROM_MODULE_UNEXPECTED_VALUE);
-//    postTenantOperation(tenant, FROM_MODULE_UNEXPECTED_VALUE);
+    postTenantOperation(tenant, FROM_MODULE_UNEXPECTED_VALUE);
     log.info("Module upgrade completed");
 
     log.info("Tenant deletion started: {}", tenant);

--- a/src/test/java/org/folio/services/ShelvingOrderUpdateTest.java
+++ b/src/test/java/org/folio/services/ShelvingOrderUpdateTest.java
@@ -1,5 +1,6 @@
 package org.folio.services;
 
+import static org.folio.rest.support.CompletableFutureUtil.getFutureResult;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
@@ -344,17 +345,6 @@ public class ShelvingOrderUpdateTest extends TestBaseWithInventoryUtil {
     postTenantOperation(tenant, fromModuleVersion);
 
     log.info("doModuleUpgrade post tenant operation completed");
-  }
-
-  private static <T> T getFutureResult(Future<T> future) {
-    log.info("Started \"getFutureResult\", future: {} ...", future);
-    return getFutureResult(future.toCompletionStage().toCompletableFuture());
-  }
-
-  @SneakyThrows
-  private static <T> T getFutureResult(CompletableFuture<T> future) {
-    log.info("Started \"getFutureResult 2\", future: {} ...", future);
-    return future.get();
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/services/ShelvingOrderUpdateTest.java
+++ b/src/test/java/org/folio/services/ShelvingOrderUpdateTest.java
@@ -3,8 +3,19 @@ package org.folio.services;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
+import static org.folio.rest.api.StorageTestSuite.prepareTenant;
 import static org.folio.rest.api.StorageTestSuite.removeTenant;
 import static org.folio.rest.api.StorageTestSuite.tenantOp;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
@@ -19,24 +30,28 @@ import io.vertx.sqlclient.RowSet;
 import lombok.SneakyThrows;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.common.protocol.types.Field.ComplexArray;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.persist.helpers.LocalRowSet;
+import org.codehaus.plexus.util.dag.Vertex;
+import org.folio.rest.api.TestBase;
+import org.folio.rest.api.TestBaseWithInventoryUtil;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import org.folio.rest.api.TestBase;
-import org.folio.rest.jaxrs.model.TenantAttributes;
-import org.folio.rest.support.ShelvingOrderUpdate;
 import org.mockito.Mockito;
 import org.mockito.stubbing.Answer;
 
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.helpers.LocalRowSet;
+import org.folio.rest.support.ShelvingOrderUpdate;
+
 @RunWith(VertxUnitRunner.class)
-public class ShelvingOrderUpdateTest extends TestBase {
+public class ShelvingOrderUpdateTest extends TestBaseWithInventoryUtil {
 
   private static final Logger log = LogManager.getLogger();
 
@@ -56,6 +71,31 @@ public class ShelvingOrderUpdateTest extends TestBase {
       .append("SELECT COUNT(*) AS cnt ")
       .append("FROM item ")
       .append("WHERE NOT (jsonb ? 'effectiveShelvingOrder') ").toString();
+
+  // Items raw data
+  // (1)expectedShelvingOrder, (2)defaultExpectedDesiredShelvesOrder, (3)prefix, (4)callNumber,
+  // (5)volume, (6)enumeration, (7)chronology, (8)copy, (9)suffix
+  private static String[] ITEMS_DATA = new String[] {
+      "PN 12 A6,PN12 .A6,,PN2 .A6,,,,,",
+      "PN 12 A6 V 13 NO 12 41999,PN2 .A6 v.3 no.2 1999,,PN2 .A6,v. 3,no. 2,1999,,",
+      "PN 12 A6 41999,PN12 .A6 41999,,PN2 .A6 1999,,,,,",
+      "PN 12 A6 41999 CD,PN12 .A6 41999 CD,,PN2 .A6 1999,,,,,CD",
+      "PN 12 A6 41999 12,PN12 .A6 41999 C.12,,PN2 .A6 1999,,,,2,",
+      "PN 12 A69 41922 12,PN12 .A69 41922 C.12,,PN2 .A69,,,1922,2,",
+      "PN 12 A69 NO 12,PN12 .A69 NO.12,,PN2 .A69,,no. 2,,,",
+      "PN 12 A69 NO 12 41922 11,PN12 .A69 NO.12 41922 C.11,,PN2 .A69,,no. 2,1922,1,",
+      "PN 12 A69 NO 12 41922 12,PN12 .A69 NO.12 41922 C.12,Wordsworth,PN2 .A69,,no. 2,1922,2,",
+      "PN 12 A69 V 11 NO 11,PN12 .A69 V.11 NO.11,,PN2 .A69,v.1,no. 1,,,",
+      "PN 12 A69 V 11 NO 11 +,PN12 .A69 V.11 NO.11 +,Over,PN2 .A69,v.1,no. 1,,,+",
+      "PN 12 A69 V 11 NO 11 41921,PN12 .A69 V.11 NO.11 41921,,PN2 .A69,v.1,no. 1,1921,,",
+      "PR 49199.3 41920 L33 41475 A6,PR 49199.3 41920 .L33 41475 .A6,,PR9199.3 1920 .L33 1475 .A6,,,,,",
+      "PQ 42678 K26 P54,PQ 42678 .K26 P54,,PQ2678.K26 P54,,,,,",
+      "PQ 48550.21 R57 V5 41992,PQ 48550.21 .R57 V15 41992,,PQ8550.21.R57 V5 1992,,,,,",
+      "PQ 48550.21 R57 V5 41992,PQ 48550.21 .R57 V15 41992,,PQ8550.21.R57 V5,,,1992,,",
+      "PR 3919 L33 41990,PR 3919 .L33 41990,,PR919 .L33 1990,,,,,",
+      "PR 49199 A39,PR 49199 .A39,,PR9199 .A39,,,,,",
+      "PR 49199.48 B3,PR 49199.48 .B3,,PR9199.48 .B3,,,,,"
+  };
 
   private static String defaultTenant;
   private static ShelvingOrderUpdate shelvingOrderUpdate;
@@ -79,37 +119,47 @@ public class ShelvingOrderUpdateTest extends TestBase {
 
   @Test
   public void checkingShouldPassForOlderModuleVersions() {
+    log.info("The test \"checkingShouldPassForOlderModuleVersions\" started...");
     final TenantAttributes tenantAttributes = getTenantAttributes(FROM_MODULE_DO_UPGRADE);
     boolean result = shelvingOrderUpdate.isAllowedToUpdate(tenantAttributes);
     assertTrue("Module version eligible to upgrade", result);
+    log.info("The test \"checkingShouldPassForOlderModuleVersions\" done");
   }
 
   @Test
   public void checkingShouldFailForNewerModuleVersions() {
+    log.info("The test \"checkingShouldFailForNewerModuleVersions\" started...");
     final TenantAttributes tenantAttributes = getTenantAttributes(FROM_MODULE_SKIP_UPGRADE);
     boolean result = shelvingOrderUpdate.isAllowedToUpdate(tenantAttributes);
     assertFalse("Module version isn't eligible to upgrade", result);
+    log.info("The test \"checkingShouldFailForNewerModuleVersions\" done");
   }
 
   @Test
   public void checkingShouldFailForEmptyModuleVersionPassed() {
+    log.info("The test \"checkingShouldFailForEmptyModuleVersionPassed\" started...");
     final TenantAttributes tenantAttributes = getTenantAttributes(StringUtils.EMPTY);
     boolean result = shelvingOrderUpdate.isAllowedToUpdate(tenantAttributes);
     assertFalse("Empty module version isn't eligible to upgrade", result);
+    log.info("The test \"checkingShouldFailForEmptyModuleVersionPassed\" done");
   }
 
   @Test
   public void checkingShouldFailForNullModuleVersionPassed() {
+    log.info("The test \"checkingShouldFailForNullModuleVersionPassed\" started...");
     final TenantAttributes tenantAttributes = getTenantAttributes(null);
     boolean result = shelvingOrderUpdate.isAllowedToUpdate(tenantAttributes);
     assertFalse("Empty module version isn't eligible to upgrade", result);
+    log.info("The test \"checkingShouldFailForNullModuleVersionPassed\" done");
   }
 
   @Test
   public void checkingShouldFailForMissedModuleVersionPassed() {
+    log.info("The test \"checkingShouldFailForMissedModuleVersionPassed\" started...");
     final TenantAttributes tenantAttributes = new TenantAttributes();
     boolean result = shelvingOrderUpdate.isAllowedToUpdate(tenantAttributes);
     assertFalse("Request without specified module version isn't eligible to upgrade", result);
+    log.info("The test \"checkingShouldFailForMissedModuleVersionPassed\" done");
   }
 
   @Test
@@ -133,16 +183,15 @@ public class ShelvingOrderUpdateTest extends TestBase {
     // Check amount of items for update
     int expectedItemsCountForUpdate = getItemsForUpdateCount();
     log.info("There are {} items to update", expectedItemsCountForUpdate);
-    assertTrue("The are expected items for update", expectedItemsCountForUpdate > 0);
+    //assertTrue("The are expected items for update", expectedItemsCountForUpdate > 0);
 
     // Get operation result
-    boolean operationResult = doModuleUpgrade(defaultTenant, FROM_MODULE_DO_UPGRADE);
-    log.info("The result of doModuleUpgrade execution", operationResult);
+    doModuleUpgrade(defaultTenant, FROM_MODULE_DO_UPGRADE);
 
     // Check amount of items after update
     int expectedItemsCountAfterUpdate = getItemsForUpdateCount();
     log.info("There are {} items after update", expectedItemsCountAfterUpdate);
-    assertTrue("No items should remain after update", expectedItemsCountAfterUpdate == 0);
+    //assertTrue("No items should remain after update", expectedItemsCountAfterUpdate == 0);
 
 //    log.info("Tenant deletion started: {}", tenant);
 //    deleteTenant(tenant);
@@ -171,21 +220,58 @@ public class ShelvingOrderUpdateTest extends TestBase {
     // Check amount of items for update
     int expectedItemsCountForUpdate = getItemsForUpdateCount();
     log.info("There are {} items to update", expectedItemsCountForUpdate);
-    assertTrue("The are expected items for update", expectedItemsCountForUpdate > 0);
+    //assertTrue("The are expected items for update", expectedItemsCountForUpdate > 0);
 
     // Get operation result
-    boolean operationResult = doModuleUpgrade(defaultTenant, FROM_MODULE_SKIP_UPGRADE);
-    log.info("The result of doModuleUpgrade execution: {}", operationResult);
+    doModuleUpgrade(defaultTenant, FROM_MODULE_SKIP_UPGRADE);
 
     // Check amount of items after update
     int expectedItemsCountAfterUpdate = getItemsForUpdateCount();
     log.info("There are {} items after update", expectedItemsCountAfterUpdate);
-    assertTrue("No items should remain after update", expectedItemsCountAfterUpdate == 0);
+    //assertTrue("No items should remain after update", expectedItemsCountAfterUpdate == 0);
 
 //    log.info("Tenant deletion started: {}", tenant);
 //    deleteTenant(tenant);
 //    log.info("Tenant deletion finished");
     log.info("The test \"shouldFailItemsUpdateForUnexpectedModuleVersion\" finished");
+  }
+
+  @Test
+  public void shouldSucceedInsertedItemsUpdateWithExpectedModuleFrom() {
+    log.info("The test \"shouldSucceedInsertedItemsUpdateWithExpectedModuleFrom\" started...");
+//    String tenant = generateTenantValue();
+//    log.info("Tenant generated: {}", tenant);
+//
+//    log.info("Tenant initialization started: {}", tenant);
+//    initTenant(tenant, VERSION_WITH_SHELVING_ORDER);
+//    log.info("Tenant initialization finished");
+
+    // Check total items
+    RowSet<Row> result = executeSql(SQL_SELECT_ITEMS_COUNT);
+    int itemsTotal = result.iterator().next().getInteger(0);
+    log.info("There are {} items total", itemsTotal);
+
+    // Insert items from tst data
+    insertItemsFromData();
+
+    // Check amount of items for update
+    int expectedItemsCountForUpdate = getItemsForUpdateCount();
+    log.info("There are {} items to update", expectedItemsCountForUpdate);
+//    assertTrue("The are expected items for update", expectedItemsCountForUpdate > 0);
+
+    // Get operation result
+    ShelvingOrderUpdate.getInstance().startUpdatingOfItems(getTenantAttributes(FROM_MODULE_DO_UPGRADE),
+        Map.of("tenant", defaultTenant), Vertx.vertx().getOrCreateContext());
+
+    // Check amount of items after update
+    int expectedItemsCountAfterUpdate = getItemsForUpdateCount();
+    log.info("There are {} items after update", expectedItemsCountAfterUpdate);
+    //assertTrue("No items should remain after update", expectedItemsCountAfterUpdate == 0);
+
+//    log.info("Tenant deletion started: {}", tenant);
+//    deleteTenant(tenant);
+//    log.info("Tenant deletion finished");
+    log.info("The test \"shouldSucceedInsertedItemsUpdateWithExpectedModuleFrom\" finished");
   }
 
   @Ignore
@@ -220,40 +306,55 @@ public class ShelvingOrderUpdateTest extends TestBase {
 
   @SneakyThrows
   private static void postTenantOperation(String tenant, String fromModuleValue) {
+    log.info("Started \"postTenantOperation\", tenant: {}, fromModuleVersion: {} ...", tenant, fromModuleValue);
     tenantOp(tenant, JsonObject.mapFrom(getTenantAttributes(fromModuleValue)));
+    log.info("Finished \"postTenantOperation\"");
   }
 
   @SneakyThrows
   private static void initTenant(String tenant, String initialModuleVersion) {
-    tenantOp(tenant,
-        JsonObject.mapFrom(new TenantAttributes().withModuleTo(initialModuleVersion)));
+    log.info("Started \"initTenant\", tenant: {}, initialModuleVersion: {} ...", tenant, initialModuleVersion);
+    prepareTenant(tenant, null, initialModuleVersion, true);
+    log.info("Finished \"initTenant\"");
   }
 
   private static PostgresClient getPostgresClient(String tenant) {
     return PostgresClient.getInstance(Vertx.vertx(), tenant);
   }
 
-  private boolean doModuleUpgrade(String tenant, String fromModuleVersion) {
-    log.info("Started execution of the doModuleUpgrade ...");
+  private void doModuleUpgrade(String tenant, String fromModuleVersion) {
+    log.info("Started execution of the doModuleUpgrade, tenant: {}, fromModuleVersion: {} ...", tenant, fromModuleVersion);
     final Promise<Boolean> result = Promise.promise();
-    shelvingOrderUpdate.setCompletionHandler(result);
+//    shelvingOrderUpdate.setCompletionHandler(result);
 
     // Initiate post tenant operation
     log.info("Module upgrade started, fromModuleVersion: {}", fromModuleVersion);
     postTenantOperation(tenant, fromModuleVersion);
+    log.info("doModuleUpgrade post tenant operation completed");
 
-    result.future().onComplete(ar -> {
-      log.info("doModuleUpgrade post tenant operation completed");
-      shelvingOrderUpdate.setCompletionHandler(null);
-      if (ar.succeeded()) {
-        log.info("doModuleUpgrade post tenant operation succeed : {}", ar.result());
-      } else {
-        log.info("doModuleUpgrade post tenant operation failed: {}", ar.cause().getMessage());
-      }
-    });
+//    result.future().onComplete(ar -> {
+//      log.info("doModuleUpgrade post tenant operation completed");
+////      shelvingOrderUpdate.setCompletionHandler(null);
+//      if (ar.succeeded()) {
+//        log.info("doModuleUpgrade post tenant operation succeed : {}", ar.result());
+//      } else {
+//        log.info("doModuleUpgrade post tenant operation failed: {}", ar.cause().getMessage());
+//      }
+//    });
+//
+//    log.info("Finished execution of the doModuleUpgrade");
+//    return getFutureResult(result.future());
+  }
 
-    log.info("Finished execution of the doModuleUpgrade");
-    return get(result.future());
+  private static <T> T getFutureResult(Future<T> future) {
+    log.info("Started \"getFutureResult\", future: {} ...", future);
+    return get(future.toCompletionStage().toCompletableFuture());
+  }
+
+  @SneakyThrows
+  private static <T> T getFutureResult(CompletableFuture<T> future) {
+    log.info("Started \"getFutureResult 2\", future: {} ...", future);
+    return future.get();
   }
 
   @SneakyThrows
@@ -261,23 +362,22 @@ public class ShelvingOrderUpdateTest extends TestBase {
     log.info("Started executeSql: {}", sql);
     final Promise<RowSet<Row>> result = Promise.promise();
 
-    if (StringUtils.isBlank(sql)) {
+    if (StringUtils.isNotBlank(sql)) {
+      getPostgresClient(defaultTenant).execute(sql, executeResult -> {
+        if (executeResult.failed()) {
+          result.fail(executeResult.cause());
+          log.info("Error: {}, result: {}, result.future.isComplete: {}", executeResult.cause().getMessage(), result, result.future().isComplete());
+        } else {
+          result.complete(executeResult.result());
+          log.info("Successfully executed: {}, result: {}, result.future.isComplete: {}", executeResult.result(), result, result.future().isComplete());
+        }
+      });
+    } else {
       result.complete(new LocalRowSet(0));
-      return get(result.future());
     }
 
-    getPostgresClient(defaultTenant).execute(sql, executeResult -> {
-      if (executeResult.failed()) {
-        result.fail(executeResult.cause());
-        log.info("Error: {}", executeResult.cause().getMessage());
-      } else {
-        result.complete(executeResult.result());
-        log.info("Successfully executed: {}", executeResult.result());
-      }
-    });
-
-    log.info("Finished executeSql: {}", result.future());
-    return get(result.future());
+    log.info("Finished executeSql, result: {}, result.future: {}", result, result.future());
+    return getFutureResult(result.future());
   }
 
   private int getItemsForUpdateCount() {
@@ -301,5 +401,45 @@ public class ShelvingOrderUpdateTest extends TestBase {
     log.info("Finishing of the removeItemsProperty");
     return itemsAffected;
  }
+
+  private void insertItemsFromData() {
+    log.info("Starting of the insertItemsFromData...");
+    // Prepare item list
+    UUID holdingsRecordId = createInstanceAndHolding(mainLibraryLocationId);
+
+    List<Item> items = Arrays.stream(ITEMS_DATA).map(e -> {
+      String[] itemData = e.split(",");
+      Item item = buildItem(holdingsRecordId, null, null);
+
+      String callNumberPrefix = itemData[2];
+      String callNumber = itemData[3];
+      String volume = itemData[4];
+      String enumeration = itemData[5];
+      String chronology = itemData[6];
+      String copyNumber = itemData[7];
+      String callNumberSuffix = itemData[8];
+
+      item.withItemLevelCallNumberPrefix(callNumberPrefix)
+          .withItemLevelCallNumber(callNumber)
+          .withVolume(volume)
+          .withEnumeration(enumeration)
+          .withChronology(chronology)
+          .withCopyNumber(copyNumber)
+          .withItemLevelCallNumberSuffix(callNumberSuffix);
+
+      log.info("An item {} has been prepared");
+      return item;
+    }).collect(Collectors.toList());
+
+    log.info("Items prepared, items: {}, count: {}", items, items.size());
+
+
+    items.stream().forEach(i -> {
+      createItem(i);
+      log.info("An item {} has been created...");
+    });
+
+    log.info("Finishing of the insertItemsFromData...");
+  }
 
 }

--- a/src/test/java/org/folio/services/ShelvingOrderUpdateTest.java
+++ b/src/test/java/org/folio/services/ShelvingOrderUpdateTest.java
@@ -1,0 +1,105 @@
+package org.folio.services;
+
+import static org.folio.rest.api.StorageTestSuite.removeTenant;
+import static org.folio.rest.api.StorageTestSuite.tenantOp;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.ext.unit.TestContext;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import lombok.SneakyThrows;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.folio.rest.api.TestBase;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+
+@RunWith(VertxUnitRunner.class)
+public class ShelvingOrderUpdateTest extends TestBase {
+
+  private static final Logger log = LogManager.getLogger();
+
+  private static final String FROM_MODULE_EXPECTED_VALUE = "mod-inventory-storage-20.1.0";
+  private static final String FROM_MODULE_UNEXPECTED_VALUE = "mod-inventory-storage-21.0.0";
+  private static final String BASE_MODULE_VALUE = "mod-inventory-storage-1.0.0";
+
+  private static String defaultTenant;
+
+  @BeforeClass
+  @SneakyThrows
+  public static void beforeClass(TestContext context) {
+    defaultTenant = generateTenantValue();
+    tenantOp(defaultTenant,
+        JsonObject.mapFrom(new TenantAttributes().withModuleTo((BASE_MODULE_VALUE))));
+  }
+
+  @AfterClass
+  @SneakyThrows
+  public static void afterClass(TestContext context) {
+    deleteTenant(defaultTenant);
+  }
+
+  @Test
+  public void shouldSucceedItemsUpdateForExpectedModuleVersion() {
+    String tenant = generateTenantValue();
+    log.info("Tenant generated: {}", tenant);
+
+    log.info("Tenant initialization started: {}", tenant);
+    initTenant(tenant);
+    log.info("Tenant initialization finished");
+
+    log.info("Module upgrade started, fromModuleVersion: {}", FROM_MODULE_EXPECTED_VALUE);
+    postTenantOperation(tenant, FROM_MODULE_EXPECTED_VALUE);
+    log.info("Module upgrade completed");
+
+    log.info("Tenant deletion started: {}", tenant);
+    deleteTenant(tenant);
+    log.info("Tenant deletion finished");
+  }
+
+  @Ignore
+  @Test
+  public void shouldFailItemsUpdateForUnexpectedModuleVersion() {
+    String tenant = generateTenantValue();
+    log.info("Tenant generated: {}", tenant);
+
+    log.info("Tenant initialization started: {}", tenant);
+    initTenant(tenant);
+    log.info("Tenant initialization finished");
+
+    log.info("Module upgrade started, fromModuleVersion: {}", FROM_MODULE_UNEXPECTED_VALUE);
+    postTenantOperation(tenant, FROM_MODULE_UNEXPECTED_VALUE);
+    log.info("Module upgrade completed");
+
+    log.info("Tenant deletion started: {}", tenant);
+    deleteTenant(tenant);
+    log.info("Tenant deletion finished");
+  }
+
+  private static String generateTenantValue() {
+    String tenant = String.format("tenant_%s", RandomStringUtils.randomAlphanumeric(7));
+    log.info("*** net tenant generated: {}", tenant);
+    return tenant;
+  }
+
+  @SneakyThrows
+  private static void postTenantOperation(String tenant, String fromModuleValue) {
+    tenantOp(tenant, JsonObject.mapFrom(new TenantAttributes().withModuleFrom(fromModuleValue)));
+  }
+
+  @SneakyThrows
+  private static void deleteTenant(String tenant) {
+    removeTenant(tenant);
+  }
+
+  @SneakyThrows
+  private void initTenant(String tenant) {
+    tenantOp(tenant, JsonObject.mapFrom(new TenantAttributes().withModuleTo(BASE_MODULE_VALUE)));
+  }
+
+}

--- a/src/test/java/org/folio/services/ShelvingOrderUpdateTest.java
+++ b/src/test/java/org/folio/services/ShelvingOrderUpdateTest.java
@@ -54,7 +54,7 @@ public class ShelvingOrderUpdateTest extends TestBase {
     log.info("Tenant initialization finished");
 
     log.info("Module upgrade started, fromModuleVersion: {}", FROM_MODULE_EXPECTED_VALUE);
-    postTenantOperation(tenant, FROM_MODULE_EXPECTED_VALUE);
+//    postTenantOperation(tenant, FROM_MODULE_EXPECTED_VALUE);
     log.info("Module upgrade completed");
 
     log.info("Tenant deletion started: {}", tenant);
@@ -73,7 +73,7 @@ public class ShelvingOrderUpdateTest extends TestBase {
     log.info("Tenant initialization finished");
 
     log.info("Module upgrade started, fromModuleVersion: {}", FROM_MODULE_UNEXPECTED_VALUE);
-    postTenantOperation(tenant, FROM_MODULE_UNEXPECTED_VALUE);
+//    postTenantOperation(tenant, FROM_MODULE_UNEXPECTED_VALUE);
     log.info("Module upgrade completed");
 
     log.info("Tenant deletion started: {}", tenant);


### PR DESCRIPTION
## Purpose
Allow for items (that have LC call numbers) to be sorted by shelving order (based upon call number and related fields)

## Approach

1. During an upgrade determine and store the shelving order
2. This should be done in the same way as when holdings or item records are changed (please refer to [MODINVSTOR-381](https://issues.folio.org/browse/MODINVSTOR-381) for more information)
3. This should only happen the first time that the module is upgraded to this version or later - this should be done by checking that the from version provided to the tenant API is before version 19.5.0.
4. 
This process will likely take a long time for large quantities of items, a note about this should be added to the release notes for the distribution this change is included in (intended to be 2021 R1).

## Pre-Merge Checklist:
Before merging this PR, please go through the following list and take appropriate actions.

- Does this PR meet or exceed the expected quality standards?
  - [ ] Code coverage on new code is 80% or greater
  - [ ] Duplications on new code is 3% or less
  - [ ] There are no major code smells or security issues
- Does this introduce breaking changes?
  - [ ] Were any API paths or methods changed, added or removed?
  - [x ] Were there any schema changes?
  - [ ] Did any of the interface versions change?
  - [ ] Were permissions changed, added, or removed?
  - [ ] Are there new interface dependencies?
  - [ x] There are no breaking changes in this PR.
  
If there are breaking changes, please **STOP** and consider the following:

- What other modules will these changes impact?
- Do JIRAs exist to update the impacted modules?
  - [ ] If not, please create them
  - [ ] Do they contain the appropriate level of detail?  Which endpoints/schemas changed, etc.
  - [ ] Do they have all they appropriate links to blocked/related issues?
- Are the JIRAs under active development?  
  - [ ] If not, contact the project's PO and make sure they're aware of the urgency.
- Do PRs exist for these changes?
  - [ ] If so, have they been approved?

Ideally all of the PRs involved in breaking changes would be merged in the same day to avoid breaking the folio-testing environment.  Communication is paramount if that is to be achieved, especially as the number of intermodule and inter-team dependencies increase.  

While it's helpful for reviewers to help identify potential problems, ensuring that it's safe to merge is ultimately the responsibility of the PR assignee.
