### PR TITLE
Use environment and tenant in topic names MODINVSTOR-744

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -2392,6 +2392,7 @@
       { "name": "JAVA_OPTIONS",
         "value": "-XX:MaxRAMPercentage=66.0"
       },
+      { "name": "ENV", "value": "folio" },
       { "name": "DB_HOST", "value": "postgres" },
       { "name": "DB_PORT", "value": "5432" },
       { "name": "DB_USERNAME", "value": "folio_admin" },

--- a/src/main/java/org/folio/Environment.java
+++ b/src/main/java/org/folio/Environment.java
@@ -1,0 +1,9 @@
+package org.folio;
+
+public class Environment {
+  private Environment() { }
+
+  public static String environmentName() {
+    return System.getenv().getOrDefault("ENV", "folio");
+  }
+}

--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -91,7 +91,7 @@ public class TenantRefAPI extends TenantAPI {
     // create topics before loading data
     return
       new KafkaAdminClientService(vertxContext.owner())
-        .createKafkaTopics(environmentName())
+        .createKafkaTopics(environmentName(), tenantId)
         .compose(x ->super.loadData(attributes, tenantId, headers, vertxContext))
         .compose(superRecordsLoaded -> {
           try {

--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -1,18 +1,6 @@
 package org.folio.rest.impl;
 
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import java.util.stream.Collectors;
-import org.apache.commons.io.IOUtils;
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-import org.folio.okapi.common.GenericCompositeFuture;
-import org.folio.rest.annotations.Validate;
-import org.folio.rest.jaxrs.model.TenantAttributes;
-import org.folio.rest.tools.utils.TenantLoading;
-import org.folio.services.kafka.topic.KafkaAdminClientService;
+import static org.folio.Environment.environmentName;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -22,8 +10,23 @@ import java.nio.charset.StandardCharsets;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.folio.okapi.common.GenericCompositeFuture;
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.TenantAttributes;
+import org.folio.rest.tools.utils.TenantLoading;
+import org.folio.services.kafka.topic.KafkaAdminClientService;
 import org.folio.services.migration.BaseMigrationService;
 import org.folio.services.migration.item.ItemShelvingOrderMigrationService;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 public class TenantRefAPI extends TenantAPI {
 
@@ -88,7 +91,7 @@ public class TenantRefAPI extends TenantAPI {
     // create topics before loading data
     return
       new KafkaAdminClientService(vertxContext.owner())
-        .createKafkaTopics()
+        .createKafkaTopics(environmentName())
         .compose(x ->super.loadData(attributes, tenantId, headers, vertxContext))
         .compose(superRecordsLoaded -> {
           try {

--- a/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
@@ -12,19 +12,21 @@ import static org.folio.services.domainevent.DomainEvent.deleteEvent;
 import static org.folio.services.domainevent.DomainEvent.updateEvent;
 import static org.folio.services.kafka.KafkaProducerServiceFactory.getKafkaProducerService;
 
-import io.vertx.core.Context;
-import io.vertx.core.Future;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.Logger;
 import org.folio.services.kafka.KafkaMessage;
 import org.folio.services.kafka.topic.KafkaTopic;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
 
 public class CommonDomainEventPublisher<T> {
   private static final Set<String> FORWARDER_HEADERS = Set.of(URL.toLowerCase(),
@@ -101,7 +103,7 @@ public class CommonDomainEventPublisher<T> {
 
     var kafkaMessage = KafkaMessage.builder()
       .key(instanceId).payload(domainEvent)
-      .topic(kafkaTopic)
+      .topicName(kafkaTopic.getTopicName())
       .headers(headersToForward);
 
     additionalHeaders.forEach(kafkaMessage::header);

--- a/src/main/java/org/folio/services/domainevent/HoldingDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/HoldingDomainEventPublisher.java
@@ -2,6 +2,7 @@ package org.folio.services.domainevent;
 
 import static io.vertx.core.Future.succeededFuture;
 import static org.folio.Environment.environmentName;
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
 
 import java.util.Collection;
 import java.util.List;
@@ -25,7 +26,7 @@ public class HoldingDomainEventPublisher extends AbstractDomainEventPublisher<Ho
   public HoldingDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     super(new HoldingsRepository(context, okapiHeaders),
     new CommonDomainEventPublisher<>(context, okapiHeaders,
-      KafkaTopic.holdingsRecord(environmentName())));
+      KafkaTopic.holdingsRecord(environmentName(), tenantId(okapiHeaders))));
   }
 
   @Override

--- a/src/main/java/org/folio/services/domainevent/HoldingDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/HoldingDomainEventPublisher.java
@@ -1,6 +1,7 @@
 package org.folio.services.domainevent;
 
 import static io.vertx.core.Future.succeededFuture;
+import static org.folio.Environment.environmentName;
 
 import java.util.Collection;
 import java.util.List;
@@ -23,7 +24,8 @@ public class HoldingDomainEventPublisher extends AbstractDomainEventPublisher<Ho
 
   public HoldingDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     super(new HoldingsRepository(context, okapiHeaders),
-    new CommonDomainEventPublisher<>(context, okapiHeaders, KafkaTopic.holdingsRecord()));
+    new CommonDomainEventPublisher<>(context, okapiHeaders,
+      KafkaTopic.holdingsRecord(environmentName())));
   }
 
   @Override

--- a/src/main/java/org/folio/services/domainevent/HoldingDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/HoldingDomainEventPublisher.java
@@ -1,7 +1,6 @@
 package org.folio.services.domainevent;
 
 import static io.vertx.core.Future.succeededFuture;
-import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_HOLDINGS_RECORD;
 
 import java.util.Collection;
 import java.util.List;
@@ -14,6 +13,7 @@ import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.folio.persist.HoldingsRepository;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
+import org.folio.services.kafka.topic.KafkaTopic;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -23,7 +23,7 @@ public class HoldingDomainEventPublisher extends AbstractDomainEventPublisher<Ho
 
   public HoldingDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     super(new HoldingsRepository(context, okapiHeaders),
-    new CommonDomainEventPublisher<>(context, okapiHeaders, INVENTORY_HOLDINGS_RECORD));
+    new CommonDomainEventPublisher<>(context, okapiHeaders, KafkaTopic.holdingsRecord()));
   }
 
   @Override

--- a/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
@@ -2,6 +2,7 @@ package org.folio.services.domainevent;
 
 import static io.vertx.core.Future.succeededFuture;
 import static org.apache.logging.log4j.LogManager.getLogger;
+import static org.folio.Environment.environmentName;
 import static org.folio.rest.support.ResponseUtil.isCreateSuccessResponse;
 import static org.folio.services.domainevent.DomainEvent.reindexEvent;
 
@@ -36,7 +37,7 @@ public class InstanceDomainEventPublisher {
   public InstanceDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     instanceRepository = new InstanceRepository(context, okapiHeaders);
     domainEventService = new CommonDomainEventPublisher<>(context, okapiHeaders,
-      KafkaTopic.instance());
+      KafkaTopic.instance(environmentName()));
   }
 
   public Future<Void> publishInstanceUpdated(Instance oldRecord, Instance newRecord) {

--- a/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
@@ -4,7 +4,6 @@ import static io.vertx.core.Future.succeededFuture;
 import static org.apache.logging.log4j.LogManager.getLogger;
 import static org.folio.rest.support.ResponseUtil.isCreateSuccessResponse;
 import static org.folio.services.domainevent.DomainEvent.reindexEvent;
-import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_INSTANCE;
 
 import java.util.Collection;
 import java.util.List;
@@ -22,6 +21,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.persist.InstanceRepository;
 import org.folio.rest.jaxrs.model.Instance;
 import org.folio.services.batch.BatchOperationContext;
+import org.folio.services.kafka.topic.KafkaTopic;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -36,7 +36,7 @@ public class InstanceDomainEventPublisher {
   public InstanceDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     instanceRepository = new InstanceRepository(context, okapiHeaders);
     domainEventService = new CommonDomainEventPublisher<>(context, okapiHeaders,
-      INVENTORY_INSTANCE);
+      KafkaTopic.instance());
   }
 
   public Future<Void> publishInstanceUpdated(Instance oldRecord, Instance newRecord) {

--- a/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
@@ -4,6 +4,7 @@ import static io.vertx.core.Future.succeededFuture;
 import static org.apache.logging.log4j.LogManager.getLogger;
 import static org.folio.Environment.environmentName;
 import static org.folio.rest.support.ResponseUtil.isCreateSuccessResponse;
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
 import static org.folio.services.domainevent.DomainEvent.reindexEvent;
 
 import java.util.Collection;
@@ -37,7 +38,7 @@ public class InstanceDomainEventPublisher {
   public InstanceDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     instanceRepository = new InstanceRepository(context, okapiHeaders);
     domainEventService = new CommonDomainEventPublisher<>(context, okapiHeaders,
-      KafkaTopic.instance(environmentName()));
+      KafkaTopic.instance(environmentName(), tenantId(okapiHeaders)));
   }
 
   public Future<Void> publishInstanceUpdated(Instance oldRecord, Instance newRecord) {

--- a/src/main/java/org/folio/services/domainevent/ItemDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/ItemDomainEventPublisher.java
@@ -2,6 +2,7 @@ package org.folio.services.domainevent;
 
 import static io.vertx.core.Future.succeededFuture;
 import static org.apache.logging.log4j.LogManager.getLogger;
+import static org.folio.Environment.environmentName;
 
 import java.util.Collection;
 import java.util.List;
@@ -31,7 +32,9 @@ public class ItemDomainEventPublisher extends AbstractDomainEventPublisher<Item,
 
   public ItemDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     super(new ItemRepository(context, okapiHeaders),
-      new CommonDomainEventPublisher<>(context, okapiHeaders, KafkaTopic.item()));
+      new CommonDomainEventPublisher<>(context, okapiHeaders,
+        KafkaTopic.item(environmentName())));
+
     holdingsRepository = new HoldingsRepository(context, okapiHeaders);
   }
 

--- a/src/main/java/org/folio/services/domainevent/ItemDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/ItemDomainEventPublisher.java
@@ -3,6 +3,7 @@ package org.folio.services.domainevent;
 import static io.vertx.core.Future.succeededFuture;
 import static org.apache.logging.log4j.LogManager.getLogger;
 import static org.folio.Environment.environmentName;
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
 
 import java.util.Collection;
 import java.util.List;
@@ -33,7 +34,7 @@ public class ItemDomainEventPublisher extends AbstractDomainEventPublisher<Item,
   public ItemDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     super(new ItemRepository(context, okapiHeaders),
       new CommonDomainEventPublisher<>(context, okapiHeaders,
-        KafkaTopic.item(environmentName())));
+        KafkaTopic.item(environmentName(), tenantId(okapiHeaders))));
 
     holdingsRepository = new HoldingsRepository(context, okapiHeaders);
   }

