### PR TITLE
MODINVSTOR-773: PgUtil.getById GET /holdings-storage/holdings/{id}

### DIFF
--- a/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsStorageAPI.java
@@ -3,23 +3,16 @@ package org.folio.rest.impl;
 import static io.vertx.core.Future.succeededFuture;
 import static org.folio.rest.support.EndpointFailureHandler.handleFailure;
 
-import java.util.List;
 import java.util.Map;
 
 import javax.ws.rs.core.Response;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.resource.HoldingsStorage;
-import org.folio.rest.persist.Criteria.Limit;
-import org.folio.rest.persist.Criteria.Offset;
 import org.folio.rest.persist.PgUtil;
-import org.folio.rest.persist.PostgresClient;
-import org.folio.rest.persist.cql.CQLWrapper;
-import org.folio.rest.tools.utils.TenantTool;
 import org.folio.services.holding.HoldingsService;
 
 import io.vertx.core.AsyncResult;
@@ -84,74 +77,14 @@ public class HoldingsStorageAPI implements HoldingsStorage {
   @Validate
   @Override
   public void getHoldingsStorageHoldingsByHoldingsRecordId(
-    String holdingsRecordId, String lang,
-    Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+      String holdingsRecordId, String lang,
+      Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler,
+      Context vertxContext) {
 
-    String tenantId = okapiHeaders.get(TENANT_HEADER);
-    try {
-      PostgresClient postgresClient = PostgresClient.getInstance(
-        vertxContext.owner(), TenantTool.calculateTenantId(tenantId));
-
-      vertxContext.runOnContext(v -> {
-        try {
-          String[] fieldList = {"*"};
-
-          CQL2PgJSON cql2pgJson = new CQL2PgJSON(HOLDINGS_RECORD_TABLE+".jsonb");
-          CQLWrapper cql = new CQLWrapper(cql2pgJson, String.format("id==%s", holdingsRecordId))
-            .setLimit(new Limit(1))
-            .setOffset(new Offset(0));
-
-          log.info(String.format("SQL generated from CQL: %s", cql.toString()));
-
-          postgresClient.get(HOLDINGS_RECORD_TABLE, HoldingsRecord.class, fieldList, cql, true, false,
-            reply -> {
-              try {
-                if (reply.succeeded()) {
-                  List<HoldingsRecord> holdingsList = reply.result().getResults();
-                  if (holdingsList.size() == 1) {
-                    HoldingsRecord holdingsRecord = holdingsList.get(0);
-
-                    asyncResultHandler.handle(
-                      succeededFuture(
-                        GetHoldingsStorageHoldingsByHoldingsRecordIdResponse.
-                          respond200WithApplicationJson(holdingsRecord)));
-                  }
-                  else {
-                  asyncResultHandler.handle(
-                    succeededFuture(
-                      GetHoldingsStorageHoldingsByHoldingsRecordIdResponse.
-                        respond404WithTextPlain("Not Found")));
-                  }
-                } else {
-                  asyncResultHandler.handle(
-                    succeededFuture(
-                      GetHoldingsStorageHoldingsByHoldingsRecordIdResponse.
-                        respond500WithTextPlain(reply.cause().getMessage())));
-
-                }
-              } catch (Exception e) {
-                  log.error(e.getMessage());
-                asyncResultHandler.handle(succeededFuture(
-                  GetHoldingsStorageHoldingsByHoldingsRecordIdResponse.
-                    respond500WithTextPlain(e.getMessage())));
-              }
-            });
-        } catch (Exception e) {
-          log.error(e.getMessage());
-          asyncResultHandler.handle(succeededFuture(
-            GetHoldingsStorageHoldingsByHoldingsRecordIdResponse.
-              respond500WithTextPlain(e.getMessage())));
-        }
-      });
-    } catch (Exception e) {
-      log.error(e.getMessage());
-      asyncResultHandler.handle(succeededFuture(
-        GetHoldingsStorageHoldingsByHoldingsRecordIdResponse.
-          respond500WithTextPlain(e.getMessage())));
-    }
-
+    PgUtil.getById(HOLDINGS_RECORD_TABLE, HoldingsRecord.class, holdingsRecordId,
+        okapiHeaders, vertxContext, GetHoldingsStorageHoldingsByHoldingsRecordIdResponse.class,
+        asyncResultHandler);
   }
 
   @Validate


### PR DESCRIPTION
The existing code for `GET /holdings-storage/holdings/{id}` uses an unnecessary complex implementation and can easily be replaced by PgUtil.getById.

This also results in a performance gain of 2-5 ms.

4 tests in HoldingsStorageTest use HoldingsStorageTest.getById that calls this API.