### PR TITLE
MODINVSTOR-723: Add publication year and publication period properties.

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -88,7 +88,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "7.7",
+      "version": "7.8",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/instance-storage.raml
+++ b/ramls/instance-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Instance Storage
-version: v7.7
+version: v7.8
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -215,6 +215,25 @@
             "type": "string",
             "description": "Date (year YYYY) of publication, distribution, etc."
           },
+          "publicationYear": {
+            "type": "integer",
+            "description": "Publication year"
+          },
+          "publicationPeriod": {
+            "type": "object",
+            "description": "Publication period",
+            "properties": {
+              "start": {
+                "type": "integer",
+                "description": "Publication start year"
+              },
+              "end": {
+                "type": "integer",
+                "description": "Publication end year"
+              }
+            },
+            "additionalProperties": false
+          },
           "role": {
             "type": "string",
             "description": "The role of the publisher, distributor, etc."

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -215,21 +215,6 @@
             "type": "string",
             "description": "Date (year YYYY) of publication, distribution, etc."
           },
-          "publicationPeriod": {
-            "type": "object",
-            "description": "Publication period",
-            "properties": {
-              "start": {
-                "type": "integer",
-                "description": "Publication start year"
-              },
-              "end": {
-                "type": "integer",
-                "description": "Publication end year"
-              }
-            },
-            "additionalProperties": false
-          },
           "role": {
             "type": "string",
             "description": "The role of the publisher, distributor, etc."
@@ -252,6 +237,21 @@
         "type": "string"
       },
       "uniqueItems": true
+    },
+    "publicationPeriod": {
+      "type": "object",
+      "description": "Publication period",
+      "properties": {
+        "start": {
+          "type": "integer",
+          "description": "Publication start year"
+        },
+        "end": {
+          "type": "integer",
+          "description": "Publication end year"
+        }
+      },
+      "additionalProperties": false
     },
     "electronicAccess": {
       "type": "array",

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -215,10 +215,6 @@
             "type": "string",
             "description": "Date (year YYYY) of publication, distribution, etc."
           },
-          "publicationYear": {
-            "type": "integer",
-            "description": "Publication year"
-          },
           "publicationPeriod": {
             "type": "object",
             "description": "Publication period",

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -129,7 +129,6 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       .toArray(String[]::new);
 
     var publication = new Publication()
-      .withPublicationYear(2012)
       .withPublicationPeriod(new PublicationPeriod().withStart(2000).withEnd(2001));
 
     JsonObject instanceToCreate = smallAngryPlanet(id);
@@ -186,7 +185,6 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     var storedPublication = instance.getJsonArray("publication")
       .getJsonObject(0).mapTo(Publication.class);
-    assertThat(storedPublication.getPublicationYear(), is(2012));
     assertThat(storedPublication.getPublicationPeriod().getStart(), is(2000));
     assertThat(storedPublication.getPublicationPeriod().getEnd(), is(2001));
   }

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -132,7 +132,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject instanceToCreate = smallAngryPlanet(id);
     instanceToCreate.put("natureOfContentTermIds", Arrays.asList(natureOfContentIds));
-    instanceToCreate.put("publicationPeriod", List.of(JsonObject.mapFrom(publicationPeriod)));
+    instanceToCreate.put("publicationPeriod", JsonObject.mapFrom(publicationPeriod));
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
@@ -182,8 +182,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(instanceFromGet.getBoolean(DISCOVERY_SUPPRESS), is(false));
     assertCreateEventForInstance(instanceFromGet);
 
-    var storedPublicationPeriod = instance.getJsonArray("publicationPeriod")
-      .getJsonObject(0).mapTo(PublicationPeriod.class);
+    var storedPublicationPeriod = instance.getJsonObject("publicationPeriod")
+      .mapTo(PublicationPeriod.class);
     assertThat(storedPublicationPeriod.getStart(), is(2000));
     assertThat(storedPublicationPeriod.getEnd(), is(2001));
   }

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -15,6 +15,8 @@ import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.InstancesBatchResponse;
 import org.folio.rest.jaxrs.model.MarcJson;
 import org.folio.rest.jaxrs.model.NatureOfContentTerm;
