### PR TITLE
MODINVSTOR-783: Revert item barcode indexes, release v21.0.6

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,22 @@
-## 21.0.6 2021-09-22
+## 21.0.6 2021-09-23
 
-* Completely revert MODINVSTOR-523 shipped with v21.0.4 (MODINVSTOR-783)
+* Completely revert MODINVSTOR-523 shipped with v21.0.4 (MODINVSTOR-783).
 
 ## 21.0.5 2021-09-22
 
-* Disable item barcode uniqueness check for R2 2021/Juniper (MODINVSTOR-782)
+* Disable item barcode uniqueness check that v21.0.4 has installed (MODINVSTOR-782).
+  Item barcode respects accents and is case insensitive and has a non-unique field index.
+  All other database indexes for item barcode are removed:
+  non-unique fullTextIndex, non-unique ginIndex -
+  these indexes are case insensitive but incorrectly ignore accents
 
 ## 21.0.4 2021-09-06
 
-* Enforce item barcode uniqueness (MODINVSTOR-523)
+* Enforce item barcode uniqueness (MODINVSTOR-523).
+  The uniqueness check respects accents and is case insensitive.
+  All other database indexes for item barcode are removed:
+  non-unique field index, non-unique fullTextIndex, non-unique ginIndex -
+  these indexes are case insensitive but incorrectly ignore accents
 
 ## 21.0.3 2021-08-16
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 21.0.6 2021-09-22
+
+* Completely revert MODINVSTOR-523 shipped with v21.0.4 (MODINVSTOR-783)
+
 ## 21.0.5 2021-09-22
 
 * Disable item barcode uniqueness check for R2 2021/Juniper (MODINVSTOR-782)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>21.0.6</version>
+  <version>21.0.7-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -195,7 +195,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>v21.0.6</tag>
+    <tag>v21.0.1</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>21.0.6-SNAPSHOT</version>
+  <version>21.0.6</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -195,7 +195,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>v21.0.1</tag>
+    <tag>v21.0.6</tag>
   </scm>
 
   <build>

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -853,6 +853,12 @@
       ],
       "ginIndex": [
         {
+          "fieldName": "barcode",
+          "tOps": "ADD",
+          "caseSensitive": false,
+          "removeAccents": true
+        },
+        {
           "fieldName": "status.name",
           "tOps": "ADD",
           "caseSensitive": false,
@@ -860,6 +866,10 @@
         }
       ],
       "fullTextIndex": [
+        {
+          "fieldName": "barcode",
+          "tOps": "ADD"
+        },
         {
           "fieldName": "callNumberAndSuffixNormalized",
           "sqlExpression" : "normalize_item_call_number_and_suffix(jsonb)",

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -1628,11 +1628,9 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     createItem(temeraire(holdingsRecordId));
     createItem(interestingTimes(holdingsRecordId));
     assertCqlFindsBarcodes("barcode==673274826203", "673274826203");
-    // respect accents, ignore case
-    assertCqlFindsBarcodes("barcode==123456a", "123456a");
-    assertCqlFindsBarcodes("barcode==123456A", "123456a");
-    assertCqlFindsBarcodes("barcode==123456ä", "123456ä");
-    assertCqlFindsBarcodes("barcode==123456Ä", "123456ä");
+    // ignore accents, ignore case
+    assertCqlFindsBarcodes("barcode==123456a sortBy barcode", "123456a", "123456ä");
+    assertCqlFindsBarcodes("barcode==123456A sortBy barcode", "123456a", "123456ä");
     assertCqlFindsBarcodes("barcode==123456* sortBy barcode", "123456a", "123456ä");
   }
 


### PR DESCRIPTION
To be sure that the unique item barcode index of release v21.0.4 gets deleted this DELETE entry in schema.json is kept (it has been released in mod-inventory-storage-21.0.5):

```
"uniqueIndex": [
        {
          "fieldName": "barcode",
          "tOps": "DELETE",
          "caseSensitive": false,
          "removeAccents": false
        },
```

This is a workaround for this issue in RMB < v33.0.3: [RMB-864](https://issues.folio.org/browse/RMB-864) Ignore deleted index in schema.json.