### PR TITLE
Include tenant and environment in topic names MODINVSTOR-738

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
-## 21.1.0 IN-PROGRESS
+## 22.0.0 IN-PROGRESS
 
 * Keyword searches now search alternate title fields (MODINVSTOR-719)
+* Kafka topic names now include environment and tenant ID (MODINVSTOR-738)
 
 ## 21.0.0 2021-06-10
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -2449,6 +2449,7 @@
       { "name": "JAVA_OPTIONS",
         "value": "-XX:MaxRAMPercentage=66.0"
       },
+      { "name": "ENV", "value": "folio" },
       { "name": "DB_HOST", "value": "postgres" },
       { "name": "DB_PORT", "value": "5432" },
       { "name": "DB_USERNAME", "value": "folio_admin" },

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>21.1.0-SNAPSHOT</version>
+  <version>22.0.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/src/main/java/org/folio/Environment.java
+++ b/src/main/java/org/folio/Environment.java
@@ -3,7 +3,7 @@ package org.folio;
 public class Environment {
   private Environment() { }
 
-  public static String getEnvironmentName() {
+  public static String environmentName() {
     return System.getenv().getOrDefault("ENV", "folio");
   }
 }

--- a/src/main/java/org/folio/Environment.java
+++ b/src/main/java/org/folio/Environment.java
@@ -1,0 +1,9 @@
+package org.folio;
+
+public class Environment {
+  private Environment() { }
+
+  public static String getEnvironmentName() {
+    return System.getenv().getOrDefault("ENV", "folio");
+  }
+}

--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -1,19 +1,5 @@
 package org.folio.rest.impl;
 
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import java.util.stream.Collectors;
-import org.apache.commons.io.IOUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.folio.okapi.common.GenericCompositeFuture;
-import org.folio.rest.annotations.Validate;
-import org.folio.rest.jaxrs.model.TenantAttributes;
-import org.folio.rest.tools.utils.TenantLoading;
-import org.folio.services.kafka.topic.KafkaAdminClientService;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -22,9 +8,24 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.okapi.common.GenericCompositeFuture;
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.tools.utils.TenantLoading;
+import org.folio.services.kafka.topic.KafkaAdminClientService;
 import org.folio.services.migration.BaseMigrationService;
 import org.folio.services.migration.instance.PublicationPeriodMigrationService;
 import org.folio.services.migration.item.ItemShelvingOrderMigrationService;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 public class TenantRefAPI extends TenantAPI {
 
@@ -89,7 +90,7 @@ public class TenantRefAPI extends TenantAPI {
     // create topics before loading data
     return
       new KafkaAdminClientService(vertxContext.owner())
-        .createKafkaTopics()
+        .createKafkaTopics(tenantId)
         .compose(x ->super.loadData(attributes, tenantId, headers, vertxContext))
         .compose(superRecordsLoaded -> {
           try {

--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -1,5 +1,7 @@
 package org.folio.rest.impl;
 
+import static org.folio.Environment.environmentName;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -90,7 +92,7 @@ public class TenantRefAPI extends TenantAPI {
     // create topics before loading data
     return
       new KafkaAdminClientService(vertxContext.owner())
-        .createKafkaTopics(tenantId)
+        .createKafkaTopics(tenantId, environmentName())
         .compose(x ->super.loadData(attributes, tenantId, headers, vertxContext))
         .compose(superRecordsLoaded -> {
           try {

--- a/src/main/java/org/folio/services/domainevent/HoldingDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/HoldingDomainEventPublisher.java
@@ -2,6 +2,7 @@ package org.folio.services.domainevent;
 
 import static io.vertx.core.Future.succeededFuture;
 import static java.util.stream.Collectors.toList;
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
 
 import java.util.Collection;
 import java.util.List;
@@ -20,7 +21,8 @@ public class HoldingDomainEventPublisher
 
   public HoldingDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     super(new HoldingsRepository(context, okapiHeaders),
-      new CommonDomainEventPublisher<>(context, okapiHeaders, KafkaTopic.holdingsRecord()));
+      new CommonDomainEventPublisher<>(context, okapiHeaders,
+        KafkaTopic.holdingsRecord(tenantId(okapiHeaders))));
   }
 
   @Override

--- a/src/main/java/org/folio/services/domainevent/HoldingDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/HoldingDomainEventPublisher.java
@@ -2,23 +2,25 @@ package org.folio.services.domainevent;
 
 import static io.vertx.core.Future.succeededFuture;
 import static java.util.stream.Collectors.toList;
-import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_HOLDINGS_RECORD;
 
-import io.vertx.core.Context;
-import io.vertx.core.Future;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.folio.persist.HoldingsRepository;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
+import org.folio.services.kafka.topic.KafkaTopic;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
 
 public class HoldingDomainEventPublisher
   extends AbstractDomainEventPublisher<HoldingsRecord, HoldingsRecord> {
 
   public HoldingDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     super(new HoldingsRepository(context, okapiHeaders),
-      new CommonDomainEventPublisher<>(context, okapiHeaders, INVENTORY_HOLDINGS_RECORD));
+      new CommonDomainEventPublisher<>(context, okapiHeaders, KafkaTopic.holdingsRecord()));
   }
 
   @Override

--- a/src/main/java/org/folio/services/domainevent/HoldingDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/HoldingDomainEventPublisher.java
@@ -2,6 +2,7 @@ package org.folio.services.domainevent;
 
 import static io.vertx.core.Future.succeededFuture;
 import static java.util.stream.Collectors.toList;
+import static org.folio.Environment.environmentName;
 import static org.folio.rest.tools.utils.TenantTool.tenantId;
 
 import java.util.Collection;
@@ -22,7 +23,7 @@ public class HoldingDomainEventPublisher
   public HoldingDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     super(new HoldingsRepository(context, okapiHeaders),
       new CommonDomainEventPublisher<>(context, okapiHeaders,
-        KafkaTopic.holdingsRecord(tenantId(okapiHeaders))));
+        KafkaTopic.holdingsRecord(tenantId(okapiHeaders), environmentName())));
   }
 
   @Override

--- a/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
@@ -2,6 +2,7 @@ package org.folio.services.domainevent;
 
 import static io.vertx.core.Future.succeededFuture;
 import static org.apache.logging.log4j.LogManager.getLogger;
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
 
 import java.util.Collection;
 import java.util.List;
@@ -22,7 +23,8 @@ public class InstanceDomainEventPublisher extends AbstractDomainEventPublisher<I
 
   public InstanceDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     super(new InstanceRepository(context, okapiHeaders),
-      new CommonDomainEventPublisher<>(context, okapiHeaders, KafkaTopic.instance()));
+      new CommonDomainEventPublisher<>(context, okapiHeaders,
+        KafkaTopic.instance(tenantId(okapiHeaders))));
   }
 
   public Future<Void> publishInstancesCreated(List<Instance> instances) {

--- a/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
@@ -2,25 +2,27 @@ package org.folio.services.domainevent;
 
 import static io.vertx.core.Future.succeededFuture;
 import static org.apache.logging.log4j.LogManager.getLogger;
-import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_INSTANCE;
 
-import io.vertx.core.Context;
-import io.vertx.core.Future;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.logging.log4j.Logger;
 import org.folio.persist.InstanceRepository;
 import org.folio.rest.jaxrs.model.Instance;
+import org.folio.services.kafka.topic.KafkaTopic;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
 
 public class InstanceDomainEventPublisher extends AbstractDomainEventPublisher<Instance, Instance> {
   private static final Logger log = getLogger(InstanceDomainEventPublisher.class);
 
   public InstanceDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     super(new InstanceRepository(context, okapiHeaders),
-      new CommonDomainEventPublisher<>(context, okapiHeaders, INVENTORY_INSTANCE));
+      new CommonDomainEventPublisher<>(context, okapiHeaders, KafkaTopic.instance()));
   }
 
   public Future<Void> publishInstancesCreated(List<Instance> instances) {

--- a/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
@@ -2,6 +2,7 @@ package org.folio.services.domainevent;
 
 import static io.vertx.core.Future.succeededFuture;
 import static org.apache.logging.log4j.LogManager.getLogger;
+import static org.folio.Environment.environmentName;
 import static org.folio.rest.tools.utils.TenantTool.tenantId;
 
 import java.util.Collection;
@@ -24,7 +25,7 @@ public class InstanceDomainEventPublisher extends AbstractDomainEventPublisher<I
   public InstanceDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     super(new InstanceRepository(context, okapiHeaders),
       new CommonDomainEventPublisher<>(context, okapiHeaders,
-        KafkaTopic.instance(tenantId(okapiHeaders))));
+        KafkaTopic.instance(tenantId(okapiHeaders), environmentName())));
   }
 
   public Future<Void> publishInstancesCreated(List<Instance> instances) {

--- a/src/main/java/org/folio/services/domainevent/ItemDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/ItemDomainEventPublisher.java
@@ -3,6 +3,7 @@ package org.folio.services.domainevent;
 import static io.vertx.core.Future.succeededFuture;
 import static java.util.stream.Collectors.toList;
 import static org.apache.logging.log4j.LogManager.getLogger;
+import static org.folio.Environment.environmentName;
 import static org.folio.rest.tools.utils.TenantTool.tenantId;
 
 import java.util.Collection;
@@ -29,7 +30,7 @@ public class ItemDomainEventPublisher extends AbstractDomainEventPublisher<Item,
   public ItemDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     super(new ItemRepository(context, okapiHeaders),
       new CommonDomainEventPublisher<>(context, okapiHeaders,
-        KafkaTopic.item(tenantId(okapiHeaders))));
+        KafkaTopic.item(tenantId(okapiHeaders), environmentName())));
 
     holdingsRepository = new HoldingsRepository(context, okapiHeaders);
   }