+import org.folio.rest.jaxrs.model.Publication;
+import org.folio.rest.jaxrs.model.PublicationPeriod;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.*;
@@ -126,9 +128,13 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       .map(NatureOfContentTerm::getId)
       .toArray(String[]::new);
 
+    var publication = new Publication()
+      .withPublicationYear(2012)
+      .withPublicationPeriod(new PublicationPeriod().withStart(2000).withEnd(2001));
+
     JsonObject instanceToCreate = smallAngryPlanet(id);
-    instanceToCreate.put("natureOfContentTermIds", Arrays
-      .asList(natureOfContentIds));
+    instanceToCreate.put("natureOfContentTermIds", Arrays.asList(natureOfContentIds));
+    instanceToCreate.put("publication", List.of(JsonObject.mapFrom(publication)));
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
@@ -177,6 +183,12 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(instanceFromGet.getBoolean(DISCOVERY_SUPPRESS), is(false));
     assertCreateEventForInstance(instanceFromGet);
+
+    var storedPublication = instance.getJsonArray("publication")
+      .getJsonObject(0).mapTo(Publication.class);
+    assertThat(storedPublication.getPublicationYear(), is(2012));
+    assertThat(storedPublication.getPublicationPeriod().getStart(), is(2000));
+    assertThat(storedPublication.getPublicationPeriod().getEnd(), is(2001));
   }
 
   @Test
@@ -477,7 +489,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     InterruptedException,
     ExecutionException,
     TimeoutException {
-    
+
     createInstancesWithClassificationNumbers();
 
     JsonObject allInstances = searchForInstances("classifications =/@classificationNumber \"K1 .M385\"");
@@ -492,7 +504,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     InterruptedException,
     ExecutionException,
     TimeoutException {
-    
+
     createInstancesWithClassificationNumbers();
 
     JsonObject allInstances = searchForInstances("classifications =\"K1 .M385\"");

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -128,12 +128,11 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       .map(NatureOfContentTerm::getId)
       .toArray(String[]::new);
 
-    var publication = new Publication()
-      .withPublicationPeriod(new PublicationPeriod().withStart(2000).withEnd(2001));
+    var publicationPeriod = new PublicationPeriod().withStart(2000).withEnd(2001);
 
     JsonObject instanceToCreate = smallAngryPlanet(id);
     instanceToCreate.put("natureOfContentTermIds", Arrays.asList(natureOfContentIds));
-    instanceToCreate.put("publication", List.of(JsonObject.mapFrom(publication)));
+    instanceToCreate.put("publicationPeriod", List.of(JsonObject.mapFrom(publicationPeriod)));
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
@@ -183,10 +182,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(instanceFromGet.getBoolean(DISCOVERY_SUPPRESS), is(false));
     assertCreateEventForInstance(instanceFromGet);
 
-    var storedPublication = instance.getJsonArray("publication")
-      .getJsonObject(0).mapTo(Publication.class);
-    assertThat(storedPublication.getPublicationPeriod().getStart(), is(2000));
-    assertThat(storedPublication.getPublicationPeriod().getEnd(), is(2001));
+    var storedPublicationPeriod = instance.getJsonArray("publicationPeriod")
+      .getJsonObject(0).mapTo(PublicationPeriod.class);
+    assertThat(storedPublicationPeriod.getStart(), is(2000));
+    assertThat(storedPublicationPeriod.getEnd(), is(2001));
   }
 
   @Test


### PR DESCRIPTION
Add `publicationPeriod` properties to `instance`.

As per Magda:
>  I believe that implementation can be achieved by having two fields: year1 and year2 and from your example above it would be populated as follows:

> Record A has a publication year of 1999, no publication start year and no publication end year – year1 is populated with 1999, year2 is blank
Record B has no publication year, a publication start year of 1996 and publication end year of 2001 – year1 is 1996 and year2 is 2001
Record C has no publication year, a publication start year of 1998 and no publication end year – year1 is 1998 and year2 is blank
Record D has no publication year, no publication start year and a publication end year of 2000 – year1 is blank year2 is 2000