### PR TITLE
MODINVSTOR-663: Log failed domain events to internal table.

### DIFF
--- a/src/main/java/org/folio/persist/NotificationSendingErrorRepository.java
+++ b/src/main/java/org/folio/persist/NotificationSendingErrorRepository.java
@@ -1,0 +1,11 @@
+package org.folio.persist;
+
+import org.folio.persist.entity.NotificationSendingError;
+import org.folio.rest.persist.PostgresClient;
+
+public class NotificationSendingErrorRepository extends AbstractRepository<NotificationSendingError> {
+  public NotificationSendingErrorRepository(PostgresClient postgresClient) {
+    super(postgresClient, "notification_sending_error",
+      NotificationSendingError.class);
+  }
+}

--- a/src/main/java/org/folio/persist/entity/NotificationSendingError.java
+++ b/src/main/java/org/folio/persist/entity/NotificationSendingError.java
@@ -1,0 +1,73 @@
+package org.folio.persist.entity;
+
+import java.util.Date;
+
+public class NotificationSendingError {
+  private String id;
+  private String topicName;
+  private String partitionKey;
+  private String payload;
+  private String error;
+  private Date incidentDateTime;
+
+  public NotificationSendingError() {}
+
+  public NotificationSendingError(String id, String topicName, String partitionKey,
+    String payload, String error, Date incidentDateTime) {
+
+    this.id = id;
+    this.topicName = topicName;
+    this.partitionKey = partitionKey;
+    this.payload = payload;
+    this.error = error;
+    this.incidentDateTime = incidentDateTime;
+  }
+
+  public String getTopicName() {
+    return topicName;
+  }
+
+  public String getPartitionKey() {
+    return partitionKey;
+  }
+
+  public String getPayload() {
+    return payload;
+  }
+
+  public String getError() {
+    return error;
+  }
+
+  public void setTopicName(String topicName) {
+    this.topicName = topicName;
+  }
+
+  public void setPartitionKey(String partitionKey) {
+    this.partitionKey = partitionKey;
+  }
+
+  public void setPayload(String payload) {
+    this.payload = payload;
+  }
+
+  public void setError(String error) {
+    this.error = error;
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+
+  public Date getIncidentDateTime() {
+    return incidentDateTime;
+  }
+
+  public void setIncidentDateTime(Date incidentDateTime) {
+    this.incidentDateTime = incidentDateTime;
+  }
+}

--- a/src/main/java/org/folio/services/domainevent/FailureHandler.java
+++ b/src/main/java/org/folio/services/domainevent/FailureHandler.java
@@ -1,0 +1,7 @@
+package org.folio.services.domainevent;
+
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
+
+public interface FailureHandler {
+  void handleFailure(Throwable error, KafkaProducerRecord<String, String> producerRecord);
+}

--- a/src/main/java/org/folio/services/domainevent/LogToDbFailureHandler.java
+++ b/src/main/java/org/folio/services/domainevent/LogToDbFailureHandler.java
@@ -11,14 +11,14 @@ import java.util.UUID;
 import org.folio.persist.NotificationSendingErrorRepository;
 import org.folio.persist.entity.NotificationSendingError;
 
-public class LogToDbFailureHandler implements FailureHandler {
+final class LogToDbFailureHandler implements FailureHandler {
   private final NotificationSendingErrorRepository repository;
 
-  public LogToDbFailureHandler(NotificationSendingErrorRepository repository) {
+  LogToDbFailureHandler(NotificationSendingErrorRepository repository) {
     this.repository = repository;
   }
 
-  public LogToDbFailureHandler(Context context, Map<String, String> okapiHeaders) {
+  LogToDbFailureHandler(Context context, Map<String, String> okapiHeaders) {
     this(new NotificationSendingErrorRepository(postgresClient(context, okapiHeaders)));
   }
 

--- a/src/main/java/org/folio/services/domainevent/LogToDbFailureHandler.java
+++ b/src/main/java/org/folio/services/domainevent/LogToDbFailureHandler.java
@@ -1,0 +1,33 @@
+package org.folio.services.domainevent;
+
+import static org.apache.commons.lang3.exception.ExceptionUtils.getStackTrace;
+import static org.folio.rest.persist.PgUtil.postgresClient;
+
+import io.vertx.core.Context;
+import io.vertx.kafka.client.producer.KafkaProducerRecord;
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+import org.folio.persist.NotificationSendingErrorRepository;
+import org.folio.persist.entity.NotificationSendingError;
+
+public class LogToDbFailureHandler implements FailureHandler {
+  private final NotificationSendingErrorRepository repository;
+
+  public LogToDbFailureHandler(NotificationSendingErrorRepository repository) {
+    this.repository = repository;
+  }
+
+  public LogToDbFailureHandler(Context context, Map<String, String> okapiHeaders) {
+    this(new NotificationSendingErrorRepository(postgresClient(context, okapiHeaders)));
+  }
+
+  @Override
+  public void handleFailure(Throwable error, KafkaProducerRecord<String, String> producerRecord) {
+    var errorLog = new NotificationSendingError(UUID.randomUUID().toString(),
+      producerRecord.topic(), producerRecord.key(), producerRecord.value(),
+      getStackTrace(error), new Date());
+
+    repository.save(errorLog.getId(), errorLog);
+  }
+}

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -903,6 +903,11 @@
       "tableName": "reindex_job",
       "withMetadata": false,
       "withAuditing": false
+    },
+    {
+      "tableName": "notification_sending_error",
+      "withMetadata": false,
+      "withAuditing": false
     }
   ],
   "scripts": [

--- a/src/test/java/org/folio/rest/api/NotificationSendingErrorRepositoryTest.java
+++ b/src/test/java/org/folio/rest/api/NotificationSendingErrorRepositoryTest.java
@@ -1,0 +1,39 @@
+package org.folio.rest.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
+import static org.folio.rest.api.StorageTestSuite.getVertx;
+
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+import org.folio.persist.NotificationSendingErrorRepository;
+import org.folio.persist.entity.NotificationSendingError;
+import org.folio.rest.persist.PgUtil;
+import org.junit.Test;
+
+public class NotificationSendingErrorRepositoryTest extends TestBaseWithInventoryUtil {
+  @Test
+  public void canSaveNotificationError() {
+    var repository = createRepository();
+    var originalError = new NotificationSendingError(UUID.randomUUID().toString(),
+      "topic", "key", "value", "error\nerror2", new Date());
+
+    get(repository.save(originalError.getId(), originalError));
+
+    var savedNotification = get(repository.getById(originalError.getId()));
+    assertThat(savedNotification.getTopicName()).isEqualTo("topic");
+    assertThat(savedNotification.getPartitionKey()).isEqualTo("key");
+    assertThat(savedNotification.getPayload()).isEqualTo("value");
+    assertThat(savedNotification.getError()).isEqualTo("error\nerror2");
+    assertThat(savedNotification.getIncidentDateTime())
+      .isEqualTo(originalError.getIncidentDateTime());
+  }
+
+  private NotificationSendingErrorRepository createRepository() {
+    var postgresClient = PgUtil.postgresClient(getVertx().getOrCreateContext(),
+      Map.of("x-okapi-tenant", TENANT_ID));
+
+    return new NotificationSendingErrorRepository(postgresClient);
+  }
+}

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -83,7 +83,8 @@ import org.testcontainers.utility.DockerImageName;
   ReindexJobRunnerTest.class,
   EffectiveLocationMigrationTest.class,
   PreviouslyHeldDataUpgradeTest.class,
-  ItemShelvingOrderMigrationServiceApiTest.class
+  ItemShelvingOrderMigrationServiceApiTest.class,
+  NotificationSendingErrorRepositoryTest.class
 })
 public class StorageTestSuite {
   public static final String TENANT_ID = "test_tenant";

--- a/src/test/java/org/folio/services/domainevent/CommonDomainEventPublisherTest.java
+++ b/src/test/java/org/folio/services/domainevent/CommonDomainEventPublisherTest.java
@@ -3,8 +3,12 @@ package org.folio.services.domainevent;
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
+import static org.folio.rest.api.TestBase.get;
+import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_INSTANCE;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -15,7 +19,6 @@ import io.vertx.kafka.client.producer.KafkaProducer;
 import java.util.Map;
 import org.folio.kafka.KafkaProducerManager;
 import org.folio.rest.api.ReindexJobRunnerTest;
-import org.folio.rest.api.TestBase;
 import org.folio.rest.api.entities.Instance;
 import org.folio.services.kafka.InventoryProducerRecordBuilder;
 import org.folio.services.kafka.topic.KafkaTopic;
@@ -30,12 +33,13 @@ import org.mockito.junit.MockitoJUnitRunner;
 public class CommonDomainEventPublisherTest {
   @Mock private KafkaProducer<String, String> producer;
   @Mock private KafkaProducerManager producerManager;
+  @Mock private FailureHandler failureHandler;
   private CommonDomainEventPublisher<Instance> eventPublisher;
 
   @Before
   public void setUpPublisher() {
     eventPublisher = new CommonDomainEventPublisher<>(
-      Map.of(), KafkaTopic.INVENTORY_INSTANCE, producerManager);
+      Map.of(), INVENTORY_INSTANCE, producerManager, failureHandler);
   }
 
   @Test
@@ -47,7 +51,7 @@ public class CommonDomainEventPublisherTest {
     when(producer.send(any())).thenReturn(succeededFuture());
     when(producer.drainHandler(any())).thenAnswer(this::drainHandler);
 
-    var recordsPublished = TestBase.get(eventPublisher.publishStream(stream,
+    var recordsPublished = get(eventPublisher.publishStream(stream,
       row -> new InventoryProducerRecordBuilder(), notUsed -> succeededFuture()));
 
     assertThat(recordsPublished).isEqualTo(6);
@@ -87,10 +91,11 @@ public class CommonDomainEventPublisherTest {
     when(producer.send(any()))
       .thenReturn(succeededFuture(), failedFuture(""), succeededFuture(), failedFuture(""));
 
-    var recordsPublished = TestBase.get(eventPublisher.publishStream(stream,
+    var recordsPublished = get(eventPublisher.publishStream(stream,
       row -> new InventoryProducerRecordBuilder(), records -> succeededFuture()));
 
     assertThat(recordsPublished).isEqualTo(2);
+    verify(failureHandler, times(2)).handleFailure(any(), any());
   }
 
   @Test
@@ -109,6 +114,19 @@ public class CommonDomainEventPublisherTest {
     assertThat(future.cause()).hasMessage("server error");
 
     verify(producer, times(1)).send(any());
+  }
+
+  @Test
+  public void shouldCallFailureHandlerWhenPublishingFailed() {
+    var causeError = new IllegalArgumentException("error");
+
+    when(producerManager.<String, String>createShared(any())).thenReturn(producer);
+    when(producer.send(any())).thenReturn(failedFuture(causeError));
+
+    assertThatThrownBy(() -> get(eventPublisher.publishAllRecordsRemoved()))
+      .hasRootCauseInstanceOf(IllegalArgumentException.class);
+
+    verify(failureHandler, times(1)).handleFailure(eq(causeError), any());
   }
 
   @SuppressWarnings("unchecked")

--- a/src/test/java/org/folio/services/domainevent/LogToDbFailureHandlerTest.java
+++ b/src/test/java/org/folio/services/domainevent/LogToDbFailureHandlerTest.java
@@ -1,0 +1,40 @@
+package org.folio.services.domainevent;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import io.vertx.kafka.client.producer.impl.KafkaProducerRecordImpl;
+import java.util.Date;
+import org.folio.persist.NotificationSendingErrorRepository;
+import org.folio.persist.entity.NotificationSendingError;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class LogToDbFailureHandlerTest {
+  @Mock
+  private NotificationSendingErrorRepository repository;
+
+  @Test
+  public void canHandleFailure() {
+    var startDate = new Date();
+    var handler = new LogToDbFailureHandler(repository);
+    handler.handleFailure(new IllegalArgumentException("null"),
+      new KafkaProducerRecordImpl<>("topic", "key", "value"));
+
+    var errorArgumentCaptor = ArgumentCaptor.forClass(NotificationSendingError.class);
+    verify(repository).save(any(), errorArgumentCaptor.capture());
+
+    var notificationSendingError = errorArgumentCaptor.getValue();
+    assertThat(notificationSendingError.getId()).isNotBlank();
+    assertThat(notificationSendingError.getTopicName()).isEqualTo("topic");
+    assertThat(notificationSendingError.getPartitionKey()).isEqualTo("key");
+    assertThat(notificationSendingError.getPayload()).isEqualTo("value");
+    assertThat(notificationSendingError.getError()).contains("IllegalArgumentException: null");
+    assertThat(notificationSendingError.getIncidentDateTime()).isBetween(startDate, new Date());
+  }
+}


### PR DESCRIPTION
## Approach:

* Create new `notification_sending_error` table with following structure:
  * id;
  * topicName;
  * partitionKey;
  * payload;
  * error;
  * incidentDateTime;
* Introduce `FailureHandler` interface that injected into domain events publisher class
* Add LogToDbTable default implementation for `FailureHandler`.