### PR TITLE
MODINVSTOR-771 Fix issue with destination service point for updating item 

### DIFF
--- a/src/main/java/org/folio/services/item/ItemService.java
+++ b/src/main/java/org/folio/services/item/ItemService.java
@@ -36,6 +36,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.persist.ItemRepository;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.jaxrs.model.Status;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.SQLConnection;
 import org.folio.rest.support.HridManager;
@@ -111,7 +112,7 @@ public class ItemService {
       .compose(oldItem -> refuseWhenHridChanged(oldItem, newItem))
       .compose(oldItem -> {
         var oldDestServicePointId = oldItem.getInTransitDestinationServicePointId();
-        if (oldDestServicePointId != null &&
+        if (newItem.getStatus().getName() == Status.Name.IN_TRANSIT &&
           newItem.getInTransitDestinationServicePointId() == null) {
 
           newItem.setInTransitDestinationServicePointId(oldDestServicePointId);

--- a/src/main/java/org/folio/services/item/ItemService.java
+++ b/src/main/java/org/folio/services/item/ItemService.java
@@ -109,6 +109,16 @@ public class ItemService {
     return itemRepository.getById(itemId)
       .compose(CommonValidators::refuseIfNotFound)
       .compose(oldItem -> refuseWhenHridChanged(oldItem, newItem))
+      .compose(oldItem -> {
+        var oldDestServicePointId = oldItem.getInTransitDestinationServicePointId();
+        if (oldDestServicePointId != null &&
+          newItem.getInTransitDestinationServicePointId() == null) {
+
+          newItem.setInTransitDestinationServicePointId(oldDestServicePointId);
+        }
+
+        return succeededFuture(oldItem);
+      })
       .compose(oldItem -> effectiveValuesService.populateEffectiveValues(newItem)
         .compose(notUsed -> {
           final Promise<Response> putResult = promise();


### PR DESCRIPTION
In transit report does not show destination service point if item is edited.

## Purpose
- save  InTransitDestinationServicePointId field for item updating;
- create tests;

Resolves: [MODINVSTOR-771](https://issues.folio.org/browse/MODINVSTOR-771)