--- a/src/main/java/org/folio/services/domainevent/ItemDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/ItemDomainEventPublisher.java
@@ -3,13 +3,11 @@ package org.folio.services.domainevent;
 import static io.vertx.core.Future.succeededFuture;
 import static java.util.stream.Collectors.toList;
 import static org.apache.logging.log4j.LogManager.getLogger;
-import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_ITEM;
 
-import io.vertx.core.Context;
-import io.vertx.core.Future;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.Logger;
@@ -17,6 +15,10 @@ import org.folio.persist.HoldingsRepository;
 import org.folio.persist.ItemRepository;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
+import org.folio.services.kafka.topic.KafkaTopic;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
 
 public class ItemDomainEventPublisher extends AbstractDomainEventPublisher<Item, ItemWithInstanceId> {
   private static final Logger log = getLogger(ItemDomainEventPublisher.class);
@@ -25,7 +27,8 @@ public class ItemDomainEventPublisher extends AbstractDomainEventPublisher<Item,
 
   public ItemDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     super(new ItemRepository(context, okapiHeaders),
-      new CommonDomainEventPublisher<>(context, okapiHeaders, INVENTORY_ITEM));
+      new CommonDomainEventPublisher<>(context, okapiHeaders, KafkaTopic.item()));
+
     holdingsRepository = new HoldingsRepository(context, okapiHeaders);
   }
 

--- a/src/main/java/org/folio/services/domainevent/ItemDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/ItemDomainEventPublisher.java
@@ -3,6 +3,7 @@ package org.folio.services.domainevent;
 import static io.vertx.core.Future.succeededFuture;
 import static java.util.stream.Collectors.toList;
 import static org.apache.logging.log4j.LogManager.getLogger;
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
 
 import java.util.Collection;
 import java.util.List;
@@ -27,7 +28,8 @@ public class ItemDomainEventPublisher extends AbstractDomainEventPublisher<Item,
 
   public ItemDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     super(new ItemRepository(context, okapiHeaders),
-      new CommonDomainEventPublisher<>(context, okapiHeaders, KafkaTopic.item()));
+      new CommonDomainEventPublisher<>(context, okapiHeaders,
+        KafkaTopic.item(tenantId(okapiHeaders))));
 
     holdingsRepository = new HoldingsRepository(context, okapiHeaders);
   }

