### PR TITLE
Fix shouldStopProcessingWhenCa.. MODINVSTOR-725

### DIFF
--- a/src/test/java/org/folio/rest/api/ItemShelvingOrderMigrationServiceApiTest.java
+++ b/src/test/java/org/folio/rest/api/ItemShelvingOrderMigrationServiceApiTest.java
@@ -38,7 +38,7 @@ public class ItemShelvingOrderMigrationServiceApiTest extends MigrationTestBase 
   public void shouldStopProcessingWhenCannotConvertItem() throws Exception {
     var item = createItem(0);
     removeShelvingOrder(List.of(item));
-    executeSql("UPDATE item SET jsonb = jsonb || '{\"a\":\"b\"}'::jsonb WHERE id = '" + item.getId() + "'");
+    executeSql("UPDATE " + getSchemaName() + ".item SET jsonb = jsonb || '{\"a\":\"b\"}'::jsonb WHERE id = '" + item.getId() + "'");
 
     var ta = getTenantAttributes();
 


### PR DESCRIPTION
Fix
ItemShelvingOrderMigrationServiceApiTest#shouldStopProcessingWhenCannotConvertItem
depends on other test (can not be run in isolation - when Vert.x
4.1.0 (Beta or CR1) is in use).