### PR TITLE
MODINVSTOR-719: Add indexTitle, alternativeTitles, series to keyword search index

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,9 @@
-## 21.0.0 2021-06-10
+## 21.1.0 IN-PROGRESS
 
 * Keyword searches now search alternate title fields (MODINVSTOR-719)
+
+## 21.0.0 2021-06-10
+
 * Introduces `publication period` for `instances` (MODINVSTOR-723)
 * Determines `publication year` based upon `publication period` (MODINVSTOR-724)
 * Introduces `bound with parts` record type (MODINVSTOR-702)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 21.0.0 2021-06-10
 
+* Keyword searches now search alternate title fields (MODINVSTOR-719)
 * Introduces `publication period` for `instances` (MODINVSTOR-723)
 * Determines `publication year` based upon `publication period` (MODINVSTOR-724)
 * Introduces `bound with parts` record type (MODINVSTOR-702)

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -463,7 +463,7 @@
         },
         {
           "fieldName": "keyword",
-          "multiFieldNames": "title,contributors[*].name,identifiers[*].value"
+          "multiFieldNames": "title,indexTitle,alternativeTitles[*].alternativeTitle,series,contributors[*].name,identifiers[*].value"
         },
         {
           "fieldName": "allTitles",

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -577,6 +577,42 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  public void canSearchAlternateTitlesUsingKeywordIndexAll()
+    throws MalformedURLException,
+    InterruptedException,
+    ExecutionException,
+    TimeoutException {
+
+    UUID firstInstanceId = UUID.randomUUID();
+    UUID alternativeTitleId = UUID.randomUUID();
+
+    JsonObject instanceToCreate = smallAngryPlanet(firstInstanceId);
+    JsonObject alternativeTitles = new JsonObject();
+    
+    alternativeTitles.put("alternativeTitleTypeId", alternativeTitleId);
+    alternativeTitles.put("alternativeTitle", "xyza");
+
+    JsonArray altTitlesArray = new JsonArray("[" + alternativeTitles.toString() + "]");
+    
+    instanceToCreate.put("alternativeTitles", altTitlesArray);
+
+    createInstance(instanceToCreate);
+
+    CompletableFuture<Response> getCompleted = new CompletableFuture<>();
+
+    client.get(instancesStorageUrl("?query=keyword%20all%20%22xyza%22"), StorageTestSuite.TENANT_ID,
+        ResponseHandler.json(getCompleted));
+
+    Response response = getCompleted.get(5, TimeUnit.SECONDS);
+
+    JsonObject responseBody = response.getJson();
+
+    JsonArray allInstances = responseBody.getJsonArray("instances");
+
+    assertThat(allInstances.size(), is(1));
+  }
+
+  @Test
   public void canSearchUsingDateOfPublication() throws Exception {
 
     JsonObject instance1 = smallAngryPlanet(null)

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -577,7 +577,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canSearchAlternateTitlesUsingKeywordIndexAll()
+  public void canSearchForAlternateTitlesUsingKeywordIndexAll()
     throws MalformedURLException,
     InterruptedException,
     ExecutionException,


### PR DESCRIPTION
I made the modifications to the index outlined in the jira issue.

I then wrote a test for the new search behavior.

I believe this is supposed to be backported, so I added
The change under the last release in the NEWS file.
Once this is approved, I'll hotfix and backport.