--- a/src/main/java/org/folio/services/kafka/topic/KafkaAdminClientService.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaAdminClientService.java
@@ -60,8 +60,7 @@ public class KafkaAdminClientService {
     KafkaAdminClient kafkaAdminClient) {
 
     final List<NewTopic> expectedTopics = readTopics()
-      .map(topic -> prefixWith(tenantId, topic))
-      .map(topic -> prefixWith(environmentName, topic))
+      .map(topic -> qualifyName(topic, environmentName, tenantId))
       .collect(Collectors.toList());
 
     return kafkaAdminClient.listTopics().compose(existingTopics -> {
@@ -80,8 +79,8 @@ public class KafkaAdminClientService {
     });
   }
 
-  private NewTopic prefixWith(String value, NewTopic topic) {
-    return topic.setName(value + "." + topic.getName());
+  private NewTopic qualifyName(NewTopic topic, String environmentName, String tenantId) {
+    return topic.setName(String.join(".", environmentName, tenantId, topic.getName()));
   }
 
   private Stream<NewTopic> readTopics() {

--- a/src/main/java/org/folio/services/kafka/topic/KafkaAdminClientService.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaAdminClientService.java
@@ -55,11 +55,11 @@ public class KafkaAdminClientService {
   }
 
   private Future<Void> createKafkaTopics(KafkaAdminClient kafkaAdminClient) {
-    final List<NewTopic> newTopics = readTopics();
+    final List<NewTopic> expectedTopics = readTopics();
 
-    return kafkaAdminClient.listTopics().compose(topics -> {
-      final List<NewTopic> topicsToCreate = newTopics.stream()
-        .filter(newTopic -> !topics.contains(newTopic.getName()))
+    return kafkaAdminClient.listTopics().compose(existingTopics -> {
+      final List<NewTopic> topicsToCreate = expectedTopics.stream()
+        .filter(newTopic -> !existingTopics.contains(newTopic.getName()))
         .map(newTopic -> newTopic.setReplicationFactor(getReplicationFactor()))
         .collect(Collectors.toList());
 

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -2,15 +2,15 @@ package org.folio.services.kafka.topic;
 
 public class KafkaTopic {
   public static KafkaTopic instance() {
-    return new KafkaTopic("inventory.instance");
+    return new KafkaTopic(prefixWithEnvironment("inventory.instance"));
   }
 
   public static KafkaTopic holdingsRecord() {
-    return new KafkaTopic("inventory.holdings-record");
+    return new KafkaTopic(prefixWithEnvironment("inventory.holdings-record"));
   }
 
   public static KafkaTopic item() {
-    return new KafkaTopic("inventory.item");
+    return new KafkaTopic(prefixWithEnvironment("inventory.item"));
   }
 
   private final String topicName;
@@ -21,5 +21,11 @@ public class KafkaTopic {
 
   public String getTopicName() {
     return topicName;
+  }
+
+  private static String prefixWithEnvironment(String topicName) {
+    final var environmentName = System.getenv().getOrDefault("ENV", "folio");
+
+    return environmentName + "." + topicName;
   }
 }

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -1,7 +1,5 @@
 package org.folio.services.kafka.topic;
 
-import java.util.stream.Stream;
-
 public enum KafkaTopic {
   INVENTORY_INSTANCE("inventory.instance"),
   INVENTORY_ITEM("inventory.item"),
@@ -15,12 +13,5 @@ public enum KafkaTopic {
 
   public String getTopicName() {
     return topicName;
-  }
-
-  public static KafkaTopic forName(String name) {
-    return Stream.of(values())
-      .filter(value -> value.getTopicName().equals(name))
-      .findFirst()
-      .orElse(null);
   }
 }

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -1,16 +1,19 @@
 package org.folio.services.kafka.topic;
 
 public class KafkaTopic {
-  public static KafkaTopic instance() {
-    return new KafkaTopic(prefixWithEnvironment("inventory.instance"));
+  public static KafkaTopic instance(String tenantId) {
+    return new KafkaTopic(prefixWithEnvironment(
+      prefixWithTenantId("inventory.instance", tenantId)));
   }
 
-  public static KafkaTopic holdingsRecord() {
-    return new KafkaTopic(prefixWithEnvironment("inventory.holdings-record"));
+  public static KafkaTopic holdingsRecord(String tenantId) {
+    return new KafkaTopic(prefixWithEnvironment(
+      prefixWithTenantId("inventory.holdings-record", tenantId)));
   }
 
-  public static KafkaTopic item() {
-    return new KafkaTopic(prefixWithEnvironment("inventory.item"));
+  public static KafkaTopic item(String tenantId) {
+    return new KafkaTopic(prefixWithEnvironment(
+      prefixWithTenantId("inventory.item", tenantId)));
   }
 
   private final String topicName;
@@ -21,6 +24,10 @@ public class KafkaTopic {
 
   public String getTopicName() {
     return topicName;
+  }
+
+  private static String prefixWithTenantId(String topicName, String tenantId) {
+    return tenantId + "." + topicName;
   }
 
   private static String prefixWithEnvironment(String topicName) {

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -1,20 +1,16 @@
 package org.folio.services.kafka.topic;
 
-public enum KafkaTopic {
-  INVENTORY_INSTANCE("inventory.instance"),
-  INVENTORY_ITEM("inventory.item"),
-  INVENTORY_HOLDINGS_RECORD("inventory.holdings-record");
-
+public class KafkaTopic {
   public static KafkaTopic instance() {
-    return INVENTORY_INSTANCE;
+    return new KafkaTopic("inventory.instance");
   }
 
   public static KafkaTopic holdingsRecord() {
-    return INVENTORY_HOLDINGS_RECORD;
+    return new KafkaTopic("inventory.holdings-record");
   }
 
   public static KafkaTopic item() {
-    return INVENTORY_ITEM;
+    return new KafkaTopic("inventory.item");
   }
 
   private final String topicName;

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -2,18 +2,15 @@ package org.folio.services.kafka.topic;
 
 public class KafkaTopic {
   public static KafkaTopic instance(String tenantId, String environmentName) {
-    return new KafkaTopic(prefixWith(environmentName,
-      prefixWith(tenantId, "inventory.instance")));
+    return new KafkaTopic(qualifyName("inventory.instance", environmentName, tenantId));
   }
 
   public static KafkaTopic holdingsRecord(String tenantId, String environmentName) {
-    return new KafkaTopic(prefixWith(environmentName,
-      prefixWith(tenantId, "inventory.holdings-record")));
+    return new KafkaTopic(qualifyName("inventory.holdings-record", environmentName, tenantId));
   }
 
   public static KafkaTopic item(String tenantId, String environmentName) {
-    return new KafkaTopic(prefixWith(environmentName,
-      prefixWith(tenantId, "inventory.item")));
+    return new KafkaTopic(qualifyName("inventory.item", environmentName, tenantId));
   }
 
   private final String topicName;
@@ -26,7 +23,7 @@ public class KafkaTopic {
     return topicName;
   }
 
-  private static String prefixWith(String value, String topicName) {
-    return value + "." + topicName;
+  private static String qualifyName(String name, String environmentName, String tenantId) {
+    return String.join(".", environmentName, tenantId, name);
   }
 }

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -13,6 +13,10 @@ public enum KafkaTopic {
     return INVENTORY_HOLDINGS_RECORD;
   }
 
+  public static KafkaTopic item() {
+    return INVENTORY_ITEM;
+  }
+
   private final String topicName;
 
   KafkaTopic(String topicName) {

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -1,20 +1,18 @@
 package org.folio.services.kafka.topic;
 
-import static org.folio.Environment.getEnvironmentName;
-
 public class KafkaTopic {
-  public static KafkaTopic instance(String tenantId) {
-    return new KafkaTopic(prefixWith(getEnvironmentName(),
+  public static KafkaTopic instance(String tenantId, String environmentName) {
+    return new KafkaTopic(prefixWith(environmentName,
       prefixWith(tenantId, "inventory.instance")));
   }
 
-  public static KafkaTopic holdingsRecord(String tenantId) {
-    return new KafkaTopic(prefixWith(getEnvironmentName(),
+  public static KafkaTopic holdingsRecord(String tenantId, String environmentName) {
+    return new KafkaTopic(prefixWith(environmentName,
       prefixWith(tenantId, "inventory.holdings-record")));
   }
 
-  public static KafkaTopic item(String tenantId) {
-    return new KafkaTopic(prefixWith(getEnvironmentName(),
+  public static KafkaTopic item(String tenantId, String environmentName) {
+    return new KafkaTopic(prefixWith(environmentName,
       prefixWith(tenantId, "inventory.item")));
   }
 

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -5,6 +5,10 @@ public enum KafkaTopic {
   INVENTORY_ITEM("inventory.item"),
   INVENTORY_HOLDINGS_RECORD("inventory.holdings-record");
 
+  public static KafkaTopic instance() {
+    return INVENTORY_INSTANCE;
+  }
+
   private final String topicName;
 
   KafkaTopic(String topicName) {

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -1,19 +1,21 @@
 package org.folio.services.kafka.topic;
 
+import static org.folio.Environment.getEnvironmentName;
+
 public class KafkaTopic {
   public static KafkaTopic instance(String tenantId) {
-    return new KafkaTopic(prefixWithEnvironment(
-      prefixWithTenantId("inventory.instance", tenantId)));
+    return new KafkaTopic(prefixWith(getEnvironmentName(),
+      prefixWith(tenantId, "inventory.instance")));
   }
 
   public static KafkaTopic holdingsRecord(String tenantId) {
-    return new KafkaTopic(prefixWithEnvironment(
-      prefixWithTenantId("inventory.holdings-record", tenantId)));
+    return new KafkaTopic(prefixWith(getEnvironmentName(),
+      prefixWith(tenantId, "inventory.holdings-record")));
   }
 
   public static KafkaTopic item(String tenantId) {
-    return new KafkaTopic(prefixWithEnvironment(
-      prefixWithTenantId("inventory.item", tenantId)));
+    return new KafkaTopic(prefixWith(getEnvironmentName(),
+      prefixWith(tenantId, "inventory.item")));
   }
 
   private final String topicName;
@@ -26,13 +28,7 @@ public class KafkaTopic {
     return topicName;
   }
 
-  private static String prefixWithTenantId(String topicName, String tenantId) {
-    return tenantId + "." + topicName;
-  }
-
-  private static String prefixWithEnvironment(String topicName) {
-    final var environmentName = System.getenv().getOrDefault("ENV", "folio");
-
-    return environmentName + "." + topicName;
+  private static String prefixWith(String value, String topicName) {
+    return value + "." + topicName;
   }
 }

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -9,6 +9,10 @@ public enum KafkaTopic {
     return INVENTORY_INSTANCE;
   }
 
+  public static KafkaTopic holdingsRecord() {
+    return INVENTORY_HOLDINGS_RECORD;
+  }
+
   private final String topicName;
 
   KafkaTopic(String topicName) {

--- a/src/main/java/org/folio/services/reindex/ReindexJobRunner.java
+++ b/src/main/java/org/folio/services/reindex/ReindexJobRunner.java
@@ -44,7 +44,8 @@ public class ReindexJobRunner {
     this(new PostgresClientFuturized(PgUtil.postgresClient(vertxContext, okapiHeaders)),
       new ReindexJobRepository(vertxContext, okapiHeaders),
       vertxContext,
-      new CommonDomainEventPublisher<>(vertxContext, okapiHeaders, KafkaTopic.instance()),
+      new CommonDomainEventPublisher<>(vertxContext, okapiHeaders,
+        KafkaTopic.instance(tenantId(okapiHeaders))),
       tenantId(okapiHeaders));
   }
 

--- a/src/main/java/org/folio/services/reindex/ReindexJobRunner.java
+++ b/src/main/java/org/folio/services/reindex/ReindexJobRunner.java
@@ -8,14 +8,9 @@ import static org.folio.rest.jaxrs.model.ReindexJob.JobStatus.ID_PUBLISHING_FAIL
 import static org.folio.rest.jaxrs.model.ReindexJob.JobStatus.PENDING_CANCEL;
 import static org.folio.rest.tools.utils.TenantTool.tenantId;
 import static org.folio.services.domainevent.DomainEvent.reindexEvent;
-import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_INSTANCE;
 
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.WorkerExecutor;
-import io.vertx.sqlclient.Row;
-import io.vertx.sqlclient.RowStream;
 import java.util.Map;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.persist.ReindexJobRepository;
@@ -26,6 +21,13 @@ import org.folio.rest.persist.PostgresClientFuturized;
 import org.folio.rest.persist.SQLConnection;
 import org.folio.services.domainevent.CommonDomainEventPublisher;
 import org.folio.services.kafka.InventoryProducerRecordBuilder;
+import org.folio.services.kafka.topic.KafkaTopic;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.WorkerExecutor;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowStream;
 
 public class ReindexJobRunner {
   public static final String REINDEX_JOB_ID_HEADER = "reindex-job-id";
@@ -42,7 +44,7 @@ public class ReindexJobRunner {
     this(new PostgresClientFuturized(PgUtil.postgresClient(vertxContext, okapiHeaders)),
       new ReindexJobRepository(vertxContext, okapiHeaders),
       vertxContext,
-      new CommonDomainEventPublisher<>(vertxContext, okapiHeaders, INVENTORY_INSTANCE),
+      new CommonDomainEventPublisher<>(vertxContext, okapiHeaders, KafkaTopic.instance()),
       tenantId(okapiHeaders));
   }
 

--- a/src/main/java/org/folio/services/reindex/ReindexJobRunner.java
+++ b/src/main/java/org/folio/services/reindex/ReindexJobRunner.java
@@ -1,6 +1,7 @@
 package org.folio.services.reindex;
 
 import static io.vertx.core.Future.succeededFuture;
+import static org.folio.Environment.environmentName;
 import static org.folio.persist.InstanceRepository.INSTANCE_TABLE;
 import static org.folio.rest.jaxrs.model.ReindexJob.JobStatus.IDS_PUBLISHED;
 import static org.folio.rest.jaxrs.model.ReindexJob.JobStatus.ID_PUBLISHING_CANCELLED;
@@ -45,7 +46,7 @@ public class ReindexJobRunner {
       new ReindexJobRepository(vertxContext, okapiHeaders),
       vertxContext,
       new CommonDomainEventPublisher<>(vertxContext, okapiHeaders,
-        KafkaTopic.instance(tenantId(okapiHeaders))),
+        KafkaTopic.instance(tenantId(okapiHeaders), environmentName())),
       tenantId(okapiHeaders));
   }
 

--- a/src/test/java/org/folio/rest/api/ItemDamagedStatusAPITest.java
+++ b/src/test/java/org/folio/rest/api/ItemDamagedStatusAPITest.java
@@ -23,7 +23,6 @@ import org.junit.Test;
 import io.vertx.core.json.JsonObject;
 
 public class ItemDamagedStatusAPITest extends TestBase {
-
   public static final String TEST_TENANT = "test_tenant";
 
   @Before

--- a/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
+++ b/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
@@ -8,7 +8,6 @@ import static org.folio.rest.jaxrs.model.ReindexJob.JobStatus.IDS_PUBLISHED;
 import static org.folio.rest.jaxrs.model.ReindexJob.JobStatus.ID_PUBLISHING_CANCELLED;
 import static org.folio.rest.jaxrs.model.ReindexJob.JobStatus.IN_PROGRESS;
 import static org.folio.rest.persist.PgUtil.postgresClient;
-import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_INSTANCE;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
@@ -20,6 +19,19 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
+import java.util.Date;
+import java.util.Map;
+import java.util.UUID;
+
+import org.folio.persist.ReindexJobRepository;
+import org.folio.rest.jaxrs.model.Instance;
+import org.folio.rest.jaxrs.model.ReindexJob;
+import org.folio.rest.persist.PostgresClientFuturized;
+import org.folio.services.domainevent.CommonDomainEventPublisher;
+import org.folio.services.kafka.topic.KafkaTopic;
+import org.folio.services.reindex.ReindexJobRunner;
+import org.junit.Test;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -27,22 +39,12 @@ import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowStream;
-import java.util.Date;
-import java.util.Map;
-import java.util.UUID;
-import org.folio.persist.ReindexJobRepository;
-import org.folio.rest.jaxrs.model.Instance;
-import org.folio.rest.jaxrs.model.ReindexJob;
-import org.folio.rest.persist.PostgresClientFuturized;
-import org.folio.services.domainevent.CommonDomainEventPublisher;
-import org.folio.services.reindex.ReindexJobRunner;
-import org.junit.Test;
 
 public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
   private final ReindexJobRepository repository = getRepository();
   private final CommonDomainEventPublisher<Instance> eventPublisher =
     new CommonDomainEventPublisher<>(getContext(), Map.of(TENANT, TENANT_ID),
-      INVENTORY_INSTANCE);
+      KafkaTopic.instance());
 
   @Test
   public void canReindexInstances() {

--- a/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
+++ b/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
@@ -3,6 +3,7 @@ package org.folio.rest.api;
 import static io.vertx.core.Future.succeededFuture;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
+import static org.folio.Environment.environmentName;
 import static org.folio.okapi.common.XOkapiHeaders.TENANT;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
 import static org.folio.rest.jaxrs.model.ReindexJob.JobStatus.IDS_PUBLISHED;
@@ -46,7 +47,7 @@ public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
   private final ReindexJobRepository repository = getRepository();
   private final CommonDomainEventPublisher<Instance> eventPublisher =
     new CommonDomainEventPublisher<>(getContext(), Map.of(TENANT, TENANT_ID),
-      KafkaTopic.instance(TENANT_ID));
+      KafkaTopic.instance(TENANT_ID, environmentName()));
 
   @Test
   public void canReindexInstances() {

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -34,9 +34,9 @@ public final class FakeKafkaConsumer {
     // These definitions are deliberately separate to the production definitions
     // This is so these can be changed independently to demonstrate
     // tests failing for the right reason prior to changing the production code
-    final var INSTANCE_TOPIC_NAME = "inventory.instance";
-    final var HOLDINGS_TOPIC_NAME = "inventory.holdings-record";
-    final var ITEM_TOPIC_NAME = "inventory.item";
+    final var INSTANCE_TOPIC_NAME = "folio.inventory.instance";
+    final var HOLDINGS_TOPIC_NAME = "folio.inventory.holdings-record";
+    final var ITEM_TOPIC_NAME = "folio.inventory.item";
 
     consumer.subscribe(Set.of(INSTANCE_TOPIC_NAME, HOLDINGS_TOPIC_NAME, ITEM_TOPIC_NAME));
     consumer.handler(message -> {

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -65,10 +65,14 @@ public final class FakeKafkaConsumer {
     return this;
   }
 
-  public void removeAllEvents() {
+  public static void removeAllEvents() {
     itemEvents.clear();
     instanceEvents.clear();
     holdingsEvents.clear();
+  }
+
+  public static int getAllPublishedInstanceIdsCount() {
+    return instanceEvents.size();
   }
 
   public static Collection<KafkaConsumerRecord<String, JsonObject> > getInstanceEvents(

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -2,15 +2,7 @@ package org.folio.rest.support.kafka;
 
 import static io.vertx.kafka.client.consumer.KafkaConsumer.create;
 import static java.util.Collections.emptyList;
-import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_HOLDINGS_RECORD;
-import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_INSTANCE;
-import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_ITEM;
 
-import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
-import io.vertx.kafka.client.consumer.KafkaConsumer;
-import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
-import io.vertx.kafka.client.serialization.JsonObjectDeserializer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -18,17 +10,17 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
+
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.folio.services.kafka.KafkaProperties;
-import org.folio.services.kafka.topic.KafkaTopic;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.serialization.JsonObjectDeserializer;
 
 public final class FakeKafkaConsumer {
-  private static final Set<String> TOPIC_NAMES = Stream.of(INVENTORY_INSTANCE,
-    INVENTORY_ITEM, INVENTORY_HOLDINGS_RECORD)
-    .map(KafkaTopic::getTopicName).collect(Collectors.toSet());
-
   private final static Map<String, List<KafkaConsumerRecord<String, JsonObject>>> itemEvents =
     new ConcurrentHashMap<>();
   private final static Map<String, List<KafkaConsumerRecord<String, JsonObject>>> instanceEvents =
@@ -36,23 +28,30 @@ public final class FakeKafkaConsumer {
   private final static Map<String, List<KafkaConsumerRecord<String, JsonObject>>> holdingsEvents =
     new ConcurrentHashMap<>();
 
-  public final FakeKafkaConsumer consume(Vertx vertx) {
+  public FakeKafkaConsumer consume(Vertx vertx) {
     final KafkaConsumer<String, JsonObject> consumer = create(vertx, consumerProperties());
 
-    consumer.subscribe(TOPIC_NAMES);
+    // These definitions are deliberately separate to the production definitions
+    // This is so these can be changed independently to demonstrate
+    // tests failing for the right reason prior to changing the production code
+    final var INSTANCE_TOPIC_NAME = "inventory.instance";
+    final var HOLDINGS_TOPIC_NAME = "inventory.holdings-record";
+    final var ITEM_TOPIC_NAME = "inventory.item";
+
+    consumer.subscribe(Set.of(INSTANCE_TOPIC_NAME, HOLDINGS_TOPIC_NAME, ITEM_TOPIC_NAME));
     consumer.handler(message -> {
       final List<KafkaConsumerRecord<String, JsonObject>> storageList;
 
-      switch (KafkaTopic.forName(message.topic())){
-        case INVENTORY_ITEM:
+      switch (message.topic()) {
+        case ITEM_TOPIC_NAME:
           storageList = itemEvents.computeIfAbsent(instanceAndIdKey(message),
             k -> new ArrayList<>());
           break;
-        case INVENTORY_INSTANCE:
+        case INSTANCE_TOPIC_NAME:
           storageList = instanceEvents.computeIfAbsent(message.key(),
             k -> new ArrayList<>());
           break;
-        case INVENTORY_HOLDINGS_RECORD:
+        case HOLDINGS_TOPIC_NAME:
           storageList = holdingsEvents.computeIfAbsent(instanceAndIdKey(message),
             k -> new ArrayList<>());
           break;

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -34,9 +34,9 @@ public final class FakeKafkaConsumer {
     // These definitions are deliberately separate to the production definitions
     // This is so these can be changed independently to demonstrate
     // tests failing for the right reason prior to changing the production code
-    final var INSTANCE_TOPIC_NAME = "folio.inventory.instance";
-    final var HOLDINGS_TOPIC_NAME = "folio.inventory.holdings-record";
-    final var ITEM_TOPIC_NAME = "folio.inventory.item";
+    final var INSTANCE_TOPIC_NAME = "folio.test_tenant.inventory.instance";
+    final var HOLDINGS_TOPIC_NAME = "folio.test_tenant.inventory.holdings-record";
+    final var ITEM_TOPIC_NAME = "folio.test_tenant.inventory.item";
 
     consumer.subscribe(Set.of(INSTANCE_TOPIC_NAME, HOLDINGS_TOPIC_NAME, ITEM_TOPIC_NAME));
     consumer.handler(message -> {

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -25,6 +25,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
@@ -41,6 +42,7 @@ public final class DomainEventAssertions {
   private DomainEventAssertions() { }
 
   private static void assertCreateEvent(KafkaConsumerRecord<String, JsonObject> createEvent, JsonObject newRecord) {
+    assertThat("Create event should be present", createEvent.value(), is(notNullValue()));
     assertThat(createEvent.value().getString("type"), is("CREATE"));
     assertThat(createEvent.value().getString("tenant"), is(TENANT_ID));
     assertThat(createEvent.value().getJsonObject("old"), nullValue());

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -38,7 +38,7 @@ import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
 
 public final class DomainEventAssertions {
-  private DomainEventAssertions() {}
+  private DomainEventAssertions() { }
 
   private static void assertCreateEvent(KafkaConsumerRecord<String, JsonObject> createEvent, JsonObject newRecord) {
     assertThat(createEvent.value().getString("type"), is("CREATE"));
@@ -89,7 +89,8 @@ public final class DomainEventAssertions {
 
   public static void assertNoUpdateEvent(String instanceId) {
     await().atLeast(1, SECONDS);
-    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
 
     final JsonObject updateMessage  = getLastInstanceEvent(instanceId).value();
     assertThat(updateMessage.getString("type"), not(is("UPDATE")));
@@ -97,7 +98,8 @@ public final class DomainEventAssertions {
 
   public static void assertNoUpdateEventForHolding(String instanceId, String hrId) {
     await().atLeast(1, SECONDS);
-    await().until(() -> getHoldingsEvents(instanceId, hrId).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getHoldingsEvents(instanceId, hrId).size(), greaterThan(0));
 
     final JsonObject updateMessage  = getLastHoldingEvent(instanceId, hrId).value();
     assertThat(updateMessage.getString("type"), not(is("UPDATE")));
@@ -105,7 +107,8 @@ public final class DomainEventAssertions {
 
   public static void assertNoRemoveEvent(String instanceId) {
     await().atLeast(1, SECONDS);
-    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
 
     final JsonObject updateMessage  = getLastInstanceEvent(instanceId).value();
     assertThat(updateMessage.getString("type"), not(is("DELETE")));
@@ -120,7 +123,8 @@ public final class DomainEventAssertions {
   public static void assertCreateEventForInstance(JsonObject instance) {
     final String instanceId = instance.getString("id");
 
-    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
 
     assertCreateEvent(getFirstInstanceEvent(instanceId), instance);
   }
@@ -141,13 +145,15 @@ public final class DomainEventAssertions {
   public static void assertRemoveEventForInstance(JsonObject instance) {
     final String instanceId = instance.getString("id");
 
-    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(1));
+    await().atMost(1, SECONDS)
+      .until(() -> getInstanceEvents(instanceId).size(), greaterThan(1));
 
     assertRemoveEvent(getLastInstanceEvent(instanceId), instance);
   }
 
   public static void assertRemoveAllEventForInstance() {
-    await().until(() -> getInstanceEvents(NULL_INSTANCE_ID).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getInstanceEvents(NULL_INSTANCE_ID).size(), greaterThan(0));
 
     assertRemoveAllEvent(getLastInstanceEvent(NULL_INSTANCE_ID));
   }
@@ -155,7 +161,8 @@ public final class DomainEventAssertions {
   public static void assertUpdateEventForInstance(JsonObject oldInstance, JsonObject newInstance) {
     final String instanceId = oldInstance.getString("id");
 
-    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(1));
+    await().atMost(1, SECONDS)
+      .until(() -> getInstanceEvents(instanceId).size(), greaterThan(1));
 
     assertUpdateEvent(getLastInstanceEvent(instanceId), oldInstance, newInstance);
   }
@@ -164,7 +171,8 @@ public final class DomainEventAssertions {
     final String itemId = item.getString("id");
     final String instanceIdForItem = getInstanceIdForItem(item);
 
-    await().until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(0));
 
     // Domain event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
@@ -177,7 +185,8 @@ public final class DomainEventAssertions {
     final String itemId = item.getString("id");
     final String instanceIdForItem = getInstanceIdForItem(item);
 
-    await().until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(1));
+    await().atMost(1, SECONDS)
+      .until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(1));
 
     // Domain event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
@@ -187,7 +196,8 @@ public final class DomainEventAssertions {
   }
 
   public static void assertRemoveAllEventForItem() {
-    await().until(() -> getItemEvents(NULL_INSTANCE_ID, null).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getItemEvents(NULL_INSTANCE_ID, null).size(), greaterThan(0));
 
     assertRemoveAllEvent(getLastItemEvent(NULL_INSTANCE_ID, null));
   }
@@ -196,7 +206,8 @@ public final class DomainEventAssertions {
     final String itemId = newItem.getString("id");
     final String instanceIdForItem = getInstanceIdForItem(newItem);
 
-    await().until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(1));
+    await().atMost(1, SECONDS)
+      .until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(1));
 
     // Domain event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
@@ -210,7 +221,8 @@ public final class DomainEventAssertions {
     final String id = hr.getString("id");
     final String instanceId = hr.getString("instanceId");
 
-    await().until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(0));
 
     assertCreateEvent(getFirstHoldingEvent(instanceId, id), hr);
   }
@@ -219,13 +231,15 @@ public final class DomainEventAssertions {
     final String id = hr.getString("id");
     final String instanceId = hr.getString("instanceId");
 
-    await().until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(1));
+    await().atMost(1, SECONDS)
+      .until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(1));
 
     assertRemoveEvent(getLastHoldingEvent(instanceId, id), hr);
   }
 
   public static void assertRemoveAllEventForHolding() {
-    await().until(() -> getHoldingsEvents(NULL_INSTANCE_ID, null).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getHoldingsEvents(NULL_INSTANCE_ID, null).size(), greaterThan(0));
 
     assertRemoveAllEvent(getLastHoldingEvent(NULL_INSTANCE_ID, null));
   }
@@ -234,7 +248,8 @@ public final class DomainEventAssertions {
     final String id = newHr.getString("id");
     final String instanceId = newHr.getString("instanceId");
 
-    await().until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(1));
+    await().atMost(1, SECONDS)
+      .until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(1));
 
     assertUpdateEvent(getLastHoldingEvent(instanceId, id), oldHr, newHr);
   }

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -24,16 +24,18 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
 
 import io.vertx.core.MultiMap;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
 
 public final class DomainEventAssertions {
   private DomainEventAssertions() {}
@@ -87,7 +89,7 @@ public final class DomainEventAssertions {
 
   public static void assertNoUpdateEvent(String instanceId) {
     await().atLeast(1, SECONDS);
-    await().until(() -> getInstanceEvents(instanceId).size() > 0);
+    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
 
     final JsonObject updateMessage  = getLastInstanceEvent(instanceId).value();
     assertThat(updateMessage.getString("type"), not(is("UPDATE")));
@@ -95,7 +97,7 @@ public final class DomainEventAssertions {
 
   public static void assertNoUpdateEventForHolding(String instanceId, String hrId) {
     await().atLeast(1, SECONDS);
-    await().until(() -> getHoldingsEvents(instanceId, hrId).size() > 0);
+    await().until(() -> getHoldingsEvents(instanceId, hrId).size(), greaterThan(0));
 
     final JsonObject updateMessage  = getLastHoldingEvent(instanceId, hrId).value();
     assertThat(updateMessage.getString("type"), not(is("UPDATE")));
@@ -103,7 +105,7 @@ public final class DomainEventAssertions {
 
   public static void assertNoRemoveEvent(String instanceId) {
     await().atLeast(1, SECONDS);
-    await().until(() -> getInstanceEvents(instanceId).size() > 0);
+    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
 
     final JsonObject updateMessage  = getLastInstanceEvent(instanceId).value();
     assertThat(updateMessage.getString("type"), not(is("DELETE")));
@@ -118,7 +120,7 @@ public final class DomainEventAssertions {
   public static void assertCreateEventForInstance(JsonObject instance) {
     final String instanceId = instance.getString("id");
 
-    await().until(() -> getInstanceEvents(instanceId).size() > 0);
+    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
 
     assertCreateEvent(getFirstInstanceEvent(instanceId), instance);
   }
@@ -139,13 +141,13 @@ public final class DomainEventAssertions {
   public static void assertRemoveEventForInstance(JsonObject instance) {
     final String instanceId = instance.getString("id");
 
-    await().until(() -> getInstanceEvents(instanceId).size() > 1);
+    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(1));
 
     assertRemoveEvent(getLastInstanceEvent(instanceId), instance);
   }
 
   public static void assertRemoveAllEventForInstance() {
-    await().until(() -> getInstanceEvents(NULL_INSTANCE_ID).size() > 0);
+    await().until(() -> getInstanceEvents(NULL_INSTANCE_ID).size(), greaterThan(0));
 
     assertRemoveAllEvent(getLastInstanceEvent(NULL_INSTANCE_ID));
   }
@@ -153,7 +155,7 @@ public final class DomainEventAssertions {
   public static void assertUpdateEventForInstance(JsonObject oldInstance, JsonObject newInstance) {
     final String instanceId = oldInstance.getString("id");
 
-    await().until(() -> getInstanceEvents(instanceId).size() > 1);
+    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(1));
 
     assertUpdateEvent(getLastInstanceEvent(instanceId), oldInstance, newInstance);
   }
@@ -162,7 +164,7 @@ public final class DomainEventAssertions {
     final String itemId = item.getString("id");
     final String instanceIdForItem = getInstanceIdForItem(item);
 
-    await().until(() -> getItemEvents(instanceIdForItem, itemId).size() > 0);
+    await().until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(0));
 
     // Domain event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
@@ -175,7 +177,7 @@ public final class DomainEventAssertions {
     final String itemId = item.getString("id");
     final String instanceIdForItem = getInstanceIdForItem(item);
 
-    await().until(() -> getItemEvents(instanceIdForItem, itemId).size() > 1);
+    await().until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(1));
 
     // Domain event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
@@ -185,7 +187,7 @@ public final class DomainEventAssertions {
   }
 
   public static void assertRemoveAllEventForItem() {
-    await().until(() -> getItemEvents(NULL_INSTANCE_ID, null).size() > 0);
+    await().until(() -> getItemEvents(NULL_INSTANCE_ID, null).size(), greaterThan(0));
 
     assertRemoveAllEvent(getLastItemEvent(NULL_INSTANCE_ID, null));
   }
@@ -194,7 +196,7 @@ public final class DomainEventAssertions {
     final String itemId = newItem.getString("id");
     final String instanceIdForItem = getInstanceIdForItem(newItem);
 
-    await().until(() -> getItemEvents(instanceIdForItem, itemId).size() > 1);
+    await().until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(1));
 
     // Domain event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
@@ -208,7 +210,7 @@ public final class DomainEventAssertions {
     final String id = hr.getString("id");
     final String instanceId = hr.getString("instanceId");
 
-    await().until(() -> getHoldingsEvents(instanceId, id).size() > 0);
+    await().until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(0));
 
     assertCreateEvent(getFirstHoldingEvent(instanceId, id), hr);
   }
@@ -217,13 +219,13 @@ public final class DomainEventAssertions {
     final String id = hr.getString("id");
     final String instanceId = hr.getString("instanceId");
 
-    await().until(() -> getHoldingsEvents(instanceId, id).size() > 1);
+    await().until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(1));
 
     assertRemoveEvent(getLastHoldingEvent(instanceId, id), hr);
   }
 
   public static void assertRemoveAllEventForHolding() {
-    await().until(() -> getHoldingsEvents(NULL_INSTANCE_ID, null).size() > 0);
+    await().until(() -> getHoldingsEvents(NULL_INSTANCE_ID, null).size(), greaterThan(0));
 
     assertRemoveAllEvent(getLastHoldingEvent(NULL_INSTANCE_ID, null));
   }
@@ -232,7 +234,7 @@ public final class DomainEventAssertions {
     final String id = newHr.getString("id");
     final String instanceId = newHr.getString("instanceId");
 
-    await().until(() -> getHoldingsEvents(instanceId, id).size() > 1);
+    await().until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(1));
 
     assertUpdateEvent(getLastHoldingEvent(instanceId, id), oldHr, newHr);
   }

--- a/src/test/java/org/folio/services/domainevent/CommonDomainEventPublisherTest.java
+++ b/src/test/java/org/folio/services/domainevent/CommonDomainEventPublisherTest.java
@@ -4,9 +4,8 @@ import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
 import static org.awaitility.Awaitility.await;
 import static org.folio.rest.api.TestBase.get;
-import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_INSTANCE;
-import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
@@ -16,19 +15,22 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import io.vertx.core.Handler;
-import io.vertx.kafka.client.producer.KafkaProducer;
 import java.util.Map;
+
 import org.folio.kafka.KafkaProducerManager;
 import org.folio.rest.api.ReindexJobRunnerTest;
 import org.folio.rest.api.entities.Instance;
 import org.folio.services.kafka.InventoryProducerRecordBuilder;
+import org.folio.services.kafka.topic.KafkaTopic;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.junit.MockitoJUnitRunner;
+
+import io.vertx.core.Handler;
+import io.vertx.kafka.client.producer.KafkaProducer;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CommonDomainEventPublisherTest {
@@ -40,7 +42,7 @@ public class CommonDomainEventPublisherTest {
   @Before
   public void setUpPublisher() {
     eventPublisher = new CommonDomainEventPublisher<>(
-      Map.of(), INVENTORY_INSTANCE, producerManager, failureHandler);
+      Map.of(), KafkaTopic.instance(), producerManager, failureHandler);
   }
 
   @Test

--- a/src/test/java/org/folio/services/domainevent/CommonDomainEventPublisherTest.java
+++ b/src/test/java/org/folio/services/domainevent/CommonDomainEventPublisherTest.java
@@ -42,7 +42,7 @@ public class CommonDomainEventPublisherTest {
   @Before
   public void setUpPublisher() {
     eventPublisher = new CommonDomainEventPublisher<>(
-      Map.of(), KafkaTopic.instance(), producerManager, failureHandler);
+      Map.of(), KafkaTopic.instance(""), producerManager, failureHandler);
   }
 
   @Test

--- a/src/test/java/org/folio/services/domainevent/CommonDomainEventPublisherTest.java
+++ b/src/test/java/org/folio/services/domainevent/CommonDomainEventPublisherTest.java
@@ -3,6 +3,7 @@ package org.folio.services.domainevent;
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
 import static org.awaitility.Awaitility.await;
+import static org.folio.Environment.environmentName;
 import static org.folio.rest.api.TestBase.get;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -42,7 +43,7 @@ public class CommonDomainEventPublisherTest {
   @Before
   public void setUpPublisher() {
     eventPublisher = new CommonDomainEventPublisher<>(
-      Map.of(), KafkaTopic.instance(""), producerManager, failureHandler);
+      Map.of(), KafkaTopic.instance("", environmentName()), producerManager, failureHandler);
   }
 
   @Test

--- a/src/test/java/org/folio/services/domainevent/CommonDomainEventPublisherTest.java
+++ b/src/test/java/org/folio/services/domainevent/CommonDomainEventPublisherTest.java
@@ -43,7 +43,8 @@ public class CommonDomainEventPublisherTest {
   @Before
   public void setUpPublisher() {
     eventPublisher = new CommonDomainEventPublisher<>(
-      Map.of(), KafkaTopic.instance("", environmentName()), producerManager, failureHandler);
+      Map.of(), KafkaTopic.instance("foo-tenant", environmentName()),
+        producerManager, failureHandler);
   }
 
   @Test

--- a/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -2,6 +2,8 @@ package org.folio.services.kafka.topic;
 
 import static io.vertx.core.Future.succeededFuture;
 import static java.util.Set.of;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
@@ -60,12 +62,16 @@ public class KafkaAdminClientServiceTest {
         verify(mockClient, times(1)).createTopics(createTopicsCaptor.capture());
         verify(mockClient, times(1)).close();
 
-        testContext.assertEquals(1, createTopicsCaptor.getAllValues().size());
-        testContext.assertEquals(allTopics.size(), createTopicsCaptor.getAllValues().get(0).size());
-        testContext.assertEquals("inventory.instance", createTopicsCaptor.getAllValues().get(0).get(0).getName());
-        testContext.assertEquals("inventory.item", createTopicsCaptor.getAllValues().get(0).get(1).getName());
-        testContext.assertEquals("inventory.holdings-record", createTopicsCaptor.getAllValues().get(0).get(2).getName());
+        // Only these items are expected, so implicitly checks size of list
+        assertThat(getTopicNames(createTopicsCaptor), containsInAnyOrder(
+          "inventory.instance", "inventory.holdings-record", "inventory.item"));
       }));
+  }
+
+  private List<String> getTopicNames(ArgumentCaptor<List<NewTopic>> createTopicsCaptor) {
+    return createTopicsCaptor.getAllValues().get(0).stream()
+      .map(NewTopic::getName)
+      .collect(Collectors.toList());
   }
 
   private Future<Void> createKafkaTopicsAsync(KafkaAdminClient mockClient) {

--- a/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -9,18 +9,20 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
 import io.vertx.core.Future;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.kafka.admin.KafkaAdminClient;
 import io.vertx.kafka.admin.NewTopic;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 
 @RunWith(VertxUnitRunner.class)
 public class KafkaAdminClientServiceTest {
@@ -60,6 +62,9 @@ public class KafkaAdminClientServiceTest {
 
         testContext.assertEquals(1, createTopicsCaptor.getAllValues().size());
         testContext.assertEquals(allTopics.size(), createTopicsCaptor.getAllValues().get(0).size());
+        testContext.assertEquals("inventory.instance", createTopicsCaptor.getAllValues().get(0).get(0).getName());
+        testContext.assertEquals("inventory.item", createTopicsCaptor.getAllValues().get(0).get(1).getName());
+        testContext.assertEquals("inventory.holdings-record", createTopicsCaptor.getAllValues().get(0).get(2).getName());
       }));
   }
 

--- a/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,8 +27,8 @@ import io.vertx.kafka.admin.NewTopic;
 
 @RunWith(VertxUnitRunner.class)
 public class KafkaAdminClientServiceTest {
-  private final Set<String> allTopics = Stream.of(KafkaTopic.values())
-    .map(KafkaTopic::getTopicName).collect(Collectors.toSet());
+  private final Set<String> allTopics = Set.of("inventory.instance",
+    "inventory.holdings-record", "inventory.item");
 
   @Test
   public void shouldNotCreateTopicIfAlreadyExist(TestContext testContext) {
@@ -63,8 +62,7 @@ public class KafkaAdminClientServiceTest {
         verify(mockClient, times(1)).close();
 
         // Only these items are expected, so implicitly checks size of list
-        assertThat(getTopicNames(createTopicsCaptor), containsInAnyOrder(
-          "inventory.instance", "inventory.holdings-record", "inventory.item"));
+        assertThat(getTopicNames(createTopicsCaptor), containsInAnyOrder(allTopics.toArray()));
       }));
   }
 

--- a/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -27,8 +27,8 @@ import io.vertx.kafka.admin.NewTopic;
 
 @RunWith(VertxUnitRunner.class)
 public class KafkaAdminClientServiceTest {
-  private final Set<String> allTopics = Set.of("inventory.instance",
-    "inventory.holdings-record", "inventory.item");
+  private final Set<String> allTopics = Set.of("folio.inventory.instance",
+    "folio.inventory.holdings-record", "folio.inventory.item");
 
   @Test
   public void shouldNotCreateTopicIfAlreadyExist(TestContext testContext) {

--- a/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -34,6 +34,7 @@ public class KafkaAdminClientServiceTest {
     when(mockClient.close()).thenReturn(succeededFuture());
 
     createKafkaTopicsAsync(mockClient)
+      .onFailure(testContext::fail)
       .onComplete(testContext.asyncAssertSuccess(notUsed -> {
         verify(mockClient, times(0)).createTopics(anyList());
         verify(mockClient, times(1)).close();
@@ -48,7 +49,9 @@ public class KafkaAdminClientServiceTest {
     when(mockClient.close()).thenReturn(succeededFuture());
 
     createKafkaTopicsAsync(mockClient)
+      .onFailure(testContext::fail)
       .onComplete(testContext.asyncAssertSuccess(notUsed -> {
+
         @SuppressWarnings("unchecked")
         final ArgumentCaptor<List<NewTopic>> createTopicsCaptor = forClass(List.class);
 

--- a/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -2,6 +2,7 @@ package org.folio.services.kafka.topic;
 
 import static io.vertx.core.Future.succeededFuture;
 import static java.util.Set.of;
+import static org.folio.Environment.environmentName;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.ArgumentCaptor.forClass;
@@ -27,7 +28,6 @@ import io.vertx.kafka.admin.NewTopic;
 
 @RunWith(VertxUnitRunner.class)
 public class KafkaAdminClientServiceTest {
-  private final String TENANT_ID = "foo-tenant";
   private final Set<String> allExpectedTopics = Set.of("folio.foo-tenant.inventory.instance",
     "folio.foo-tenant.inventory.holdings-record", "folio.foo-tenant.inventory.item");
 
@@ -40,7 +40,7 @@ public class KafkaAdminClientServiceTest {
     when(mockClient.createTopics(anyList())).thenReturn(succeededFuture());
     when(mockClient.close()).thenReturn(succeededFuture());
 
-    createKafkaTopicsAsync(TENANT_ID, mockClient)
+    createKafkaTopicsAsync(mockClient)
       .onFailure(testContext::fail)
       .onComplete(testContext.asyncAssertSuccess(notUsed -> {
         verify(mockClient, times(0)).createTopics(anyList());
@@ -55,7 +55,7 @@ public class KafkaAdminClientServiceTest {
     when(mockClient.createTopics(anyList())).thenReturn(succeededFuture());
     when(mockClient.close()).thenReturn(succeededFuture());
 
-    createKafkaTopicsAsync(TENANT_ID, mockClient)
+    createKafkaTopicsAsync(mockClient)
       .onFailure(testContext::fail)
       .onComplete(testContext.asyncAssertSuccess(notUsed -> {
 
@@ -76,7 +76,8 @@ public class KafkaAdminClientServiceTest {
       .collect(Collectors.toList());
   }
 
-  private Future<Void> createKafkaTopicsAsync(String tenant, KafkaAdminClient client) {
-    return new KafkaAdminClientService(() -> client).createKafkaTopics(tenant);
+  private Future<Void> createKafkaTopicsAsync(KafkaAdminClient client) {
+    return new KafkaAdminClientService(() -> client)
+      .createKafkaTopics("foo-tenant", environmentName());
   }
 }

--- a/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -34,6 +34,9 @@ public class KafkaAdminClientServiceTest {
   public void shouldNotCreateTopicIfAlreadyExist(TestContext testContext) {
     final KafkaAdminClient mockClient = mock(KafkaAdminClient.class);
     when(mockClient.listTopics()).thenReturn(succeededFuture(allTopics));
+    // Still mock this even though no invocations are expected
+    // in order to make diagnosis of failures easier
+    when(mockClient.createTopics(anyList())).thenReturn(succeededFuture());
     when(mockClient.close()).thenReturn(succeededFuture());
 
     createKafkaTopicsAsync(mockClient)


### PR DESCRIPTION
## Purpose

Publish all inventory messages to different topics, whose name starts with the environment, then the tenant ID e.g. `test.foo_tenant.inventory.instance`

None of the existing topics have been removed, as I wasn't sure about the requirements or the impact on pre-existing consumers.

This change is **implementation compatibility breaking** and needs to be deployed together with changes to consuming modules.

## Approach
Usually, I prefer to refactor the code to make the change easier before making a change. Given the urgency of this change, the need to back port it and my lack of familiarity with the code, I chose to try to make the least amount of changes.

There are changes to the tests in order to be able to change the topic names in them independently of the production code. I find this useful for checking that test fail in the expected way before making the production code change.

More information can be found in some of the commit messages.

I may issue a follow up pull request to this with further refactoring of this code, after these changes have been tested, back ported and released.