### PR TITLE
MODINVSTOR-734: Replace Assertj matchers by Hamcrest matchers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,12 +77,6 @@
       <version>2.9.1</version>
     </dependency>
     <dependency>
-      <groupId>org.assertj</groupId>
-      <artifactId>assertj-core</artifactId>
-      <version>3.19.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
       <version>2.10.9</version>

--- a/src/test/java/org/folio/rest/api/ItemShelvingOrderMigrationServiceApiTest.java
+++ b/src/test/java/org/folio/rest/api/ItemShelvingOrderMigrationServiceApiTest.java
@@ -3,7 +3,7 @@ package org.folio.rest.api;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.folio.rest.api.StorageTestSuite.tenantOp;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertThrows;
 
@@ -44,7 +44,7 @@ public class ItemShelvingOrderMigrationServiceApiTest extends MigrationTestBase 
     var ta = getTenantAttributes();
 
     assertThat(assertThrows(Throwable.class, () -> tenantOp(TENANT_ID, ta)).getMessage(),
-      is("Unrecognized field \"a\" (class org.folio.rest.jaxrs.model.Item), not marked as ignorable"));
+      containsString("Unrecognized field \"a\" (class org.folio.rest.jaxrs.model.Item), not marked as ignorable"));
   }
 
   private JsonObject getTenantAttributes() {

--- a/src/test/java/org/folio/rest/api/ItemShelvingOrderMigrationServiceApiTest.java
+++ b/src/test/java/org/folio/rest/api/ItemShelvingOrderMigrationServiceApiTest.java
@@ -1,10 +1,11 @@
 package org.folio.rest.api;
 
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.folio.rest.api.StorageTestSuite.tenantOp;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.Assert.assertThrows;
 
 import io.vertx.core.json.JsonObject;
 import java.util.List;
@@ -42,9 +43,8 @@ public class ItemShelvingOrderMigrationServiceApiTest extends MigrationTestBase 
 
     var ta = getTenantAttributes();
 
-    assertThatThrownBy(() -> tenantOp(TENANT_ID, ta))
-      .hasMessageContaining("Unrecognized field \"a\" " +
-        "(class org.folio.rest.jaxrs.model.Item), not marked as ignorable");
+    assertThat(assertThrows(Throwable.class, () -> tenantOp(TENANT_ID, ta)).getMessage(),
+      is("Unrecognized field \"a\" (class org.folio.rest.jaxrs.model.Item), not marked as ignorable"));
   }
 
   private JsonObject getTenantAttributes() {

--- a/src/test/java/org/folio/rest/api/NotificationSendingErrorRepositoryTest.java
+++ b/src/test/java/org/folio/rest/api/NotificationSendingErrorRepositoryTest.java
@@ -1,8 +1,9 @@
 package org.folio.rest.api;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.folio.rest.api.StorageTestSuite.getVertx;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.util.Date;
 import java.util.Map;
@@ -22,12 +23,11 @@ public class NotificationSendingErrorRepositoryTest extends TestBaseWithInventor
     get(repository.save(originalError.getId(), originalError));
 
     var savedNotification = get(repository.getById(originalError.getId()));
-    assertThat(savedNotification.getTopicName()).isEqualTo("topic");
-    assertThat(savedNotification.getPartitionKey()).isEqualTo("key");
-    assertThat(savedNotification.getPayload()).isEqualTo("value");
-    assertThat(savedNotification.getError()).isEqualTo("error\nerror2");
-    assertThat(savedNotification.getIncidentDateTime())
-      .isEqualTo(originalError.getIncidentDateTime());
+    assertThat(savedNotification.getTopicName(), is("topic"));
+    assertThat(savedNotification.getPartitionKey(), is("key"));
+    assertThat(savedNotification.getPayload(), is("value"));
+    assertThat(savedNotification.getError(), is("error\nerror2"));
+    assertThat(savedNotification.getIncidentDateTime(), is(originalError.getIncidentDateTime()));
   }
 
   private NotificationSendingErrorRepository createRepository() {

--- a/src/test/java/org/folio/services/domainevent/LogToDbFailureHandlerTest.java
+++ b/src/test/java/org/folio/services/domainevent/LogToDbFailureHandlerTest.java
@@ -1,5 +1,6 @@
 package org.folio.services.domainevent;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -39,7 +40,7 @@ public class LogToDbFailureHandlerTest {
     assertThat(notificationSendingError.getTopicName(), is("topic"));
     assertThat(notificationSendingError.getPartitionKey(), is("key"));
     assertThat(notificationSendingError.getPayload(), is("value"));
-    assertThat(notificationSendingError.getError(), is(("IllegalArgumentException: null")));
+    assertThat(notificationSendingError.getError(), containsString("IllegalArgumentException: null"));
     assertThat(notificationSendingError.getIncidentDateTime(), is(greaterThanOrEqualTo(startDate)));
     assertThat(notificationSendingError.getIncidentDateTime(), is(lessThanOrEqualTo(new Date())));
   }

--- a/src/test/java/org/folio/services/domainevent/LogToDbFailureHandlerTest.java
+++ b/src/test/java/org/folio/services/domainevent/LogToDbFailureHandlerTest.java
@@ -1,6 +1,11 @@
 package org.folio.services.domainevent;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.number.OrderingComparison.greaterThanOrEqualTo;
+import static org.hamcrest.number.OrderingComparison.lessThanOrEqualTo;
+import static org.hamcrest.text.IsBlankString.blankOrNullString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 
@@ -30,11 +35,12 @@ public class LogToDbFailureHandlerTest {
     verify(repository).save(any(), errorArgumentCaptor.capture());
 
     var notificationSendingError = errorArgumentCaptor.getValue();
-    assertThat(notificationSendingError.getId()).isNotBlank();
-    assertThat(notificationSendingError.getTopicName()).isEqualTo("topic");
-    assertThat(notificationSendingError.getPartitionKey()).isEqualTo("key");
-    assertThat(notificationSendingError.getPayload()).isEqualTo("value");
-    assertThat(notificationSendingError.getError()).contains("IllegalArgumentException: null");
-    assertThat(notificationSendingError.getIncidentDateTime()).isBetween(startDate, new Date());
+    assertThat(notificationSendingError.getId(), is(not(blankOrNullString())));
+    assertThat(notificationSendingError.getTopicName(), is("topic"));
+    assertThat(notificationSendingError.getPartitionKey(), is("key"));
+    assertThat(notificationSendingError.getPayload(), is("value"));
+    assertThat(notificationSendingError.getError(), is(("IllegalArgumentException: null")));
+    assertThat(notificationSendingError.getIncidentDateTime(), is(greaterThanOrEqualTo(startDate)));
+    assertThat(notificationSendingError.getIncidentDateTime(), is(lessThanOrEqualTo(new Date())));
   }
 }

