### PR TITLE
MODINVSTOR-795: Backport database memory fix (RMB v33.1.1,  and Vert.x to 4.1.4 (MODINVSTOR-793)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 21.0.8 2021-09-30
+
+* Fix database memory bug by updating RMB to 33.1.1 and Vert.x to 4.1.4 (MODINVSTOR-793, MODINVSTOR-795)
+
 ## 21.0.7 2021-09-30
 
 * Removes publication period defaulting during upgrade (MODINVSTOR-806)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>21.0.8-SNAPSHOT</version>
+  <version>21.0.8</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -179,7 +179,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>v21.0.1</tag>
+    <tag>v21.0.8</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,11 @@
   </pluginRepositories>
 
   <properties>
-    <vertx.version>4.1.0.CR1</vertx.version>
+    <vertx.version>4.1.4</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>33.0.0</raml-module-builder-version>
+    <raml-module-builder-version>33.1.1</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/record-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances,/inventory-hierarchy/updated-instance-ids,/inventory-hierarchy/items-and-holdings,/inventory-view/instances</generate_routing_context>
     <argLine />
   </properties>
@@ -48,16 +48,6 @@
         <version>${vertx.version}</version>
         <type>pom</type>
         <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-sql-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
-      </dependency>
-      <dependency>
-        <groupId>io.vertx</groupId>
-        <artifactId>vertx-pg-client</artifactId>
-        <version>${vertx.version}-FOLIO</version>
       </dependency>
       <dependency>
         <groupId>org.testcontainers</groupId>
@@ -149,12 +139,6 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
       <scope>test</scope>
-    </dependency>
-    <!-- This dependency is required until https://issues.folio.org/browse/RMB-503 is fixed -->
-    <dependency>
-      <groupId>org.glassfish.web</groupId>
-      <artifactId>javax.el</artifactId>
-      <version>2.2.4</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>21.0.8</version>
+  <version>21.0.9-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -179,7 +179,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>v21.0.8</tag>
+    <tag>v21.0.1</tag>
   </scm>
 
   <build>


### PR DESCRIPTION
Fix database memory bug by updating RMB to 33.1.1 and Vert.x to 4.1.4 (MODINVSTOR-793, MODINVSTOR-795)