### PR TITLE
Describe how mod-source-record-storage  source records are not automatically deleted MODINVSTOR-828

### DIFF
--- a/ramls/instance-storage.raml
+++ b/ramls/instance-storage.raml
@@ -115,7 +115,7 @@ resourceTypes:
                   example: "Internal server error, contact administrator"
           description: |
             Delete the source record.
-            Note: The source records gets automatically deleted when its instance record is deleted.
+            Note: When the Inventory instance record is deleted, its source record in mod-inventory-storage is automatically deleted. If the Inventory instance record is linked to a corresponding record in mod-source-record-storage, that SRS record is NOT automatically deleted.
         /marc-json:
           displayName: MARC source record as JSON
           is: [language]


### PR DESCRIPTION
The presence of source records in mod-inventory-storage creates ambiguity between them and source records defined in mod-source-record-storage.

This has led to folks thinking that documentation in this module about automatic source record deletion, that refers to source records, refers to source records in mod-source-record-storage rather than in this module.

It has been requested that we change the wording to remove that ambiguity. The new wording has been provided by @a-mbreaux 

(Personally, I don't think these kinds of reference to other modules were intended in an interface definition, however I'm changing it at folks request)