### PR TITLE
MODINVSTOR-774: populatePublicationPeriod.sql

### DIFF
--- a/src/main/resources/templates/db_scripts/populatePublicationPeriod.sql
+++ b/src/main/resources/templates/db_scripts/populatePublicationPeriod.sql
@@ -1,0 +1,46 @@
+START TRANSACTION;
+
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.parse_start_year(jsonb) RETURNS int AS $$
+  SELECT COALESCE(
+    (regexp_match($1->'publication'->0->>'dateOfPublication', '(\d{4})\w{0,2}(?:\s?-|\sand|\s?,)'))[1],
+    (regexp_match($1->'publication'->0->>'dateOfPublication', '\d{4}'))[1]
+  )::int;
+$$ LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.parse_end_year(jsonb) RETURNS int AS $$
+  SELECT COALESCE(
+    (regexp_match($1->'publication'->-1->>'dateOfPublication', '(?:-\s?|and\s|,\s?)\w{0,2}(\d{4})'))[1],
+    (regexp_match($1->'publication'->-1->>'dateOfPublication', '\d{4}'))[1],
+    (regexp_match($1->'publication'-> 0->>'dateOfPublication', '(?:-\s?|and\s|,\s?)\w{0,2}(\d{4})'))[1],
+    (regexp_match($1->'publication'-> 0->>'dateOfPublication', '\d{4}'))[1]
+  )::int;
+$$ LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT;
+
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.parse_publication_period(jsonb) RETURNS jsonb AS $$
+  SELECT CASE
+    WHEN $1->'publication' IS NULL THEN NULL
+    WHEN jsonb_array_length($1->'publication') = 0 THEN NULL
+    WHEN parse_start_year($1) IS NULL AND parse_end_year($1) IS NULL THEN NULL
+    WHEN parse_start_year($1) IS NULL THEN jsonb_build_object('end', parse_end_year($1))
+    WHEN parse_end_year($1) IS NULL OR parse_start_year($1) >= parse_end_year($1)
+        THEN jsonb_build_object('start', parse_start_year($1))
+    ELSE jsonb_build_object('start', parse_start_year($1), 'end', parse_end_year($1))
+  END;
+$$ LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT;
+
+ALTER TABLE ${myuniversity}_${mymodule}.instance DISABLE TRIGGER USER;
+
+UPDATE ${myuniversity}_${mymodule}.instance
+SET jsonb = jsonb || jsonb_build_object(
+  'publicationPeriod', parse_publication_period(jsonb),
+  '_version', to_jsonb(coalesce((jsonb->>'_version')::numeric + 1, 1)))
+WHERE jsonb->>'publicationPeriod' IS NULL AND parse_publication_period(jsonb) IS NOT NULL;
+
+ALTER TABLE ${myuniversity}_${mymodule}.instance ENABLE TRIGGER USER;
+
+DROP FUNCTION
+  ${myuniversity}_${mymodule}.parse_start_year(jsonb),
+  ${myuniversity}_${mymodule}.parse_end_year(jsonb),
+  ${myuniversity}_${mymodule}.parse_publication_period(jsonb);
+
+END TRANSACTION;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1077,6 +1077,11 @@
       "run": "after",
       "snippetPath": "inventory-hierarchy/addHoldingsIfItemsSuppressedItemsAndHoldingsView.sql",
       "fromModuleVersion": "22.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "populatePublicationPeriod.sql",
+      "fromModuleVersion": "22.0.0"
     }
   ]
 }