--- a/src/test/java/org/folio/services/migration/BatchedReadStreamTest.java
+++ b/src/test/java/org/folio/services/migration/BatchedReadStreamTest.java
@@ -1,10 +1,10 @@
 package org.folio.services.migration;
 
-import static org.assertj.core.api.Assertions.assertThat;
 import static org.awaitility.Awaitility.await;
 import static org.folio.rest.api.TestBase.get;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
@@ -45,18 +45,18 @@ public class BatchedReadStreamTest {
     ArgumentCaptor<List<Row>> captor = ArgumentCaptor.forClass(List.class);
     verify(handler, times(numberOfBatches)).handle(captor.capture());
 
-    assertThat(captor.getAllValues()).hasSize(numberOfBatches);
-    assertThat(captor.getAllValues().get(4)).hasSize(10);
+    assertThat(captor.getAllValues().size(), is(numberOfBatches));
+    assertThat(captor.getAllValues().get(4).size(), is(10));
     captor.getAllValues().stream().limit(numberOfBatches - 1)
-      .forEach(list -> assertThat(list).hasSize(batchSize));
+      .forEach(list -> assertThat(list.size(), is(batchSize)));
 
 
     var ids = new HashSet<UUID>(numberOfRecords);
     captor.getAllValues().forEach(
       list -> list.forEach(
-        // Make sure all IDS are unique so that batch doe not produce
+        // Make sure all IDS are unique so that batch does not produce
         // duplicate records
-        row -> assertThat(ids.add(row.getUUID("id"))).isTrue()));
+        row -> assertThat(ids.add(row.getUUID("id")), is(true))));
   }
 
   @Test


### PR DESCRIPTION
This project already uses Hamcrest for matchers, why has an alternative been introduced?