### PR TITLE
MODINVSTOR-816: previouslyHeld default must be boolean, not string

### DIFF
--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -363,7 +363,7 @@
     "previouslyHeld": {
       "type": "boolean",
       "description": "Records the fact that the resource was previously held by the library for things like Hathi access, etc.",
-      "default":"false"
+      "default": false
     },
     "staffSuppress": {
       "type": "boolean",


### PR DESCRIPTION
https://issues.folio.org/browse/MODINVSTOR-816