--- a/src/test/java/org/folio/rest/api/PublicationPeriodMigrationTest.java
+++ b/src/test/java/org/folio/rest/api/PublicationPeriodMigrationTest.java
@@ -1,0 +1,102 @@
+package org.folio.rest.api;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.UUID;
+import org.junit.Test;
+
+public class PublicationPeriodMigrationTest extends MigrationTestBase {
+  private static final String MIGRATION_SCRIPT =
+      "SET search_path TO " + getSchemaName() + ";\n" +
+      loadScript("populatePublicationPeriod.sql");
+
+  TestCase [] testCases = {
+    new TestCase(null, null, null, null),
+    new TestCase("1990", null, 1990, null),
+    new TestCase("[1990]", null, 1990, null),
+    new TestCase("©1990", null, 1990, null),
+    new TestCase("[1999?]", null, 1999, null),
+    new TestCase("Cop 1990", null, 1990, null),
+    new TestCase("[2003], ©2001", null, 2003, null),
+    new TestCase("2001, 2003,", null, 2001, 2003),
+    new TestCase("2001- 2003", null, 2001, 2003),
+    new TestCase("between 2001 and 2003", null, 2001, 2003),
+    new TestCase("©2001", "[2003]", 2001, 2003),
+    new TestCase("©2001", "[2001]", 2001, null),
+    new TestCase("2001", "2003", 2001, 2003),
+    new TestCase("2003-2001", "2003", 2003, null),
+    new TestCase("2000-2010", "2012-2020", 2000, 2020),
+    new TestCase(null, "1999", null, 1999),
+    new TestCase("[19uu]", null, null, null),
+    new TestCase(null, "[19uu]", null, null),
+    new TestCase("hafniae MCMLXX", null, null, null),
+    new TestCase(null, "hafniae MCMLXX", null, null),
+  };
+
+  @Test
+  public void canMigrate() throws Throwable {
+    for (TestCase testCase : testCases) {
+      testCase.createInstance();
+    }
+    // remove auto-generated publicationPeriod
+    executeSql("UPDATE " + getSchemaName() + ".instance SET jsonb = jsonb - 'publicationPeriod'");
+
+    executeMultipleSqlStatements(MIGRATION_SCRIPT);
+
+    for (TestCase testCase : testCases) {
+      testCase.assertPublicationPeriod();
+    }
+  }
+
+  private static class TestCase {
+    final UUID id;
+    final String dateOfPublication1;
+    final String dateOfPublication2;
+    final Integer expectedStart;
+    final Integer expectedEnd;
+
+    public TestCase(String dateOfPublication1, String dateOfPublication2,
+        Integer expectedStart, Integer expectedEnd) {
+      id = UUID.randomUUID();
+      this.dateOfPublication1 = dateOfPublication1;
+      this.dateOfPublication2 = dateOfPublication2;
+      this.expectedStart = expectedStart;
+      this.expectedEnd = expectedEnd;
+    }
+
+    public void createInstance() {
+      JsonArray publication = new JsonArray();
+      if (dateOfPublication1 != null || dateOfPublication2 != null) {
+        if (dateOfPublication1 == null) {
+          publication.add(new JsonObject());
+        } else {
+          publication.add(new JsonObject().put("dateOfPublication", dateOfPublication1));
+        }
+        if (dateOfPublication2 != null) {
+          publication.add(new JsonObject().put("dateOfPublication", dateOfPublication2));
+        }
+      }
+      instancesClient.create(instance(id).put("publication", publication));
+    }
+
+    /**
+     * Assert that publicationPeriod (start and end) have the expected values.
+     */
+    public void assertPublicationPeriod() {
+      String reason = dateOfPublication1 + " -- " + dateOfPublication2;
+      JsonObject json = instancesClient.getById(id).getJson();
+      JsonObject publicationPeriod = json.getJsonObject("publicationPeriod");
+      if (expectedStart == null && expectedEnd == null) {
+        assertThat(reason, publicationPeriod, is(nullValue()));
+        return;
+      }
+      assertThat(reason, publicationPeriod.getInteger("start"), is(expectedStart));
+      assertThat(reason, publicationPeriod.getInteger("end"), is(expectedEnd));
+    }
+  }
+
+}

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -85,6 +85,7 @@ import org.testcontainers.utility.DockerImageName;
   PreviouslyHeldDataUpgradeTest.class,
   ItemShelvingOrderMigrationServiceApiTest.class,
   NotificationSendingErrorRepositoryTest.class,
+  PublicationPeriodMigrationTest.class,
   LegacyItemEffectiveLocationMigrationScriptTest.class,
   IterationJobRunnerTest.class
 })


### PR DESCRIPTION
To speed up the migration use SQL (not Java) to parse
the publication array and populate the publicationPeriod field.