### PR TITLE
MODINVSTOR-24: Instance storage APIs do not validate

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 23.0.0 in progress
+
+* Introduces validation against RAML API specs for 147 APIs (MODINVSTOR-24)
+
 ## 22.0.0 2021-10-06
 
 * Added new identifiers for ISMN and UPC (MODINVSTOR-770)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>22.1.0-SNAPSHOT</version>
+  <version>23.0.0-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/src/main/java/org/folio/rest/impl/AuthorityRecordsAPI.java
+++ b/src/main/java/org/folio/rest/impl/AuthorityRecordsAPI.java
@@ -9,6 +9,7 @@ import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Map;
 import javax.ws.rs.core.Response;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Authority;
 import org.folio.rest.jaxrs.resource.AuthorityStorage;
 import org.folio.rest.persist.PgUtil;
@@ -18,6 +19,7 @@ public class AuthorityRecordsAPI implements AuthorityStorage {
 
   public static final String AUTHORITY_TABLE = "authority";
 
+  @Validate
   @Override
   public void getAuthorityStorageAuthorities(int offset, int limit,
                                              String query, String lang,
@@ -29,6 +31,7 @@ public class AuthorityRecordsAPI implements AuthorityStorage {
       routingContext, okapiHeaders, vertxContext);
   }
 
+  @Validate
   @Override
   public void postAuthorityStorageAuthorities(String lang, Authority entity,
                                               RoutingContext routingContext,
@@ -40,6 +43,7 @@ public class AuthorityRecordsAPI implements AuthorityStorage {
       .onFailure(handleFailure(asyncResultHandler));
   }
 
+  @Validate
   @Override
   public void deleteAuthorityStorageAuthorities(String lang,
                                                 RoutingContext routingContext,
@@ -52,6 +56,7 @@ public class AuthorityRecordsAPI implements AuthorityStorage {
       .onFailure(handleFailure(asyncResultHandler));
   }
 
+  @Validate
   @Override
   public void getAuthorityStorageAuthoritiesByAuthorityId(String authorityId,
                                                           String lang,
@@ -62,6 +67,7 @@ public class AuthorityRecordsAPI implements AuthorityStorage {
       GetAuthorityStorageAuthoritiesByAuthorityIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteAuthorityStorageAuthoritiesByAuthorityId(String authorityId,
                                                              String lang,
@@ -73,6 +79,7 @@ public class AuthorityRecordsAPI implements AuthorityStorage {
       .onFailure(handleFailure(asyncResultHandler));
   }
 
+  @Validate
   @Override
   public void putAuthorityStorageAuthoritiesByAuthorityId(String authorityId,
                                                           String lang,

--- a/src/main/java/org/folio/rest/impl/BoundWithPartAPI.java
+++ b/src/main/java/org/folio/rest/impl/BoundWithPartAPI.java
@@ -3,45 +3,48 @@ package org.folio.rest.impl;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.BoundWithPart;
 import org.folio.rest.jaxrs.model.BoundWithParts;
 import org.folio.rest.persist.PgUtil;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.Pattern;
 import javax.ws.rs.core.Response;
 import java.util.Map;
 
 public class BoundWithPartAPI implements org.folio.rest.jaxrs.resource.InventoryStorageBoundWithParts {
   private static final String BOUND_WITH_TABLE = "bound_with_part";
 
+  @Validate
   @Override
-  public void getInventoryStorageBoundWithParts(String query, @Min(0) @Max(2147483647) int offset, @Min(0) @Max(2147483647) int limit, @Pattern(regexp = "[a-zA-Z]{2}") String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getInventoryStorageBoundWithParts(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.get(BOUND_WITH_TABLE, BoundWithPart.class, BoundWithParts.class, query, offset, limit,
       okapiHeaders, vertxContext, org.folio.rest.jaxrs.resource.InventoryStorageBoundWithParts.GetInventoryStorageBoundWithPartsResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
-  public void postInventoryStorageBoundWithParts(@Pattern(regexp = "[a-zA-Z]{2}") String lang, BoundWithPart entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void postInventoryStorageBoundWithParts(String lang, BoundWithPart entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.post(BOUND_WITH_TABLE, entity, okapiHeaders, vertxContext,
       PostInventoryStorageBoundWithPartsResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
-  public void getInventoryStorageBoundWithPartsById(String id, @Pattern(regexp = "[a-zA-Z]{2}") String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getInventoryStorageBoundWithPartsById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.getById(BOUND_WITH_TABLE, BoundWithPart.class, id,
       okapiHeaders, vertxContext, GetInventoryStorageBoundWithPartsByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
-  public void deleteInventoryStorageBoundWithPartsById(String id, @Pattern(regexp = "[a-zA-Z]{2}") String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void deleteInventoryStorageBoundWithPartsById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.deleteById(BOUND_WITH_TABLE, id, okapiHeaders, vertxContext,
       DeleteInventoryStorageBoundWithPartsByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
-  public void putInventoryStorageBoundWithPartsById(String id, @Pattern(regexp = "[a-zA-Z]{2}") String lang, BoundWithPart entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void putInventoryStorageBoundWithPartsById(String id, String lang, BoundWithPart entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.put(BOUND_WITH_TABLE, entity, id, okapiHeaders, vertxContext,
       PutInventoryStorageBoundWithPartsByIdResponse.class, asyncResultHandler);
   }

--- a/src/main/java/org/folio/rest/impl/ElectronicAccessRelationshipAPI.java
+++ b/src/main/java/org/folio/rest/impl/ElectronicAccessRelationshipAPI.java
@@ -16,6 +16,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.rest.RestVerticle;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.ElectronicAccessRelationship;
 import org.folio.rest.jaxrs.model.ElectronicAccessRelationships;
 import org.folio.rest.persist.Criteria.Limit;
@@ -42,6 +43,7 @@ public class ElectronicAccessRelationshipAPI implements org.folio.rest.jaxrs.res
   private static final Logger LOG = LogManager.getLogger();
   private static final Messages MESSAGES = Messages.getInstance();
 
+  @Validate
   @Override
   public void getElectronicAccessRelationships(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -83,6 +85,7 @@ public class ElectronicAccessRelationshipAPI implements org.folio.rest.jaxrs.res
     });
   }
 
+  @Validate
   @Override
   public void postElectronicAccessRelationships(String lang, ElectronicAccessRelationship entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -129,12 +132,14 @@ public class ElectronicAccessRelationshipAPI implements org.folio.rest.jaxrs.res
     });
   }
 
+  @Validate
   @Override
   public void getElectronicAccessRelationshipsByElectronicAccessRelationshipId(String electronicAccessRelationshipId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.getById(RESOURCE_TABLE, ElectronicAccessRelationship.class, electronicAccessRelationshipId,
         okapiHeaders, vertxContext, GetElectronicAccessRelationshipsByElectronicAccessRelationshipIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteElectronicAccessRelationshipsByElectronicAccessRelationshipId(String electronicAccessRelationshipId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -171,6 +176,7 @@ public class ElectronicAccessRelationshipAPI implements org.folio.rest.jaxrs.res
     });
   }
 
+  @Validate
   @Override
   public void putElectronicAccessRelationshipsByElectronicAccessRelationshipId(String electronicAccessRelationshipId, String lang, ElectronicAccessRelationship entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {

--- a/src/main/java/org/folio/rest/impl/HoldingsNoteTypeAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsNoteTypeAPI.java
@@ -14,6 +14,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.HoldingsNoteType;
 import org.folio.rest.jaxrs.model.HoldingsNoteTypes;
 import org.folio.rest.persist.Criteria.Limit;
@@ -43,6 +44,7 @@ public class HoldingsNoteTypeAPI implements org.folio.rest.jaxrs.resource.Holdin
   private static final Logger log             = LogManager.getLogger();
   private final Messages messages             = Messages.getInstance();
 
+  @Validate
   @Override
   public void getHoldingsNoteTypes(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     /**
@@ -87,6 +89,7 @@ public class HoldingsNoteTypeAPI implements org.folio.rest.jaxrs.resource.Holdin
     });
   }
 
+  @Validate
   @Override
   public void postHoldingsNoteTypes(String lang, HoldingsNoteType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -126,12 +129,14 @@ public class HoldingsNoteTypeAPI implements org.folio.rest.jaxrs.resource.Holdin
     });
   }
 
+  @Validate
   @Override
   public void getHoldingsNoteTypesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.getById(REFERENCE_TABLE, HoldingsNoteType.class, id,
         okapiHeaders, vertxContext, GetHoldingsNoteTypesByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteHoldingsNoteTypesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -172,6 +177,7 @@ public class HoldingsNoteTypeAPI implements org.folio.rest.jaxrs.resource.Holdin
     });
   }
 
+  @Validate
   @Override
   public void putHoldingsNoteTypesById(String id, String lang, HoldingsNoteType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {

--- a/src/main/java/org/folio/rest/impl/HoldingsRecordsSourceAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsRecordsSourceAPI.java
@@ -7,6 +7,7 @@ import java.util.Map;
 import javax.ws.rs.core.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.HoldingsRecordsSource;
 import org.folio.rest.jaxrs.model.HoldingsRecordsSource.Source;
 import org.folio.rest.jaxrs.model.HoldingsRecordsSources;
@@ -27,18 +28,21 @@ public class HoldingsRecordsSourceAPI implements org.folio.rest.jaxrs.resource.H
   private static final Logger log = LogManager.getLogger();
   private final Messages messages = Messages.getInstance();
 
+  @Validate
   @Override
   public void getHoldingsSources(String query, int offset, int limit, String lang,
     Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
       PgUtil.get(REFERENCE_TABLE, HoldingsRecordsSource.class, HoldingsRecordsSources.class, query, offset, limit, okapiHeaders, vertxContext, GetHoldingsSourcesResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void postHoldingsSources(String lang, HoldingsRecordsSource entity,
     Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
       PgUtil.post(REFERENCE_TABLE, entity, okapiHeaders, vertxContext, PostHoldingsSourcesResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void getHoldingsSourcesById(String id, String lang,
     Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -46,6 +50,7 @@ public class HoldingsRecordsSourceAPI implements org.folio.rest.jaxrs.resource.H
         vertxContext, GetHoldingsSourcesByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteHoldingsSourcesById(String id, String lang,
     Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -79,6 +84,7 @@ public class HoldingsRecordsSourceAPI implements org.folio.rest.jaxrs.resource.H
     });
   }
 
+  @Validate
   @Override
   public void putHoldingsSourcesById(String id, String lang,
     HoldingsRecordsSource entity, Map<String, String> okapiHeaders,

--- a/src/main/java/org/folio/rest/impl/HoldingsTypeAPI.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsTypeAPI.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.HoldingsType;
@@ -45,6 +46,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
   private static final Logger log = LogManager.getLogger();
   private final Messages messages             = Messages.getInstance();
 
+  @Validate
   @Override
   public void getHoldingsTypes(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     /**
@@ -89,6 +91,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
     });
   }
 
+  @Validate
   @Override
   public void postHoldingsTypes(String lang,
                                 HoldingsType entity,
@@ -108,12 +111,14 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
       .onComplete(asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void getHoldingsTypesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.getById(REFERENCE_TABLE, HoldingsType.class, id,
         okapiHeaders, vertxContext, GetHoldingsTypesByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteHoldingsTypesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -154,6 +159,7 @@ public class HoldingsTypeAPI implements org.folio.rest.jaxrs.resource.HoldingsTy
     });
   }
 
+  @Validate
   @Override
   public void putHoldingsTypesById(String id, String lang, HoldingsType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {

--- a/src/main/java/org/folio/rest/impl/IllPolicyAPI.java
+++ b/src/main/java/org/folio/rest/impl/IllPolicyAPI.java
@@ -90,7 +90,7 @@ public class IllPolicyAPI implements org.folio.rest.jaxrs.resource.IllPolicies {
     });
   }
 
-
+  @Validate
   @Override
   public void postIllPolicies(String lang, IllPolicy entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -130,12 +130,14 @@ public class IllPolicyAPI implements org.folio.rest.jaxrs.resource.IllPolicies {
     });
   }
 
+  @Validate
   @Override
   public void getIllPoliciesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.getById(REFERENCE_TABLE, IllPolicy.class, id,
         okapiHeaders, vertxContext, GetIllPoliciesByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void putIllPoliciesById(String id, String lang, IllPolicy entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -174,6 +176,7 @@ public class IllPolicyAPI implements org.folio.rest.jaxrs.resource.IllPolicies {
     });
   }
 
+  @Validate
   @Override
   public void deleteIllPoliciesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {

--- a/src/main/java/org/folio/rest/impl/InstanceIterationAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceIterationAPI.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.IterationJob;
 import org.folio.rest.jaxrs.model.IterationJobParams;
 import org.folio.rest.jaxrs.resource.InstanceStorageInstancesIteration;
@@ -17,6 +18,7 @@ import org.folio.services.iteration.IterationService;
 
 public class InstanceIterationAPI implements InstanceStorageInstancesIteration {
 
+  @Validate
   @Override
   public void postInstanceStorageInstancesIteration(IterationJobParams jobParams, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> resultHandler, Context vertxContext) {
@@ -27,6 +29,7 @@ public class InstanceIterationAPI implements InstanceStorageInstancesIteration {
       .onFailure(postFailed(resultHandler));
   }
 
+  @Validate
   @Override
   public void getInstanceStorageInstancesIterationById(String id, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> resultHandler, Context vertxContext) {
@@ -37,6 +40,7 @@ public class InstanceIterationAPI implements InstanceStorageInstancesIteration {
       .onFailure(getFailed(resultHandler));
   }
 
+  @Validate
   @Override
   public void deleteInstanceStorageInstancesIterationById(String id, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> resultHandler, Context vertxContext) {

--- a/src/main/java/org/folio/rest/impl/InstanceNoteTypeAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceNoteTypeAPI.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.InstanceNoteType;
 import org.folio.rest.jaxrs.model.InstanceNoteTypes;
 import org.folio.rest.persist.Criteria.Limit;
@@ -39,6 +40,7 @@ public class InstanceNoteTypeAPI implements org.folio.rest.jaxrs.resource.Instan
   private static final Logger log             = LogManager.getLogger();
   private final Messages messages             = Messages.getInstance();
 
+  @Validate
   @Override
   public void getInstanceNoteTypes(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     /**
@@ -76,6 +78,7 @@ public class InstanceNoteTypeAPI implements org.folio.rest.jaxrs.resource.Instan
     });
   }
 
+  @Validate
   @Override
   public void postInstanceNoteTypes(String lang, InstanceNoteType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -109,6 +112,7 @@ public class InstanceNoteTypeAPI implements org.folio.rest.jaxrs.resource.Instan
     });
   }
 
+  @Validate
   @Override
   public void getInstanceNoteTypesById(String id, String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -117,6 +121,7 @@ public class InstanceNoteTypeAPI implements org.folio.rest.jaxrs.resource.Instan
       vertxContext, GetInstanceNoteTypesByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteInstanceNoteTypesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -151,6 +156,7 @@ public class InstanceNoteTypeAPI implements org.folio.rest.jaxrs.resource.Instan
     });
   }
 
+  @Validate
   @Override
   public void putInstanceNoteTypesById(String id, String lang, InstanceNoteType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {

--- a/src/main/java/org/folio/rest/impl/InstanceStatusAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceStatusAPI.java
@@ -12,6 +12,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.rest.RestVerticle;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.InstanceStatus;
 import org.folio.rest.jaxrs.model.InstanceStatuses;
 import org.folio.rest.persist.Criteria.Limit;
@@ -39,6 +40,7 @@ public class InstanceStatusAPI implements org.folio.rest.jaxrs.resource.Instance
   private static final Logger LOG = LogManager.getLogger();
   private static final Messages MESSAGES = Messages.getInstance();
 
+  @Validate
   @Override
   public void deleteInstanceStatuses(String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     String tenantId = TenantTool.tenantId(okapiHeaders);
@@ -69,6 +71,7 @@ public class InstanceStatusAPI implements org.folio.rest.jaxrs.resource.Instance
     }
   }
 
+  @Validate
   @Override
   public void getInstanceStatuses(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -110,6 +113,7 @@ public class InstanceStatusAPI implements org.folio.rest.jaxrs.resource.Instance
     });
   }
 
+  @Validate
   @Override
   public void postInstanceStatuses(String lang, InstanceStatus entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -156,12 +160,14 @@ public class InstanceStatusAPI implements org.folio.rest.jaxrs.resource.Instance
     });
   }
 
+  @Validate
   @Override
   public void getInstanceStatusesByInstanceStatusId(String instanceStatusId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.getById(RESOURCE_TABLE, InstanceStatus.class, instanceStatusId,
         okapiHeaders, vertxContext, GetInstanceStatusesByInstanceStatusIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteInstanceStatusesByInstanceStatusId(String instanceStatusId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -198,6 +204,7 @@ public class InstanceStatusAPI implements org.folio.rest.jaxrs.resource.Instance
     });
   }
 
+  @Validate
   @Override
   public void putInstanceStatusesByInstanceStatusId(String instanceStatusId, String lang, InstanceStatus entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {

--- a/src/main/java/org/folio/rest/impl/InstanceStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceStorageAPI.java
@@ -10,11 +10,6 @@ import static org.folio.rest.support.EndpointFailureHandler.handleFailure;
 import java.util.List;
 import java.util.Map;
 
-import javax.validation.constraints.Max;
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Pattern;
-import javax.ws.rs.DefaultValue;
 import javax.ws.rs.core.Response;
 
 import io.vertx.core.AsyncResult;
@@ -27,6 +22,7 @@ import org.apache.logging.log4j.Logger;
 
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Instance;
 import org.folio.rest.jaxrs.model.InstanceRelationship;
 import org.folio.rest.jaxrs.model.InstanceRelationships;
@@ -69,12 +65,13 @@ public class InstanceStorageAPI implements InstanceStorage {
       .setOffset(new Offset(offset));
   }
 
+  @Validate
   @Override
   public void getInstanceStorageInstances(
-    @DefaultValue("0") @Min(0L) @Max(1000L) int offset,
-    @DefaultValue("10") @Min(1L) @Max(100L) int limit,
+    int offset,
+    int limit,
     String query,
-    @DefaultValue("en") @Pattern(regexp = "[a-zA-Z]{2}") String lang,
+    String lang,
     RoutingContext routingContext, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler,
     Context vertxContext) {
@@ -97,9 +94,10 @@ public class InstanceStorageAPI implements InstanceStorage {
       "instances", routingContext, okapiHeaders, vertxContext);
   }
 
+  @Validate
   @Override
   public void postInstanceStorageInstances(
-    @DefaultValue("en") @Pattern(regexp = "[a-zA-Z]{2}") String lang,
+    String lang,
     Instance entity,
     RoutingContext routingContext, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler,
@@ -111,9 +109,10 @@ public class InstanceStorageAPI implements InstanceStorage {
       .onFailure(handleFailure(asyncResultHandler));
   }
 
+  @Validate
   @Override
   public void deleteInstanceStorageInstances(
-    @DefaultValue("en") @Pattern(regexp = "[a-zA-Z]{2}") String lang,
+    String lang,
     RoutingContext routingContext, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler,
     Context vertxContext) {
@@ -125,10 +124,11 @@ public class InstanceStorageAPI implements InstanceStorage {
       .onFailure(handleFailure(asyncResultHandler));
   }
 
+  @Validate
   @Override
   public void getInstanceStorageInstancesByInstanceId(
-    @NotNull String instanceId,
-    @DefaultValue("en") @Pattern(regexp = "[a-zA-Z]{2}") String lang,
+    String instanceId,
+    String lang,
     Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler,
     Context vertxContext) {
@@ -196,10 +196,11 @@ public class InstanceStorageAPI implements InstanceStorage {
     }
   }
 
+  @Validate
   @Override
   public void deleteInstanceStorageInstancesByInstanceId(
-    @NotNull String instanceId,
-    @DefaultValue("en") @Pattern(regexp = "[a-zA-Z]{2}") String lang,
+    String instanceId,
+    String lang,
     Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler,
     Context vertxContext) {
@@ -210,10 +211,11 @@ public class InstanceStorageAPI implements InstanceStorage {
       .onFailure(handleFailure(asyncResultHandler));
   }
 
+  @Validate
   @Override
   public void putInstanceStorageInstancesByInstanceId(
-    @NotNull String instanceId,
-    @DefaultValue("en") @Pattern(regexp = "[a-zA-Z]{2}") String lang,
+    String instanceId,
+    String lang,
     Instance entity,
     Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler,
@@ -225,10 +227,11 @@ public class InstanceStorageAPI implements InstanceStorage {
       .onFailure(handleFailure(asyncResultHandler));
   }
 
+  @Validate
   @Override
   public void deleteInstanceStorageInstancesSourceRecordByInstanceId(
-      @NotNull String instanceId,
-      @DefaultValue("en") @Pattern(regexp = "[a-zA-Z]{2}") String lang,
+      String instanceId,
+      String lang,
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
@@ -237,6 +240,7 @@ public class InstanceStorageAPI implements InstanceStorage {
         DeleteInstanceStorageInstancesSourceRecordByInstanceIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void getInstanceStorageInstancesSourceRecordMarcJsonByInstanceId(
       String instanceId, String lang, Map<String, String> okapiHeaders,
@@ -247,10 +251,11 @@ public class InstanceStorageAPI implements InstanceStorage {
       GetInstanceStorageInstancesSourceRecordMarcJsonByInstanceIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteInstanceStorageInstancesSourceRecordMarcJsonByInstanceId(
-      @NotNull String instanceId,
-      @DefaultValue("en") @Pattern(regexp = "[a-zA-Z]{2}") String lang,
+      String instanceId,
+      String lang,
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
       Context vertxContext) {
@@ -259,10 +264,11 @@ public class InstanceStorageAPI implements InstanceStorage {
         DeleteInstanceStorageInstancesSourceRecordMarcJsonByInstanceIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void putInstanceStorageInstancesSourceRecordMarcJsonByInstanceId(
-      @NotNull String instanceId,
-      @DefaultValue("en") @Pattern(regexp = "[a-zA-Z]{2}") String lang,
+      String instanceId,
+      String lang,
       MarcJson entity,
       Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler,
@@ -292,6 +298,7 @@ public class InstanceStorageAPI implements InstanceStorage {
   /**
    * Example stub showing how other formats might get implemented.
    */
+  @Validate
   @Override
   public void getInstanceStorageInstancesSourceRecordModsByInstanceId(
       String instanceId, String lang, Map<String, String> okapiHeaders,
@@ -305,6 +312,7 @@ public class InstanceStorageAPI implements InstanceStorage {
   /**
    * Example stub showing how other formats might get implemented.
    */
+  @Validate
   @Override
   public void putInstanceStorageInstancesSourceRecordModsByInstanceId(
       String instanceId, String lang, Map<String, String> okapiHeaders,
@@ -315,6 +323,7 @@ public class InstanceStorageAPI implements InstanceStorage {
         .respond500WithTextPlain("Not implemented yet.")));
   }
 
+  @Validate
   @Override
   public void getInstanceStorageInstanceRelationships(int offset, int limit, String query, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PostgresClient postgresClient =
@@ -370,17 +379,20 @@ public class InstanceStorageAPI implements InstanceStorage {
     }
   }
 
+  @Validate
   @Override
   public void postInstanceStorageInstanceRelationships(String lang, InstanceRelationship entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.post(INSTANCE_RELATIONSHIP_TABLE, entity, okapiHeaders, vertxContext,
         PostInstanceStorageInstanceRelationshipsResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void getInstanceStorageInstanceRelationshipsByRelationshipId(String relationshipId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     throw new UnsupportedOperationException("Not supported yet."); //To change body of generated methods, choose Tools | Templates.
   }
 
+  @Validate
   @Override
   public void deleteInstanceStorageInstanceRelationshipsByRelationshipId(String relationshipId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PostgresClient postgresClient =
@@ -398,6 +410,7 @@ public class InstanceStorageAPI implements InstanceStorage {
     });
   }
 
+  @Validate
   @Override
   public void putInstanceStorageInstanceRelationshipsByRelationshipId(String relationshipId, String lang, InstanceRelationship entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {

--- a/src/main/java/org/folio/rest/impl/InstanceStorageBatchAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceStorageBatchAPI.java
@@ -18,6 +18,7 @@ import javax.ws.rs.core.Response;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Instance;
 import org.folio.rest.jaxrs.model.Instances;
 import org.folio.rest.jaxrs.model.InstancesBatchResponse;
@@ -47,6 +48,7 @@ public class InstanceStorageBatchAPI implements InstanceStorageBatchInstances {
   private static final int PARALLEL_DB_CONNECTIONS_LIMIT = Integer.parseInt(
     MODULE_SPECIFIC_ARGS.getOrDefault(PARALLEL_DB_CONNECTIONS_LIMIT_KEY, "4"));
 
+  @Validate
   @Override
   public void postInstanceStorageBatchInstances(Instances entity,
                                                 Map<String, String> okapiHeaders,

--- a/src/main/java/org/folio/rest/impl/InventoryHierarchyAPI.java
+++ b/src/main/java/org/folio/rest/impl/InventoryHierarchyAPI.java
@@ -3,7 +3,6 @@ package org.folio.rest.impl;
 import java.util.Map;
 import java.util.UUID;
 
-import javax.validation.constraints.Pattern;
 import javax.ws.rs.core.Response;
 
 import org.apache.commons.lang3.StringUtils;
@@ -39,7 +38,7 @@ public class InventoryHierarchyAPI extends AbstractInstanceRecordsAPI implements
   @Validate
   @Override
   public void getInventoryHierarchyUpdatedInstanceIds(String startDate, String endDate, boolean deletedRecordSupport, boolean skipSuppressedFromDiscoveryRecords,
-      boolean onlyInstanceUpdateDate, @Pattern(regexp = "[a-zA-Z]{2}") String lang, RoutingContext routingContext, Map<String, String> okapiHeaders,
+      boolean onlyInstanceUpdateDate, String lang, RoutingContext routingContext, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     if(StringUtils.isEmpty(startDate) && StringUtils.isEmpty(endDate)) {
       String sql = SQL_INITIAL_LOAD;

--- a/src/main/java/org/folio/rest/impl/InventoryViewAPI.java
+++ b/src/main/java/org/folio/rest/impl/InventoryViewAPI.java
@@ -9,10 +9,12 @@ import io.vertx.core.Handler;
 import io.vertx.ext.web.RoutingContext;
 import java.util.Map;
 import javax.ws.rs.core.Response;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.InventoryViewInstance;
 import org.folio.rest.jaxrs.resource.InventoryViewInstances;
 
 public class InventoryViewAPI implements InventoryViewInstances {
+  @Validate
   @Override
   public void getInventoryViewInstances(int offset, int limit, String query, String lang,
     RoutingContext routingContext, Map<String, String> okapiHeaders,

--- a/src/main/java/org/folio/rest/impl/ItemDamagedStatusAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemDamagedStatusAPI.java
@@ -21,6 +21,7 @@ import io.vertx.sqlclient.RowSet;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.exception.FieldException;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.ItemDamageStatus;
 import org.folio.rest.jaxrs.model.ItemDamageStatuses;
 import org.folio.rest.jaxrs.resource.ItemDamagedStatuses;
@@ -38,6 +39,7 @@ public class ItemDamagedStatusAPI implements ItemDamagedStatuses {
   private final Messages messages = Messages.getInstance();
   private PostgresClientFactory pgClientFactory = new PostgresClientFactory();
 
+  @Validate
   @Override
   public void getItemDamagedStatuses(
     String query,
@@ -91,6 +93,7 @@ public class ItemDamagedStatusAPI implements ItemDamagedStatuses {
         .withTotalRecords(results.getResultInfo().getTotalRecords()));
   }
 
+  @Validate
   @Override
   public void postItemDamagedStatuses(
     String lang,
@@ -128,6 +131,7 @@ public class ItemDamagedStatusAPI implements ItemDamagedStatuses {
         .map(entity::withId);
   }
 
+  @Validate
   @Override
   public void getItemDamagedStatusesById(
     String id,
@@ -166,6 +170,7 @@ public class ItemDamagedStatusAPI implements ItemDamagedStatuses {
         .getById(REFERENCE_TABLE, id, ItemDamageStatus.class, promise));
   }
 
+  @Validate
   @Override
   public void deleteItemDamagedStatusesById(
     String id,
@@ -224,6 +229,7 @@ public class ItemDamagedStatusAPI implements ItemDamagedStatuses {
         .map(RowSet<Row>::rowCount);
   }
 
+  @Validate
   @Override
   public void putItemDamagedStatusesById(
     String id,

--- a/src/main/java/org/folio/rest/impl/ItemNoteTypeAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemNoteTypeAPI.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.ItemNoteType;
 import org.folio.rest.jaxrs.model.ItemNoteTypes;
 import org.folio.rest.persist.Criteria.Limit;
@@ -38,6 +39,7 @@ public class ItemNoteTypeAPI implements org.folio.rest.jaxrs.resource.ItemNoteTy
   private static final Logger log             = LogManager.getLogger();
   private final Messages messages             = Messages.getInstance();
 
+  @Validate
   @Override
   public void getItemNoteTypes(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     /**
@@ -82,6 +84,7 @@ public class ItemNoteTypeAPI implements org.folio.rest.jaxrs.resource.ItemNoteTy
     });
   }
 
+  @Validate
   @Override
   public void postItemNoteTypes(String lang, ItemNoteType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -121,12 +124,14 @@ public class ItemNoteTypeAPI implements org.folio.rest.jaxrs.resource.ItemNoteTy
     });
   }
 
+  @Validate
   @Override
   public void getItemNoteTypesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.getById(REFERENCE_TABLE, ItemNoteType.class, id,
         okapiHeaders, vertxContext, GetItemNoteTypesByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteItemNoteTypesById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -167,6 +172,7 @@ public class ItemNoteTypeAPI implements org.folio.rest.jaxrs.resource.ItemNoteTy
     });
   }
 
+  @Validate
   @Override
   public void putItemNoteTypesById(String id, String lang, ItemNoteType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {

--- a/src/main/java/org/folio/rest/impl/LoanTypeAPI.java
+++ b/src/main/java/org/folio/rest/impl/LoanTypeAPI.java
@@ -234,6 +234,7 @@ public class LoanTypeAPI implements org.folio.rest.jaxrs.resource.LoanTypes {
     });
   }
 
+  @Validate
   @Override
   public void deleteLoanTypes(String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {

--- a/src/main/java/org/folio/rest/impl/LocationAPI.java
+++ b/src/main/java/org/folio/rest/impl/LocationAPI.java
@@ -16,6 +16,7 @@ import javax.ws.rs.core.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.exception.FieldException;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Location;
 import org.folio.rest.jaxrs.model.Locations;
 import org.folio.rest.persist.PgUtil;
@@ -41,6 +42,7 @@ public class LocationAPI implements org.folio.rest.jaxrs.resource.Locations {
   public static final String SERVICEPOINT_IDS = "servicePointIds";
   public static final String PRIMARY_SERVICEPOINT = "primaryServicePoint";
 
+  @Validate
   @Override
   public void deleteLocations(String lang,
           Map<String, String> okapiHeaders,
@@ -65,6 +67,7 @@ public class LocationAPI implements org.folio.rest.jaxrs.resource.Locations {
 
   // Note, this is the way to get rid of unnecessary try-catch blocks. Use the
   // same everywhere!
+  @Validate
   @Override
   public void getLocations(
     String query,
@@ -105,6 +108,7 @@ public class LocationAPI implements org.folio.rest.jaxrs.resource.Locations {
         });
   }
 
+  @Validate
   @Override
   public void postLocations(
     String lang,
@@ -154,6 +158,7 @@ public class LocationAPI implements org.folio.rest.jaxrs.resource.Locations {
 
   }
 
+  @Validate
   @Override
   public void getLocationsById(
     String id,
@@ -166,6 +171,7 @@ public class LocationAPI implements org.folio.rest.jaxrs.resource.Locations {
         GetLocationsByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteLocationsById(
     String id,
@@ -178,6 +184,7 @@ public class LocationAPI implements org.folio.rest.jaxrs.resource.Locations {
         DeleteLocationsByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void putLocationsById(
     String id,

--- a/src/main/java/org/folio/rest/impl/LocationUnitAPI.java
+++ b/src/main/java/org/folio/rest/impl/LocationUnitAPI.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import javax.ws.rs.core.Response;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Loccamp;
 import org.folio.rest.jaxrs.model.Loccamps;
 import org.folio.rest.jaxrs.model.Locinst;
@@ -31,6 +32,7 @@ public class LocationUnitAPI implements LocationUnits {
   public static final String URL_PREFIX_LIB = URL_PREFIX + "/libraries";
   private static final String MOD_NAME = "mod_inventory_storage";
 
+  @Validate
   @Override
   public void deleteLocationUnitsInstitutions(String lang,
     Map<String, String> okapiHeaders,
@@ -53,6 +55,7 @@ public class LocationUnitAPI implements LocationUnits {
         });
   }
 
+  @Validate
   @Override
   public void getLocationUnitsInstitutions(
     String query, int offset, int limit,
@@ -89,6 +92,7 @@ public class LocationUnitAPI implements LocationUnits {
         });
   }
 
+  @Validate
   @Override
   public void postLocationUnitsInstitutions(String lang,
     Locinst entity, Map<String, String> okapiHeaders,
@@ -128,6 +132,7 @@ public class LocationUnitAPI implements LocationUnits {
       });
   }
 
+  @Validate
   @Override
   public void getLocationUnitsInstitutionsById(String id,
     String lang, Map<String, String> okapiHeaders,
@@ -138,6 +143,7 @@ public class LocationUnitAPI implements LocationUnits {
         GetLocationUnitsInstitutionsByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteLocationUnitsInstitutionsById(String id,
     String lang, Map<String, String> okapiHeaders,
@@ -148,6 +154,7 @@ public class LocationUnitAPI implements LocationUnits {
         DeleteLocationUnitsInstitutionsByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void putLocationUnitsInstitutionsById(
     String id,
@@ -168,6 +175,7 @@ public class LocationUnitAPI implements LocationUnits {
   }
 
   ////////////////////////////////////////////
+  @Validate
   @Override
   public void deleteLocationUnitsCampuses(String lang,
     Map<String, String> okapiHeaders,
@@ -191,6 +199,7 @@ public class LocationUnitAPI implements LocationUnits {
         });
   }
 
+  @Validate
   @Override
   public void getLocationUnitsCampuses(
     String query, int offset, int limit,
@@ -228,6 +237,7 @@ public class LocationUnitAPI implements LocationUnits {
           });
   }
 
+  @Validate
   @Override
   public void postLocationUnitsCampuses(String lang,
     Loccamp entity, Map<String, String> okapiHeaders,
@@ -265,6 +275,7 @@ public class LocationUnitAPI implements LocationUnits {
       });
   }
 
+  @Validate
   @Override
   public void getLocationUnitsCampusesById(String id,
     String lang, Map<String, String> okapiHeaders,
@@ -275,6 +286,7 @@ public class LocationUnitAPI implements LocationUnits {
         GetLocationUnitsCampusesByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteLocationUnitsCampusesById(String id,
     String lang, Map<String, String> okapiHeaders,
@@ -284,6 +296,7 @@ public class LocationUnitAPI implements LocationUnits {
         DeleteLocationUnitsCampusesByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void putLocationUnitsCampusesById(
     String id,
@@ -302,6 +315,7 @@ public class LocationUnitAPI implements LocationUnits {
   }
 
   ////////////////////////////////////////////
+  @Validate
   @Override
   public void deleteLocationUnitsLibraries(String lang,
     Map<String, String> okapiHeaders,
@@ -326,6 +340,7 @@ public class LocationUnitAPI implements LocationUnits {
       });
   }
 
+  @Validate
   @Override
   public void getLocationUnitsLibraries(
     String query, int offset, int limit,
@@ -363,6 +378,7 @@ public class LocationUnitAPI implements LocationUnits {
         });
   }
 
+  @Validate
   @Override
   public void postLocationUnitsLibraries(String lang,
     Loclib entity, Map<String, String> okapiHeaders,
@@ -401,6 +417,7 @@ public class LocationUnitAPI implements LocationUnits {
       });
   }
 
+  @Validate
   @Override
   public void getLocationUnitsLibrariesById(String id,
     String lang, Map<String, String> okapiHeaders,
@@ -411,6 +428,7 @@ public class LocationUnitAPI implements LocationUnits {
         GetLocationUnitsLibrariesByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteLocationUnitsLibrariesById(String id,
     String lang, Map<String, String> okapiHeaders,
@@ -420,6 +438,7 @@ public class LocationUnitAPI implements LocationUnits {
         DeleteLocationUnitsLibrariesByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void putLocationUnitsLibrariesById(
     String id,

--- a/src/main/java/org/folio/rest/impl/MaterialTypeAPI.java
+++ b/src/main/java/org/folio/rest/impl/MaterialTypeAPI.java
@@ -210,6 +210,7 @@ public class MaterialTypeAPI implements MaterialTypes {
     });
   }
 
+  @Validate
   @Override
   public void deleteMaterialTypes(String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {

--- a/src/main/java/org/folio/rest/impl/ModeOfIssuanceAPI.java
+++ b/src/main/java/org/folio/rest/impl/ModeOfIssuanceAPI.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.rest.RestVerticle;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.IssuanceMode;
 import org.folio.rest.jaxrs.model.IssuanceModes;
 import org.folio.rest.jaxrs.resource.ModesOfIssuance;
@@ -38,6 +39,7 @@ public class ModeOfIssuanceAPI implements ModesOfIssuance {
   private static final Logger LOG = LogManager.getLogger();
   private static final Messages MESSAGES = Messages.getInstance();
 
+  @Validate
   @Override
   public void deleteModesOfIssuance(String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -69,6 +71,7 @@ public class ModeOfIssuanceAPI implements ModesOfIssuance {
     }
   }
 
+  @Validate
   @Override
   public void getModesOfIssuance(String query, int offset, int limit, String lang,
     Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
@@ -113,6 +116,7 @@ public class ModeOfIssuanceAPI implements ModesOfIssuance {
     });
   }
 
+  @Validate
   @Override
   public void postModesOfIssuance(String lang, IssuanceMode entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
     Context vertxContext) {
@@ -161,12 +165,14 @@ public class ModeOfIssuanceAPI implements ModesOfIssuance {
     });
   }
 
+  @Validate
   @Override
   public void getModesOfIssuanceByModeOfIssuanceId(String modeOfIssuanceId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.getById(RESOURCE_TABLE, IssuanceMode.class, modeOfIssuanceId, okapiHeaders, vertxContext,
         GetModesOfIssuanceByModeOfIssuanceIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteModesOfIssuanceByModeOfIssuanceId(String modeOfIssuanceId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -203,6 +209,7 @@ public class ModeOfIssuanceAPI implements ModesOfIssuance {
     });
   }
 
+  @Validate
   @Override
   public void putModesOfIssuanceByModeOfIssuanceId(String modeOfIssuanceId, String lang, IssuanceMode entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {

--- a/src/main/java/org/folio/rest/impl/NatureOfContentTermAPI.java
+++ b/src/main/java/org/folio/rest/impl/NatureOfContentTermAPI.java
@@ -10,6 +10,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.NatureOfContentTerm;
 import org.folio.rest.jaxrs.model.NatureOfContentTerms;
 import org.folio.rest.persist.Criteria.Limit;
@@ -40,7 +41,7 @@ public class NatureOfContentTermAPI implements org.folio.rest.jaxrs.resource.Nat
   private static final Logger log             = LogManager.getLogger();
   private final Messages messages             = Messages.getInstance();
 
-
+  @Validate
   @Override
   public void getNatureOfContentTerms(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     /**
@@ -78,6 +79,7 @@ public class NatureOfContentTermAPI implements org.folio.rest.jaxrs.resource.Nat
     });
   }
 
+  @Validate
   @Override
   public void postNatureOfContentTerms(String lang, NatureOfContentTerm entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -111,12 +113,14 @@ public class NatureOfContentTermAPI implements org.folio.rest.jaxrs.resource.Nat
     });
   }
 
+  @Validate
   @Override
   public void getNatureOfContentTermsById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.getById(REFERENCE_TABLE, NatureOfContentTerm.class, id, okapiHeaders,
       vertxContext, GetNatureOfContentTermsByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteNatureOfContentTermsById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -151,6 +155,7 @@ public class NatureOfContentTermAPI implements org.folio.rest.jaxrs.resource.Nat
     });
   }
 
+  @Validate
   @Override
   public void putNatureOfContentTermsById(String id, String lang, NatureOfContentTerm entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {

--- a/src/main/java/org/folio/rest/impl/OaiPmhViewInstancesAPI.java
+++ b/src/main/java/org/folio/rest/impl/OaiPmhViewInstancesAPI.java
@@ -3,7 +3,6 @@ package org.folio.rest.impl;
 import java.util.Map;
 import java.util.UUID;
 
-import javax.validation.constraints.Pattern;
 import javax.ws.rs.core.Response;
 
 import org.folio.rest.annotations.Validate;
@@ -48,7 +47,7 @@ public class OaiPmhViewInstancesAPI extends AbstractInstanceRecordsAPI implement
 
   @Validate
   @Override
-  public void getOaiPmhViewUpdatedInstanceIds(String startDate, String endDate, boolean deletedRecordSupport, boolean skipSuppressedFromDiscoveryRecords, @Pattern(regexp = "[a-zA-Z]{2}") String lang, RoutingContext routingContext,
+  public void getOaiPmhViewUpdatedInstanceIds(String startDate, String endDate, boolean deletedRecordSupport, boolean skipSuppressedFromDiscoveryRecords, String lang, RoutingContext routingContext,
       Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
 
     fetchRecordsByQuery(SQL_UPDATED_INSTANCES_IDS,

--- a/src/main/java/org/folio/rest/impl/ReindexInstanceAPI.java
+++ b/src/main/java/org/folio/rest/impl/ReindexInstanceAPI.java
@@ -9,11 +9,13 @@ import io.vertx.core.Handler;
 import java.util.Map;
 import javax.ws.rs.core.Response;
 import org.folio.persist.ReindexJobRepository;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.ReindexJob;
 import org.folio.rest.jaxrs.resource.InstanceStorageReindex;
 import org.folio.services.reindex.ReindexService;
 
 public class ReindexInstanceAPI implements InstanceStorageReindex {
+  @Validate
   @Override
   public void postInstanceStorageReindex(Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -25,6 +27,7 @@ public class ReindexInstanceAPI implements InstanceStorageReindex {
         PostInstanceStorageReindexResponse.respond500WithTextPlain(error.getMessage()))));
   }
 
+  @Validate
   @Override
   public void getInstanceStorageReindexById(String id, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -33,6 +36,7 @@ public class ReindexInstanceAPI implements InstanceStorageReindex {
       vertxContext, GetInstanceStorageReindexByIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteInstanceStorageReindexById(String id, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {

--- a/src/main/java/org/folio/rest/impl/ServicePointAPI.java
+++ b/src/main/java/org/folio/rest/impl/ServicePointAPI.java
@@ -10,6 +10,7 @@ import javax.ws.rs.core.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.RestVerticle;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.HoldShelfExpiryPeriod;
 import org.folio.rest.jaxrs.model.Servicepoint;
 import org.folio.rest.jaxrs.model.Servicepoints;
@@ -58,6 +59,7 @@ public class ServicePointAPI implements org.folio.rest.jaxrs.resource.ServicePoi
     return false;
   }
 
+  @Validate
   @Override
   public void deleteServicePoints(String lang, Map<String, String> okapiHeaders,
           Handler<AsyncResult<Response>> asyncResultHandler,
@@ -90,6 +92,7 @@ public class ServicePointAPI implements org.folio.rest.jaxrs.resource.ServicePoi
     });
   }
 
+  @Validate
   @Override
   public void getServicePoints(String query, int offset, int limit, String lang,
           Map<String, String> okapiHeaders,
@@ -100,6 +103,7 @@ public class ServicePointAPI implements org.folio.rest.jaxrs.resource.ServicePoi
         query, offset, limit, okapiHeaders, vertxContext, GetServicePointsResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void postServicePoints(String lang, Servicepoint entity,
           Map<String, String> okapiHeaders,
@@ -155,6 +159,7 @@ public class ServicePointAPI implements org.folio.rest.jaxrs.resource.ServicePoi
     });
   }
 
+  @Validate
   @Override
   public void getServicePointsByServicepointId(String servicepointId,
           String lang, Map<String, String> okapiHeaders,
@@ -165,6 +170,7 @@ public class ServicePointAPI implements org.folio.rest.jaxrs.resource.ServicePoi
         GetServicePointsByServicepointIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteServicePointsByServicepointId(String servicepointId,
           String lang, Map<String, String> okapiHeaders,
@@ -214,6 +220,7 @@ public class ServicePointAPI implements org.folio.rest.jaxrs.resource.ServicePoi
     });
   }
 
+  @Validate
   @Override
   public void putServicePointsByServicepointId(String servicepointId,
           String lang, Servicepoint entity, Map<String, String> okapiHeaders,

--- a/src/main/java/org/folio/rest/impl/ServicePointsUserAPI.java
+++ b/src/main/java/org/folio/rest/impl/ServicePointsUserAPI.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import javax.ws.rs.core.Response;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.ServicePointsUser;
 import org.folio.rest.jaxrs.model.ServicePointsUsers;
 import org.folio.rest.persist.PgUtil;
@@ -21,6 +22,7 @@ public class ServicePointsUserAPI implements org.folio.rest.jaxrs.resource.Servi
   private static final Logger logger = LogManager.getLogger();
   private static final String SERVICE_POINT_USER_TABLE = "service_point_user";
 
+  @Validate
   @Override
   public void deleteServicePointsUsers(String lang, Map<String, String> okapiHeaders,
     Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
@@ -41,6 +43,7 @@ public class ServicePointsUserAPI implements org.folio.rest.jaxrs.resource.Servi
     });
   }
 
+  @Validate
   @Override
   public void getServicePointsUsers(String query, int offset, int limit,
     String lang, Map<String, String> okapiHeaders,
@@ -51,6 +54,7 @@ public class ServicePointsUserAPI implements org.folio.rest.jaxrs.resource.Servi
       asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void postServicePointsUsers(String lang, ServicePointsUser entity,
     Map<String, String> okapiHeaders,
@@ -60,6 +64,7 @@ public class ServicePointsUserAPI implements org.folio.rest.jaxrs.resource.Servi
       PostServicePointsUsersResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void getServicePointsUsersByServicePointsUserId(String servicePointsUserId,
     String lang, Map<String, String> okapiHeaders,
@@ -70,6 +75,7 @@ public class ServicePointsUserAPI implements org.folio.rest.jaxrs.resource.Servi
       asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteServicePointsUsersByServicePointsUserId(String servicePointsUserId,
     String lang, Map<String, String> okapiHeaders,
@@ -79,6 +85,7 @@ public class ServicePointsUserAPI implements org.folio.rest.jaxrs.resource.Servi
       DeleteServicePointsUsersByServicePointsUserIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void putServicePointsUsersByServicePointsUserId(String servicePointsUserId,
     String lang, ServicePointsUser entity, Map<String, String> okapiHeaders,

--- a/src/main/java/org/folio/rest/impl/ShelfLocationAPI.java
+++ b/src/main/java/org/folio/rest/impl/ShelfLocationAPI.java
@@ -21,6 +21,8 @@ import java.util.ArrayList;
 import org.apache.commons.lang3.NotImplementedException;
 import static org.folio.rest.impl.LocationAPI.LOCATION_TABLE;
 import static org.folio.rest.impl.StorageHelper.*;
+
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Location;
 
 /**
@@ -39,6 +41,7 @@ public class ShelfLocationAPI implements ShelfLocations {
    * Get a list of the new locations, and fake old kind of shelf-locations out
    * of them.
    */
+  @Validate
   @Override
   public void getShelfLocations(
         String query,
@@ -91,6 +94,7 @@ public class ShelfLocationAPI implements ShelfLocations {
    * Get a new-kind of Location object, and convert it to old-style
    * shelf-location.
    */
+  @Validate
   @Override
   public void getShelfLocationsById(
     String id,
@@ -117,6 +121,7 @@ public class ShelfLocationAPI implements ShelfLocations {
         });
   }
 
+  @Validate
   @Override
   public void postShelfLocations(
           String lang,
@@ -127,6 +132,7 @@ public class ShelfLocationAPI implements ShelfLocations {
     throw new NotImplementedException("Creating shelf-locations is DEPRECATED. " + USE_NEW);
   }
 
+  @Validate
   @Override
   public void deleteShelfLocations(
     String lang,
@@ -136,6 +142,7 @@ public class ShelfLocationAPI implements ShelfLocations {
     throw new NotImplementedException("Deleting shelf-locations is DEPRECATED. " + USE_NEW);
   }
 
+  @Validate
   @Override
   public void deleteShelfLocationsById(
           String id,
@@ -145,6 +152,7 @@ public class ShelfLocationAPI implements ShelfLocations {
     throw new NotImplementedException("Deleting shelf-locations is DEPRECATED. " + USE_NEW);
   }
 
+  @Validate
   @Override
   public void putShelfLocationsById(
           String id,

--- a/src/main/java/org/folio/rest/impl/StatisticalCodeAPI.java
+++ b/src/main/java/org/folio/rest/impl/StatisticalCodeAPI.java
@@ -9,6 +9,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.StatisticalCode;
 import org.folio.rest.jaxrs.model.StatisticalCodes;
 import org.folio.rest.persist.Criteria.Limit;
@@ -37,6 +38,7 @@ public class StatisticalCodeAPI implements org.folio.rest.jaxrs.resource.Statist
   private static final Logger LOG = LogManager.getLogger();
   private static final Messages MESSAGES = Messages.getInstance();
 
+  @Validate
   @Override
   public void getStatisticalCodes(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     /**
@@ -82,6 +84,7 @@ public class StatisticalCodeAPI implements org.folio.rest.jaxrs.resource.Statist
 
   }
 
+  @Validate
   @Override
   public void postStatisticalCodes(String lang, StatisticalCode entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -121,12 +124,14 @@ public class StatisticalCodeAPI implements org.folio.rest.jaxrs.resource.Statist
     });
   }
 
+  @Validate
   @Override
   public void getStatisticalCodesByStatisticalCodeId(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.getById(REFERENCE_TABLE, StatisticalCode.class, id, okapiHeaders, vertxContext,
         GetStatisticalCodesByStatisticalCodeIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteStatisticalCodesByStatisticalCodeId(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -167,6 +172,7 @@ public class StatisticalCodeAPI implements org.folio.rest.jaxrs.resource.Statist
     });
   }
 
+  @Validate
   @Override
   public void putStatisticalCodesByStatisticalCodeId(String id, String lang, StatisticalCode entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {

--- a/src/main/java/org/folio/rest/impl/StatisticalCodeTypeAPI.java
+++ b/src/main/java/org/folio/rest/impl/StatisticalCodeTypeAPI.java
@@ -11,6 +11,7 @@ import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.cql2pgjson.exception.FieldException;
 import org.folio.rest.RestVerticle;
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.StatisticalCodeType;
 import org.folio.rest.jaxrs.model.StatisticalCodeTypes;
 import org.folio.rest.persist.Criteria.Limit;
@@ -37,6 +38,7 @@ public class StatisticalCodeTypeAPI implements org.folio.rest.jaxrs.resource.Sta
   private static final Logger LOG = LogManager.getLogger();
   private static final Messages MESSAGES = Messages.getInstance();
 
+  @Validate
   @Override
   public void deleteStatisticalCodeTypes(String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     String tenantId = TenantTool.tenantId(okapiHeaders);
@@ -66,6 +68,7 @@ public class StatisticalCodeTypeAPI implements org.folio.rest.jaxrs.resource.Sta
     }
   }
 
+  @Validate
   @Override
   public void getStatisticalCodeTypes(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -107,6 +110,7 @@ public class StatisticalCodeTypeAPI implements org.folio.rest.jaxrs.resource.Sta
     });
   }
 
+  @Validate
   @Override
   public void postStatisticalCodeTypes(String lang, StatisticalCodeType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -154,12 +158,14 @@ public class StatisticalCodeTypeAPI implements org.folio.rest.jaxrs.resource.Sta
     });
   }
 
+  @Validate
   @Override
   public void getStatisticalCodeTypesByStatisticalCodeTypeId(String statisticalCodeTypeId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.getById(RESOURCE_TABLE, StatisticalCodeType.class, statisticalCodeTypeId, okapiHeaders, vertxContext,
         GetStatisticalCodeTypesByStatisticalCodeTypeIdResponse.class, asyncResultHandler);
   }
 
+  @Validate
   @Override
   public void deleteStatisticalCodeTypesByStatisticalCodeTypeId(String statisticalCodeTypeId, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {
@@ -196,6 +202,7 @@ public class StatisticalCodeTypeAPI implements org.folio.rest.jaxrs.resource.Sta
     });
   }
 
+  @Validate
   @Override
   public void putStatisticalCodeTypesByStatisticalCodeTypeId(String statisticalCodeTypeId, String lang, StatisticalCodeType entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     vertxContext.runOnContext(v -> {


### PR DESCRIPTION
Many APIs are missing the `@Validate` annotation on the
implementing method (on the method, not on the method parameters).

Adding it makes RMB validate all method parameters against the
RAML definition.

If a method has a `@Validate` annotation added to a method
parameter like `@Min(0) @Max(2147483647) int offset`
it must be removed because it causes this error:

`HV000151: A method overriding another method must not redefine
the parameter constraint configuration`