### PR TITLE
Update instance-storage from 7.6 to 7.7

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -88,7 +88,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "7.6",
+      "version": "7.7",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/instance-storage.raml
+++ b/ramls/instance-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Instance Storage
-version: v7.6
+version: v7.7
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 


### PR DESCRIPTION
The instance-storage interface needs to be updated because of adding of contributorsNames index.
Please see https://issues.folio.org/browse/MODINVSTOR-707 and its related tickets.