### PR TITLE
Make provided inventory-hierarchy version consistent MODINVSTOR-735

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1131,7 +1131,7 @@
     },
     {
       "id": "inventory-hierarchy",
-      "version": "0.1",
+      "version": "0.2",
       "handlers": [
         {
           "methods": ["GET"],


### PR DESCRIPTION
The version was changed in the NEWS and RAML during MODINVSTOR-670 however not changed in the module descriptor