--- a/src/main/java/org/folio/services/domainevent/ItemDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/ItemDomainEventPublisher.java
@@ -2,7 +2,6 @@ package org.folio.services.domainevent;
 
 import static io.vertx.core.Future.succeededFuture;
 import static org.apache.logging.log4j.LogManager.getLogger;
-import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_ITEM;
 
 import java.util.Collection;
 import java.util.List;
@@ -20,6 +19,7 @@ import org.folio.persist.HoldingsRepository;
 import org.folio.persist.ItemRepository;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
+import org.folio.services.kafka.topic.KafkaTopic;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
@@ -31,7 +31,7 @@ public class ItemDomainEventPublisher extends AbstractDomainEventPublisher<Item,
 
   public ItemDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
     super(new ItemRepository(context, okapiHeaders),
-      new CommonDomainEventPublisher<>(context, okapiHeaders, INVENTORY_ITEM));
+      new CommonDomainEventPublisher<>(context, okapiHeaders, KafkaTopic.item()));
     holdingsRepository = new HoldingsRepository(context, okapiHeaders);
   }
 

--- a/src/main/java/org/folio/services/kafka/KafkaMessage.java
+++ b/src/main/java/org/folio/services/kafka/KafkaMessage.java
@@ -10,14 +10,11 @@ public final class KafkaMessage<T> {
   private final T payload;
   private final String key;
   private final String topicName;
-  private final KafkaTopic topic;
   private final Map<String, String> headers;
 
-  private KafkaMessage(T payload, String key, KafkaTopic topic,
-    String topicName, Map<String, String> headers) {
+  private KafkaMessage(T payload, String key, String topicName, Map<String, String> headers) {
     this.payload = payload;
     this.key = key;
-    this.topic = topic;
     this.topicName = topicName;
     this.headers = unmodifiableMap(headers);
   }
@@ -34,10 +31,6 @@ public final class KafkaMessage<T> {
     return this.key;
   }
 
-  public KafkaTopic getTopic() {
-    return this.topic;
-  }
-
   public String getTopicName() {
     return topicName;
   }
@@ -49,7 +42,6 @@ public final class KafkaMessage<T> {
   public static class KafkaMessageBuilder<T> {
     private T payload;
     private String key;
-    private KafkaTopic topic;
     private String topicName;
     private final Map<String, String> headers = new HashMap<>();
 
@@ -63,8 +55,12 @@ public final class KafkaMessage<T> {
       return this;
     }
 
+    public KafkaMessageBuilder<T> topicName(String topicName) {
+      this.topicName = topicName;
+      return this;
+    }
+
     public KafkaMessageBuilder<T> topic(KafkaTopic topic) {
-      this.topic = topic;
       this.topicName = topic.getTopicName();
       return this;
     }
@@ -80,7 +76,7 @@ public final class KafkaMessage<T> {
     }
 
     public KafkaMessage<T> build() {
-      return new KafkaMessage<>(payload, key, topic, topicName,
+      return new KafkaMessage<>(payload, key, topicName,
         headers
       );
     }

--- a/src/main/java/org/folio/services/kafka/KafkaMessage.java
+++ b/src/main/java/org/folio/services/kafka/KafkaMessage.java
@@ -9,13 +9,16 @@ import org.folio.services.kafka.topic.KafkaTopic;
 public final class KafkaMessage<T> {
   private final T payload;
   private final String key;
+  private final String topicName;
   private final KafkaTopic topic;
   private final Map<String, String> headers;
 
-  private KafkaMessage(T payload, String key, KafkaTopic topic, Map<String, String> headers) {
+  private KafkaMessage(T payload, String key, KafkaTopic topic,
+    String topicName, Map<String, String> headers) {
     this.payload = payload;
     this.key = key;
     this.topic = topic;
+    this.topicName = topicName;
     this.headers = unmodifiableMap(headers);
   }
 
@@ -35,6 +38,10 @@ public final class KafkaMessage<T> {
     return this.topic;
   }
 
+  public String getTopicName() {
+    return topicName;
+  }
+
   public Map<String, String> getHeaders() {
     return this.headers;
   }
@@ -43,6 +50,7 @@ public final class KafkaMessage<T> {
     private T payload;
     private String key;
     private KafkaTopic topic;
+    private String topicName;
     private final Map<String, String> headers = new HashMap<>();
 
     public KafkaMessageBuilder<T> payload(T payload) {
@@ -57,6 +65,7 @@ public final class KafkaMessage<T> {
 
     public KafkaMessageBuilder<T> topic(KafkaTopic topic) {
       this.topic = topic;
+      this.topicName = topic.getTopicName();
       return this;
     }
 
@@ -71,7 +80,9 @@ public final class KafkaMessage<T> {
     }
 
     public KafkaMessage<T> build() {
-      return new KafkaMessage<>(payload, key, topic, headers);
+      return new KafkaMessage<>(payload, key, topic, topicName,
+        headers
+      );
     }
   }
 }

--- a/src/main/java/org/folio/services/kafka/KafkaProducerService.java
+++ b/src/main/java/org/folio/services/kafka/KafkaProducerService.java
@@ -5,12 +5,14 @@ import static io.vertx.core.Promise.promise;
 import static io.vertx.kafka.client.producer.KafkaProducerRecord.create;
 import static org.folio.dbschema.ObjectMapperTool.getMapper;
 
+import java.util.Map;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
+
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.kafka.client.producer.KafkaProducer;
 import io.vertx.kafka.client.producer.RecordMetadata;
-import java.util.Map;
 
 public class KafkaProducerService {
   private final KafkaProducer<String, String> kafkaProducer;
@@ -25,7 +27,7 @@ public class KafkaProducerService {
   public Future<Void> sendMessage(KafkaMessage<?> message) {
     try {
       final String payload = getMapper().writeValueAsString(message.getPayload());
-      return sendMessageInternal(message.getTopic().getTopicName(),
+      return sendMessageInternal(message.getTopicName(),
         message.getKey(), payload, message.getHeaders());
     } catch (JsonProcessingException ex) {
       return failedFuture(new IllegalArgumentException("Unable to deserialize message", ex));

--- a/src/main/java/org/folio/services/kafka/topic/KafkaAdminClientService.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaAdminClientService.java
@@ -34,9 +34,9 @@ public class KafkaAdminClientService {
     this.clientFactory = clientFactory;
   }
 
-  public Future<Void> createKafkaTopics(String environmentName) {
+  public Future<Void> createKafkaTopics(String environmentName, String tenantId) {
     final KafkaAdminClient kafkaAdminClient = clientFactory.get();
-    return createKafkaTopics(kafkaAdminClient, environmentName).onComplete(result -> {
+    return createKafkaTopics(kafkaAdminClient, environmentName, tenantId).onComplete(result -> {
       if (result.succeeded()) {
         log.info("Topics created successfully");
       } else {
@@ -52,10 +52,10 @@ public class KafkaAdminClientService {
   }
 
   private Future<Void> createKafkaTopics(KafkaAdminClient kafkaAdminClient,
-    String environmentName) {
+    String environmentName, String tenantId) {
 
     final var expectedTopics = readTopics()
-      .map(expectedTopic -> qualifyName(expectedTopic, environmentName))
+      .map(expectedTopic -> qualifyName(expectedTopic, environmentName, tenantId))
       .collect(Collectors.toList());
 
     return kafkaAdminClient.listTopics().compose(existingTopics -> {
@@ -74,8 +74,8 @@ public class KafkaAdminClientService {
     });
   }
 
-  private NewTopic qualifyName(NewTopic topic, String environmentName) {
-    return topic.setName(String.join(".", environmentName, topic.getName()));
+  private NewTopic qualifyName(NewTopic topic, String environmentName, String tenantId) {
+    return topic.setName(String.join(".", environmentName, tenantId, topic.getName()));
   }
 
   private Stream<NewTopic> readTopics() {

--- a/src/main/java/org/folio/services/kafka/topic/KafkaAdminClientService.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaAdminClientService.java
@@ -51,11 +51,11 @@ public class KafkaAdminClientService {
   }
 
   private Future<Void> createKafkaTopics(KafkaAdminClient kafkaAdminClient) {
-    final List<NewTopic> newTopics = readTopics();
+    final List<NewTopic> expectedTopics = readTopics();
 
-    return kafkaAdminClient.listTopics().compose(topics -> {
-      final List<NewTopic> topicsToCreate = newTopics.stream()
-        .filter(newTopic -> !topics.contains(newTopic.getName()))
+    return kafkaAdminClient.listTopics().compose(existingTopics -> {
+      final List<NewTopic> topicsToCreate = expectedTopics.stream()
+        .filter(newTopic -> !existingTopics.contains(newTopic.getName()))
         .map(newTopic -> newTopic.setReplicationFactor(getReplicationFactor()))
         .collect(Collectors.toList());
 

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -1,7 +1,5 @@
 package org.folio.services.kafka.topic;
 
-import java.util.stream.Stream;
-
 public enum KafkaTopic {
   INVENTORY_INSTANCE("inventory.instance"),
   INVENTORY_ITEM("inventory.item"),
@@ -15,12 +13,5 @@ public enum KafkaTopic {
 
   public String getTopicName() {
     return topicName;
-  }
-
-  public static KafkaTopic forName(String name) {
-    return Stream.of(values())
-      .filter(value -> value.getTopicName().equals(name))
-      .findFirst()
-      .orElse(null);
   }
 }

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -11,6 +11,10 @@ public enum KafkaTopic {
     return INVENTORY_INSTANCE;
   }
 
+  public static KafkaTopic holdingsRecord() {
+    return INVENTORY_HOLDINGS_RECORD;
+  }
+
   KafkaTopic(String topicName) {
     this.topicName = topicName;
   }

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -7,6 +7,10 @@ public enum KafkaTopic {
 
   private final String topicName;
 
+  public static KafkaTopic instance() {
+    return INVENTORY_INSTANCE;
+  }
+
   KafkaTopic(String topicName) {
     this.topicName = topicName;
   }

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -1,16 +1,16 @@
 package org.folio.services.kafka.topic;
 
 public class KafkaTopic {
-  public static KafkaTopic instance() {
-    return new KafkaTopic("inventory.instance");
+  public static KafkaTopic instance(String environmentName) {
+    return new KafkaTopic(qualifyName("inventory.instance", environmentName));
   }
 
-  public static KafkaTopic holdingsRecord() {
-    return new KafkaTopic("inventory.holdings-record");
+  public static KafkaTopic holdingsRecord(String environmentName) {
+    return new KafkaTopic(qualifyName("inventory.holdings-record", environmentName));
   }
 
-  public static KafkaTopic item() {
-    return new KafkaTopic("inventory.item");
+  public static KafkaTopic item(String environmentName) {
+    return new KafkaTopic(qualifyName("inventory.item", environmentName));
   }
 
   private final String topicName;
@@ -21,5 +21,9 @@ public class KafkaTopic {
 
   public String getTopicName() {
     return topicName;
+  }
+
+  private static String qualifyName(String name, String environmentName) {
+    return String.join(".", environmentName, name);
   }
 }

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -1,23 +1,19 @@
 package org.folio.services.kafka.topic;
 
-public enum KafkaTopic {
-  INVENTORY_INSTANCE("inventory.instance"),
-  INVENTORY_ITEM("inventory.item"),
-  INVENTORY_HOLDINGS_RECORD("inventory.holdings-record");
-
-  private final String topicName;
-
+public class KafkaTopic {
   public static KafkaTopic instance() {
-    return INVENTORY_INSTANCE;
+    return new KafkaTopic("inventory.instance");
   }
 
   public static KafkaTopic holdingsRecord() {
-    return INVENTORY_HOLDINGS_RECORD;
+    return new KafkaTopic("inventory.holdings-record");
   }
 
   public static KafkaTopic item() {
-    return INVENTORY_ITEM;
+    return new KafkaTopic("inventory.item");
   }
+
+  private final String topicName;
 
   KafkaTopic(String topicName) {
     this.topicName = topicName;

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -15,6 +15,10 @@ public enum KafkaTopic {
     return INVENTORY_HOLDINGS_RECORD;
   }
 
+  public static KafkaTopic item() {
+    return INVENTORY_ITEM;
+  }
+
   KafkaTopic(String topicName) {
     this.topicName = topicName;
   }

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -1,16 +1,16 @@
 package org.folio.services.kafka.topic;
 
 public class KafkaTopic {
-  public static KafkaTopic instance(String environmentName) {
-    return new KafkaTopic(qualifyName("inventory.instance", environmentName));
+  public static KafkaTopic instance(String environmentName, String tenantId) {
+    return new KafkaTopic(qualifyName("inventory.instance", environmentName, tenantId));
   }
 
-  public static KafkaTopic holdingsRecord(String environmentName) {
-    return new KafkaTopic(qualifyName("inventory.holdings-record", environmentName));
+  public static KafkaTopic holdingsRecord(String environmentName, String tenantId) {
+    return new KafkaTopic(qualifyName("inventory.holdings-record", environmentName, tenantId));
   }
 
-  public static KafkaTopic item(String environmentName) {
-    return new KafkaTopic(qualifyName("inventory.item", environmentName));
+  public static KafkaTopic item(String environmentName, String tenantId) {
+    return new KafkaTopic(qualifyName("inventory.item", environmentName, tenantId));
   }
 
   private final String topicName;
@@ -23,7 +23,7 @@ public class KafkaTopic {
     return topicName;
   }
 
-  private static String qualifyName(String name, String environmentName) {
-    return String.join(".", environmentName, name);
+  private static String qualifyName(String name, String environmentName, String tenantId) {
+    return String.join(".", environmentName, tenantId, name);
   }
 }

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -55,7 +55,6 @@ import java.net.URL;
 import java.time.Instant;
 import java.util.Date;
 import java.util.List;
-
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -81,7 +80,6 @@ import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.builders.ItemRequestBuilder;
 import org.folio.rest.support.matchers.DomainEventAssertions;
-import org.folio.services.CallNumberUtils;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.After;
@@ -197,7 +195,6 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(itemFromPost.getString("effectiveShelvingOrder"), is(desiredShelvingOrder));
   }
-
 
   @Test
   public void canCreateAnItemViaCollectionResource()

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -32,9 +32,9 @@ public final class FakeKafkaConsumer {
     // These definitions are deliberately separate to the production definitions
     // This is so these can be changed independently to demonstrate
     // tests failing for the right reason prior to changing the production code
-    final var INSTANCE_TOPIC_NAME = "folio.inventory.instance";
-    final var HOLDINGS_TOPIC_NAME = "folio.inventory.holdings-record";
-    final var ITEM_TOPIC_NAME = "folio.inventory.item";
+    final var INSTANCE_TOPIC_NAME = "folio.test_tenant.inventory.instance";
+    final var HOLDINGS_TOPIC_NAME = "folio.test_tenant.inventory.holdings-record";
+    final var ITEM_TOPIC_NAME = "folio.test_tenant.inventory.item";
 
     consumer.subscribe(Set.of(INSTANCE_TOPIC_NAME, HOLDINGS_TOPIC_NAME, ITEM_TOPIC_NAME));
 

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -14,7 +14,6 @@ import java.util.stream.Collectors;
 
 import org.folio.services.kafka.KafkaMessage;
 import org.folio.services.kafka.KafkaProperties;
-import org.folio.services.kafka.topic.KafkaTopic;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -33,9 +32,9 @@ public final class FakeKafkaConsumer {
     // These definitions are deliberately separate to the production definitions
     // This is so these can be changed independently to demonstrate
     // tests failing for the right reason prior to changing the production code
-    final var INSTANCE_TOPIC_NAME = "inventory.instance";
-    final var HOLDINGS_TOPIC_NAME = "inventory.holdings-record";
-    final var ITEM_TOPIC_NAME = "inventory.item";
+    final var INSTANCE_TOPIC_NAME = "folio.inventory.instance";
+    final var HOLDINGS_TOPIC_NAME = "folio.inventory.holdings-record";
+    final var ITEM_TOPIC_NAME = "folio.inventory.item";
 
     consumer.subscribe(Set.of(INSTANCE_TOPIC_NAME, HOLDINGS_TOPIC_NAME, ITEM_TOPIC_NAME));
 

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -43,7 +43,7 @@ public final class FakeKafkaConsumer {
       final KafkaMessage<JsonObject> kafkaMessage = kafkaRecordToKafkaMessage(message);
       final List<KafkaMessage<JsonObject>> storageList;
 
-      switch (kafkaMessage.getTopic()){
+      switch (kafkaMessage.getTopic()) {
         case INVENTORY_ITEM:
           storageList = itemEvents.computeIfAbsent(instanceAndIdKey(kafkaMessage),
             k -> new ArrayList<>());

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -23,16 +23,19 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertEquals;
 
-import io.vertx.core.MultiMap;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
 import org.folio.services.kafka.KafkaMessage;
+
+import io.vertx.core.MultiMap;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 
 public final class DomainEventAssertions {
   private DomainEventAssertions() {}
@@ -85,7 +88,7 @@ public final class DomainEventAssertions {
 
   public static void assertNoUpdateEvent(String instanceId) {
     await().atLeast(1, SECONDS);
-    await().until(() -> getInstanceEvents(instanceId).size() > 0);
+    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
 
     final JsonObject updateMessage  = getLastInstanceEvent(instanceId).getPayload();
     assertThat(updateMessage.getString("type"), not(is("UPDATE")));
@@ -93,7 +96,7 @@ public final class DomainEventAssertions {
 
   public static void assertNoUpdateEventForHolding(String instanceId, String hrId) {
     await().atLeast(1, SECONDS);
-    await().until(() -> getHoldingsEvents(instanceId, hrId).size() > 0);
+    await().until(() -> getHoldingsEvents(instanceId, hrId).size(), greaterThan(0));
 
     final JsonObject updateMessage  = getLastHoldingEvent(instanceId, hrId).getPayload();
     assertThat(updateMessage.getString("type"), not(is("UPDATE")));
@@ -101,7 +104,7 @@ public final class DomainEventAssertions {
 
   public static void assertNoRemoveEvent(String instanceId) {
     await().atLeast(1, SECONDS);
-    await().until(() -> getInstanceEvents(instanceId).size() > 0);
+    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
 
     final JsonObject updateMessage  = getLastInstanceEvent(instanceId).getPayload();
     assertThat(updateMessage.getString("type"), not(is("DELETE")));
@@ -116,7 +119,7 @@ public final class DomainEventAssertions {
   public static void assertCreateEventForInstance(JsonObject instance) {
     final String instanceId = instance.getString("id");
 
-    await().until(() -> getInstanceEvents(instanceId).size() > 0);
+    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
 
     assertCreateEvent(getFirstInstanceEvent(instanceId), instance);
   }
@@ -137,13 +140,13 @@ public final class DomainEventAssertions {
   public static void assertRemoveEventForInstance(JsonObject instance) {
     final String instanceId = instance.getString("id");
 
-    await().until(() -> getInstanceEvents(instanceId).size() > 1);
+    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(1));
 
     assertRemoveEvent(getLastInstanceEvent(instanceId), instance);
   }
 
   public static void assertRemoveAllEventForInstance() {
-    await().until(() -> getInstanceEvents(NULL_INSTANCE_ID).size() > 0);
+    await().until(() -> getInstanceEvents(NULL_INSTANCE_ID).size(), greaterThan(0));
 
     assertRemoveAllEvent(getLastInstanceEvent(NULL_INSTANCE_ID));
   }
@@ -151,7 +154,7 @@ public final class DomainEventAssertions {
   public static void assertUpdateEventForInstance(JsonObject oldInstance, JsonObject newInstance) {
     final String instanceId = oldInstance.getString("id");
 
-    await().until(() -> getInstanceEvents(instanceId).size() > 1);
+    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(1));
 
     assertUpdateEvent(getLastInstanceEvent(instanceId), oldInstance, newInstance);
   }
@@ -160,7 +163,7 @@ public final class DomainEventAssertions {
     final String itemId = item.getString("id");
     final String instanceIdForItem = getInstanceIdForItem(item);
 
-    await().until(() -> getItemEvents(instanceIdForItem, itemId).size() > 0);
+    await().until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(0));
 
     // Domain event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
@@ -173,7 +176,7 @@ public final class DomainEventAssertions {
     final String itemId = item.getString("id");
     final String instanceIdForItem = getInstanceIdForItem(item);
 
-    await().until(() -> getItemEvents(instanceIdForItem, itemId).size() > 1);
+    await().until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(1));
 
     // Domain event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
@@ -183,7 +186,7 @@ public final class DomainEventAssertions {
   }
 
   public static void assertRemoveAllEventForItem() {
-    await().until(() -> getItemEvents(NULL_INSTANCE_ID, null).size() > 0);
+    await().until(() -> getItemEvents(NULL_INSTANCE_ID, null).size(), greaterThan(0));
 
     assertRemoveAllEvent(getLastItemEvent(NULL_INSTANCE_ID, null));
   }
@@ -192,7 +195,7 @@ public final class DomainEventAssertions {
     final String itemId = newItem.getString("id");
     final String instanceIdForItem = getInstanceIdForItem(newItem);
 
-    await().until(() -> getItemEvents(instanceIdForItem, itemId).size() > 1);
+    await().until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(1));
 
     // Domain event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
@@ -206,7 +209,7 @@ public final class DomainEventAssertions {
     final String id = hr.getString("id");
     final String instanceId = hr.getString("instanceId");
 
-    await().until(() -> getHoldingsEvents(instanceId, id).size() > 0);
+    await().until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(0));
 
     assertCreateEvent(getFirstHoldingEvent(instanceId, id), hr);
   }
@@ -215,13 +218,13 @@ public final class DomainEventAssertions {
     final String id = hr.getString("id");
     final String instanceId = hr.getString("instanceId");
 
-    await().until(() -> getHoldingsEvents(instanceId, id).size() > 1);
+    await().until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(1));
 
     assertRemoveEvent(getLastHoldingEvent(instanceId, id), hr);
   }
 
   public static void assertRemoveAllEventForHolding() {
-    await().until(() -> getHoldingsEvents(NULL_INSTANCE_ID, null).size() > 0);
+    await().until(() -> getHoldingsEvents(NULL_INSTANCE_ID, null).size(), greaterThan(0));
 
     assertRemoveAllEvent(getLastHoldingEvent(NULL_INSTANCE_ID, null));
   }
@@ -230,7 +233,7 @@ public final class DomainEventAssertions {
     final String id = newHr.getString("id");
     final String instanceId = newHr.getString("instanceId");
 
-    await().until(() -> getHoldingsEvents(instanceId, id).size() > 1);
+    await().until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(1));
 
     assertUpdateEvent(getLastHoldingEvent(instanceId, id), oldHr, newHr);
   }

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -24,6 +24,7 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 
 import java.util.List;
@@ -41,6 +42,7 @@ public final class DomainEventAssertions {
   private DomainEventAssertions() { }
 
   private static void assertCreateEvent(KafkaMessage<JsonObject> createEvent, JsonObject newRecord) {
+    assertThat("Create event should be present", createEvent.getPayload(), is(notNullValue()));
     assertThat(createEvent.getPayload().getString("type"), is("CREATE"));
     assertThat(createEvent.getPayload().getString("tenant"), is(TENANT_ID));
     assertThat(createEvent.getPayload().getJsonObject("old"), nullValue());

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -38,7 +38,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 
 public final class DomainEventAssertions {
-  private DomainEventAssertions() {}
+  private DomainEventAssertions() { }
 
   private static void assertCreateEvent(KafkaMessage<JsonObject> createEvent, JsonObject newRecord) {
     assertThat(createEvent.getPayload().getString("type"), is("CREATE"));
@@ -88,7 +88,8 @@ public final class DomainEventAssertions {
 
   public static void assertNoUpdateEvent(String instanceId) {
     await().atLeast(1, SECONDS);
-    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
 
     final JsonObject updateMessage  = getLastInstanceEvent(instanceId).getPayload();
     assertThat(updateMessage.getString("type"), not(is("UPDATE")));
@@ -96,7 +97,8 @@ public final class DomainEventAssertions {
 
   public static void assertNoUpdateEventForHolding(String instanceId, String hrId) {
     await().atLeast(1, SECONDS);
-    await().until(() -> getHoldingsEvents(instanceId, hrId).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getHoldingsEvents(instanceId, hrId).size(), greaterThan(0));
 
     final JsonObject updateMessage  = getLastHoldingEvent(instanceId, hrId).getPayload();
     assertThat(updateMessage.getString("type"), not(is("UPDATE")));
@@ -104,7 +106,8 @@ public final class DomainEventAssertions {
 
   public static void assertNoRemoveEvent(String instanceId) {
     await().atLeast(1, SECONDS);
-    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
 
     final JsonObject updateMessage  = getLastInstanceEvent(instanceId).getPayload();
     assertThat(updateMessage.getString("type"), not(is("DELETE")));
@@ -119,7 +122,8 @@ public final class DomainEventAssertions {
   public static void assertCreateEventForInstance(JsonObject instance) {
     final String instanceId = instance.getString("id");
 
-    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
 
     assertCreateEvent(getFirstInstanceEvent(instanceId), instance);
   }
@@ -140,13 +144,15 @@ public final class DomainEventAssertions {
   public static void assertRemoveEventForInstance(JsonObject instance) {
     final String instanceId = instance.getString("id");
 
-    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(1));
+    await().atMost(1, SECONDS)
+      .until(() -> getInstanceEvents(instanceId).size(), greaterThan(1));
 
     assertRemoveEvent(getLastInstanceEvent(instanceId), instance);
   }
 
   public static void assertRemoveAllEventForInstance() {
-    await().until(() -> getInstanceEvents(NULL_INSTANCE_ID).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getInstanceEvents(NULL_INSTANCE_ID).size(), greaterThan(0));
 
     assertRemoveAllEvent(getLastInstanceEvent(NULL_INSTANCE_ID));
   }
@@ -154,7 +160,8 @@ public final class DomainEventAssertions {
   public static void assertUpdateEventForInstance(JsonObject oldInstance, JsonObject newInstance) {
     final String instanceId = oldInstance.getString("id");
 
-    await().until(() -> getInstanceEvents(instanceId).size(), greaterThan(1));
+    await().atMost(1, SECONDS)
+      .until(() -> getInstanceEvents(instanceId).size(), greaterThan(1));
 
     assertUpdateEvent(getLastInstanceEvent(instanceId), oldInstance, newInstance);
   }
@@ -163,7 +170,8 @@ public final class DomainEventAssertions {
     final String itemId = item.getString("id");
     final String instanceIdForItem = getInstanceIdForItem(item);
 
-    await().until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(0));
 
     // Domain event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
@@ -176,7 +184,8 @@ public final class DomainEventAssertions {
     final String itemId = item.getString("id");
     final String instanceIdForItem = getInstanceIdForItem(item);
 
-    await().until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(1));
+    await().atMost(1, SECONDS)
+      .until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(1));
 
     // Domain event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
@@ -186,7 +195,8 @@ public final class DomainEventAssertions {
   }
 
   public static void assertRemoveAllEventForItem() {
-    await().until(() -> getItemEvents(NULL_INSTANCE_ID, null).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getItemEvents(NULL_INSTANCE_ID, null).size(), greaterThan(0));
 
     assertRemoveAllEvent(getLastItemEvent(NULL_INSTANCE_ID, null));
   }
@@ -195,7 +205,8 @@ public final class DomainEventAssertions {
     final String itemId = newItem.getString("id");
     final String instanceIdForItem = getInstanceIdForItem(newItem);
 
-    await().until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(1));
+    await().atMost(1, SECONDS)
+      .until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(1));
 
     // Domain event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
@@ -209,7 +220,8 @@ public final class DomainEventAssertions {
     final String id = hr.getString("id");
     final String instanceId = hr.getString("instanceId");
 
-    await().until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(0));
 
     assertCreateEvent(getFirstHoldingEvent(instanceId, id), hr);
   }
@@ -218,13 +230,15 @@ public final class DomainEventAssertions {
     final String id = hr.getString("id");
     final String instanceId = hr.getString("instanceId");
 
-    await().until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(1));
+    await().atMost(1, SECONDS)
+      .until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(1));
 
     assertRemoveEvent(getLastHoldingEvent(instanceId, id), hr);
   }
 
   public static void assertRemoveAllEventForHolding() {
-    await().until(() -> getHoldingsEvents(NULL_INSTANCE_ID, null).size(), greaterThan(0));
+    await().atMost(1, SECONDS)
+      .until(() -> getHoldingsEvents(NULL_INSTANCE_ID, null).size(), greaterThan(0));
 
     assertRemoveAllEvent(getLastHoldingEvent(NULL_INSTANCE_ID, null));
   }
@@ -233,7 +247,8 @@ public final class DomainEventAssertions {
     final String id = newHr.getString("id");
     final String instanceId = newHr.getString("instanceId");
 
-    await().until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(1));
+    await().atMost(1, SECONDS)
+      .until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(1));
 
     assertUpdateEvent(getLastHoldingEvent(instanceId, id), oldHr, newHr);
   }

--- a/src/test/java/org/folio/services/kafka/KafkaProducerServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/KafkaProducerServiceTest.java
@@ -18,7 +18,7 @@ public class KafkaProducerServiceTest {
     final var producer = new KafkaProducerService(mock(KafkaProducer.class));
 
     final KafkaMessage<Object> message = KafkaMessage.builder()
-      .key("id").payload(new Object()).topic(INVENTORY_INSTANCE).build();
+      .key("id").payload(new Object()).topicName(INVENTORY_INSTANCE.getTopicName()).build();
 
     assertThrows("Unable to deserialize message", ExecutionException.class,
       () -> producer.sendMessage(message).toCompletionStage().toCompletableFuture()

--- a/src/test/java/org/folio/services/kafka/KafkaProducerServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/KafkaProducerServiceTest.java
@@ -1,12 +1,12 @@
 package org.folio.services.kafka;
 
-import static org.folio.services.kafka.topic.KafkaTopic.INVENTORY_INSTANCE;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.mock;
 
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import org.folio.services.kafka.topic.KafkaTopic;
 import org.junit.Test;
 
 import io.vertx.kafka.client.producer.KafkaProducer;
@@ -18,7 +18,7 @@ public class KafkaProducerServiceTest {
     final var producer = new KafkaProducerService(mock(KafkaProducer.class));
 
     final KafkaMessage<Object> message = KafkaMessage.builder()
-      .key("id").payload(new Object()).topicName(INVENTORY_INSTANCE.getTopicName()).build();
+      .key("id").payload(new Object()).topicName(KafkaTopic.instance().getTopicName()).build();
 
     assertThrows("Unable to deserialize message", ExecutionException.class,
       () -> producer.sendMessage(message).toCompletionStage().toCompletableFuture()

--- a/src/test/java/org/folio/services/kafka/KafkaProducerServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/KafkaProducerServiceTest.java
@@ -18,7 +18,7 @@ public class KafkaProducerServiceTest {
     final var producer = new KafkaProducerService(mock(KafkaProducer.class));
 
     final KafkaMessage<Object> message = KafkaMessage.builder()
-      .key("id").payload(new Object()).topicName(KafkaTopic.instance().getTopicName()).build();
+      .key("id").payload(new Object()).topicName(KafkaTopic.instance("folio").getTopicName()).build();
 
     assertThrows("Unable to deserialize message", ExecutionException.class,
       () -> producer.sendMessage(message).toCompletionStage().toCompletableFuture()

--- a/src/test/java/org/folio/services/kafka/KafkaProducerServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/KafkaProducerServiceTest.java
@@ -18,7 +18,8 @@ public class KafkaProducerServiceTest {
     final var producer = new KafkaProducerService(mock(KafkaProducer.class));
 
     final KafkaMessage<Object> message = KafkaMessage.builder()
-      .key("id").payload(new Object()).topicName(KafkaTopic.instance("folio").getTopicName()).build();
+      .key("id").payload(new Object()).topicName(
+        KafkaTopic.instance("folio", "foo-tenant").getTopicName()).build();
 
     assertThrows("Unable to deserialize message", ExecutionException.class,
       () -> producer.sendMessage(message).toCompletionStage().toCompletableFuture()

--- a/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -27,8 +27,8 @@ import io.vertx.kafka.admin.NewTopic;
 
 @RunWith(VertxUnitRunner.class)
 public class KafkaAdminClientServiceTest {
-  private final Set<String> allTopics = Set.of("inventory.instance",
-    "inventory.holdings-record", "inventory.item");
+  private final Set<String> allTopics = Set.of("folio.inventory.instance",
+    "folio.inventory.holdings-record", "folio.inventory.item");
 
   @Test
   public void shouldNotCreateTopicIfAlreadyExist(TestContext testContext) {
@@ -50,7 +50,7 @@ public class KafkaAdminClientServiceTest {
   @Test
   public void shouldCreateTopicIfNotExist(TestContext testContext) {
     final KafkaAdminClient mockClient = mock(KafkaAdminClient.class);
-    when(mockClient.listTopics()).thenReturn(succeededFuture(of("inventory.some-another-topic")));
+    when(mockClient.listTopics()).thenReturn(succeededFuture(of("folio.inventory.some-another-topic")));
     when(mockClient.createTopics(anyList())).thenReturn(succeededFuture());
     when(mockClient.close()).thenReturn(succeededFuture());
 
@@ -75,6 +75,6 @@ public class KafkaAdminClientServiceTest {
   }
 
   private Future<Void> createKafkaTopicsAsync(KafkaAdminClient mockClient) {
-    return new KafkaAdminClientService(() -> mockClient).createKafkaTopics();
+    return new KafkaAdminClientService(() -> mockClient).createKafkaTopics("folio");
   }
 }

--- a/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -27,8 +27,9 @@ import io.vertx.kafka.admin.NewTopic;
 
 @RunWith(VertxUnitRunner.class)
 public class KafkaAdminClientServiceTest {
-  private final Set<String> allTopics = Set.of("folio.inventory.instance",
-    "folio.inventory.holdings-record", "folio.inventory.item");
+  private final String TENANT_ID = "foo-tenant";
+  private final Set<String> allTopics = Set.of("folio.foo-tenant.inventory.instance",
+    "folio.foo-tenant.inventory.holdings-record", "folio.foo-tenant.inventory.item");
 
   @Test
   public void shouldNotCreateTopicIfAlreadyExist(TestContext testContext) {
@@ -39,7 +40,7 @@ public class KafkaAdminClientServiceTest {
     when(mockClient.createTopics(anyList())).thenReturn(succeededFuture());
     when(mockClient.close()).thenReturn(succeededFuture());
 
-    createKafkaTopicsAsync(mockClient)
+    createKafkaTopicsAsync(TENANT_ID, mockClient)
       .onFailure(testContext::fail)
       .onComplete(testContext.asyncAssertSuccess(notUsed -> {
         verify(mockClient, times(0)).createTopics(anyList());
@@ -50,11 +51,11 @@ public class KafkaAdminClientServiceTest {
   @Test
   public void shouldCreateTopicIfNotExist(TestContext testContext) {
     final KafkaAdminClient mockClient = mock(KafkaAdminClient.class);
-    when(mockClient.listTopics()).thenReturn(succeededFuture(of("folio.inventory.some-another-topic")));
+    when(mockClient.listTopics()).thenReturn(succeededFuture(of("folio.foo-tenant.inventory.some-another-topic")));
     when(mockClient.createTopics(anyList())).thenReturn(succeededFuture());
     when(mockClient.close()).thenReturn(succeededFuture());
 
-    createKafkaTopicsAsync(mockClient)
+    createKafkaTopicsAsync(TENANT_ID, mockClient)
       .onFailure(testContext::fail)
       .onComplete(testContext.asyncAssertSuccess(notUsed -> {
         @SuppressWarnings("unchecked")
@@ -74,7 +75,9 @@ public class KafkaAdminClientServiceTest {
       .collect(Collectors.toList());
   }
 
-  private Future<Void> createKafkaTopicsAsync(KafkaAdminClient mockClient) {
-    return new KafkaAdminClientService(() -> mockClient).createKafkaTopics("folio");
+  private Future<Void> createKafkaTopicsAsync(String tenantId,
+    KafkaAdminClient mockClient) {
+    return new KafkaAdminClientService(() -> mockClient)
+      .createKafkaTopics("folio", tenantId);
   }
 }

--- a/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -9,18 +9,20 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+
 import io.vertx.core.Future;
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.kafka.admin.KafkaAdminClient;
 import io.vertx.kafka.admin.NewTopic;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.ArgumentCaptor;
 
 @RunWith(VertxUnitRunner.class)
 public class KafkaAdminClientServiceTest {
@@ -34,6 +36,7 @@ public class KafkaAdminClientServiceTest {
     when(mockClient.close()).thenReturn(succeededFuture());
 
     createKafkaTopicsAsync(mockClient)
+      .onFailure(testContext::fail)
       .onComplete(testContext.asyncAssertSuccess(notUsed -> {
         verify(mockClient, times(0)).createTopics(anyList());
         verify(mockClient, times(1)).close();
@@ -48,6 +51,7 @@ public class KafkaAdminClientServiceTest {
     when(mockClient.close()).thenReturn(succeededFuture());
 
     createKafkaTopicsAsync(mockClient)
+      .onFailure(testContext::fail)
       .onComplete(testContext.asyncAssertSuccess(notUsed -> {
         @SuppressWarnings("unchecked")
         final ArgumentCaptor<List<NewTopic>> createTopicsCaptor = forClass(List.class);

--- a/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -14,7 +14,6 @@ import static org.mockito.Mockito.when;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -28,8 +27,8 @@ import io.vertx.kafka.admin.NewTopic;
 
 @RunWith(VertxUnitRunner.class)
 public class KafkaAdminClientServiceTest {
-  private final Set<String> allTopics = Stream.of(KafkaTopic.values())
-    .map(KafkaTopic::getTopicName).collect(Collectors.toSet());
+  private final Set<String> allTopics = Set.of("inventory.instance",
+    "inventory.holdings-record", "inventory.item");
 
   @Test
   public void shouldNotCreateTopicIfAlreadyExist(TestContext testContext) {
@@ -62,8 +61,7 @@ public class KafkaAdminClientServiceTest {
         verify(mockClient, times(1)).close();
 
         // Only these items are expected, so implicitly checks size of list
-        assertThat(getTopicNames(createTopicsCaptor), containsInAnyOrder(
-          "inventory.instance", "inventory.holdings-record", "inventory.item"));
+        assertThat(getTopicNames(createTopicsCaptor), containsInAnyOrder(allTopics.toArray()));
       }));
   }
 

--- a/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -2,6 +2,8 @@ package org.folio.services.kafka.topic;
 
 import static io.vertx.core.Future.succeededFuture;
 import static java.util.Set.of;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.ArgumentCaptor.forClass;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.Mockito.mock;
@@ -59,9 +61,16 @@ public class KafkaAdminClientServiceTest {
         verify(mockClient, times(1)).createTopics(createTopicsCaptor.capture());
         verify(mockClient, times(1)).close();
 
-        testContext.assertEquals(1, createTopicsCaptor.getAllValues().size());
-        testContext.assertEquals(allTopics.size(), createTopicsCaptor.getAllValues().get(0).size());
+        // Only these items are expected, so implicitly checks size of list
+        assertThat(getTopicNames(createTopicsCaptor), containsInAnyOrder(
+          "inventory.instance", "inventory.holdings-record", "inventory.item"));
       }));
+  }
+
+  private List<String> getTopicNames(ArgumentCaptor<List<NewTopic>> createTopicsCaptor) {
+    return createTopicsCaptor.getAllValues().get(0).stream()
+      .map(NewTopic::getName)
+      .collect(Collectors.toList());
   }
 
   private Future<Void> createKafkaTopicsAsync(KafkaAdminClient mockClient) {

--- a/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -34,6 +34,9 @@ public class KafkaAdminClientServiceTest {
   public void shouldNotCreateTopicIfAlreadyExist(TestContext testContext) {
     final KafkaAdminClient mockClient = mock(KafkaAdminClient.class);
     when(mockClient.listTopics()).thenReturn(succeededFuture(allTopics));
+    // Still mock this even though no invocations are expected
+    // in order to make diagnosis of failures easier
+    when(mockClient.createTopics(anyList())).thenReturn(succeededFuture());
     when(mockClient.close()).thenReturn(succeededFuture());
 
     createKafkaTopicsAsync(mockClient)


### PR DESCRIPTION
## Purpose

Publish all inventory messages to different topics, whose name starts with the environment, then the tenant ID e.g. `test.foo_tenant.inventory.instance`

None of the existing topics have been removed, as I wasn't sure about the requirements or the impact on pre-existing consumers.

This change is **implementation compatibility breaking** and needs to be deployed together with changes to consuming modules.

## Approach
Usually, I prefer to refactor the code to make the change easier before making a change. Given the urgency of this change, that it is being made to an existing release and my lack of familiarity with the code, I chose to try to make the least amount of changes.

There are changes to the tests in order to be able to change the topic names in them independently of the production code. I find this useful for checking that test fail in the expected way before making the production code change.

The re-indexing test uses mocks in this version rather than publishing messages, so it isn't possible to add the same checks as in the mainline change.

More information can be found in some of the commit messages.