### PR TITLE
MODINVSTOR-827 Clean kafka topics on tenant delete

### DIFF
--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -164,7 +164,7 @@ public class TenantRefAPI extends TenantAPI {
                          Handler<AsyncResult<Response>> handler, Context context) {
     // delete Kafka topics if tenant purged
     Future.succeededFuture()
-      .compose(x -> tenantAttributes.getPurge()
+      .compose(x -> tenantAttributes.getPurge() != null && tenantAttributes.getPurge()
         ? new KafkaAdminClientService(context.owner()).deleteKafkaTopics(TenantTool.tenantId(headers), environmentName())
         : Future.succeededFuture())
       .onComplete(x -> super.postTenant(tenantAttributes, headers, handler, context));

--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -163,11 +163,10 @@ public class TenantRefAPI extends TenantAPI {
   public void postTenant(TenantAttributes tenantAttributes, Map<String, String> headers,
                          Handler<AsyncResult<Response>> handler, Context context) {
     // delete Kafka topics if tenant purged
-    Future.succeededFuture()
-      .compose(x -> tenantAttributes.getPurge() != null && tenantAttributes.getPurge()
-        ? new KafkaAdminClientService(context.owner()).deleteKafkaTopics(TenantTool.tenantId(headers), environmentName())
-        : Future.succeededFuture())
-      .onComplete(x -> super.postTenant(tenantAttributes, headers, handler, context));
+    Future<Void> result = tenantAttributes.getPurge() != null && tenantAttributes.getPurge()
+      ? new KafkaAdminClientService(context.owner()).deleteKafkaTopics(TenantTool.tenantId(headers), environmentName())
+      : Future.succeededFuture();
+    result.onComplete(x -> super.postTenant(tenantAttributes, headers, handler, context));
   }
 
   private Future<Void> runJavaMigrations(TenantAttributes ta, Context context,

--- a/src/main/java/org/folio/services/kafka/topic/KafkaAdminClientService.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaAdminClientService.java
@@ -1,26 +1,26 @@
 package org.folio.services.kafka.topic;
 
-import static io.vertx.core.Future.succeededFuture;
-import static io.vertx.kafka.admin.KafkaAdminClient.create;
-import static org.apache.logging.log4j.LogManager.getLogger;
-import static org.folio.services.kafka.KafkaProperties.getReplicationFactor;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.admin.KafkaAdminClient;
+import io.vertx.kafka.admin.NewTopic;
+import org.apache.logging.log4j.Logger;
+import org.folio.kafka.KafkaConfig;
+import org.folio.services.kafka.KafkaProperties;
+import org.folio.util.ResourceUtil;
 
 import java.util.List;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-import org.apache.logging.log4j.Logger;
-import org.folio.kafka.KafkaConfig;
-import org.folio.services.kafka.KafkaProperties;
-import org.folio.util.ResourceUtil;
-
-import io.vertx.core.Future;
-import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.kafka.admin.KafkaAdminClient;
-import io.vertx.kafka.admin.NewTopic;
+import static io.vertx.core.Future.succeededFuture;
+import static io.vertx.kafka.admin.KafkaAdminClient.create;
+import static org.apache.logging.log4j.LogManager.getLogger;
+import static org.folio.services.kafka.KafkaProperties.getReplicationFactor;
 
 public class KafkaAdminClientService {
   private static final Logger log = getLogger(KafkaAdminClientService.class);
@@ -53,11 +53,34 @@ public class KafkaAdminClientService {
             log.error("Failed to close kafka admin client", closeResult.cause());
           }
         });
+      });
+  }
+
+  public Future<Void> deleteKafkaTopics(String tenantId, String environmentName) {
+    Promise<Void> result = Promise.promise();
+    final KafkaAdminClient kafkaAdminClient = clientFactory.get();
+    List<String> topicsToDelete = readTopics()
+      .map(topic -> qualifyName(topic, environmentName, tenantId))
+      .map(NewTopic::getName)
+      .collect(Collectors.toList());
+    kafkaAdminClient.deleteTopics(topicsToDelete, result);
+    result.future().onComplete(res -> {
+      if (res.succeeded()) {
+        log.info("Topics deleted successfully");
+      } else {
+        log.error("Unable to delete topics", res.cause());
+      }
+      kafkaAdminClient.close().onComplete(closeResult -> {
+        if (closeResult.failed()) {
+          log.error("Failed to close kafka admin client", closeResult.cause());
+        }
+      });
     });
+    return result.future();
   }
 
   private Future<Void> createKafkaTopics(String tenantId, String environmentName,
-    KafkaAdminClient kafkaAdminClient) {
+                                         KafkaAdminClient kafkaAdminClient) {
 
     final List<NewTopic> expectedTopics = readTopics()
       .map(topic -> qualifyName(topic, environmentName, tenantId))

--- a/src/main/java/org/folio/services/kafka/topic/KafkaAdminClientService.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaAdminClientService.java
@@ -57,14 +57,15 @@ public class KafkaAdminClientService {
   }
 
   public Future<Void> deleteKafkaTopics(String tenantId, String environmentName) {
+    Promise<Void> promise = Promise.promise();
     Promise<Void> result = Promise.promise();
     final KafkaAdminClient kafkaAdminClient = clientFactory.get();
     List<String> topicsToDelete = readTopics()
       .map(topic -> qualifyName(topic, environmentName, tenantId))
       .map(NewTopic::getName)
       .collect(Collectors.toList());
-    kafkaAdminClient.deleteTopics(topicsToDelete, result);
-    result.future().onComplete(res -> {
+    kafkaAdminClient.deleteTopics(topicsToDelete, promise);
+    promise.future().onComplete(res -> {
       if (res.succeeded()) {
         log.info("Topics deleted successfully");
       } else {
@@ -75,6 +76,7 @@ public class KafkaAdminClientService {
           log.error("Failed to close kafka admin client", closeResult.cause());
         }
       });
+      result.complete();
     });
     return result.future();
   }

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -63,7 +63,6 @@ import org.testcontainers.utility.DockerImageName;
   ItemDamagedStatusAPITest.class,
   ItemDamagedStatusAPIUnitTest.class,
   ItemEffectiveLocationTest.class,
-  SampleDataTest.class,
   HridSettingsStorageTest.class,
   HridSettingsStorageParameterizedTest.class,
   ItemCopyNumberMigrationScriptTest.class,
@@ -88,7 +87,8 @@ import org.testcontainers.utility.DockerImageName;
   PublicationPeriodMigrationTest.class,
   LegacyItemEffectiveLocationMigrationScriptTest.class,
   IterationJobRunnerTest.class,
-  AuthorityStorageTest.class
+  AuthorityStorageTest.class,
+  SampleDataTest.class
 })
 public class StorageTestSuite {
   public static final String TENANT_ID = "test_tenant";

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -52,7 +52,7 @@ public final class DomainEventAssertions {
    * <a href="https://issues.folio.org/browse/MODINVSTOR-754">MODINVSTOR-754</a>
    */
   private static ConditionFactory await() {
-    return Awaitility.await().atMost(2, SECONDS);
+    return Awaitility.await().atMost(5, SECONDS);
   }
 
   private static void assertCreateEvent(KafkaConsumerRecord<String, JsonObject> createEvent, JsonObject newRecord) {


### PR DESCRIPTION
### Purpose/Overview:
There are a lot of unused topics that can be on envs with several tenants. To decrease pressure on consumers modules it’s nice to clean unused topics in Kafka.

### Approach:

Delete topics for the tenant on the tenant delete operation