### PR TITLE
Change version to 21.0.0 MODINVSTOR-725

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,6 @@
 ## 21.0.0 IN-PROGRESS
+
+* `embed_postgres` command line option is no longer supported (MODINVSTOR-728)
 * Upgrades to RAML Module Builder 33.0.0 (MODINVSTOR-728)
 * Upgrades to Vert.x 4.1.0.CR1 (MODINVSTOR-728)
 

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>20.3.0-SNAPSHOT</version>
+  <version>21.0.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>


### PR DESCRIPTION
As RMB 33.x removes support for the `embed_postgres` parameter