### PR TITLE
MODINVSTOR-832: Adding admin notes field to instance records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 22.1.0 IN-PROGRESS
+
+* Added Administrative notes to instance records (MODINVSTOR-832)
+
 ## 22.0.0 2021-10-06
 
 * Added new identifiers for ISMN and UPC (MODINVSTOR-770)

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -331,7 +331,7 @@
     },
     "notes": {
       "type": "array",
-      "description": "Bibliographic notes (e.g. general notes, specialized notes), and administrative notes",
+      "description": "Bibliographic notes (e.g. general notes, specialized notes)",
       "items": {
         "type": "object",
         "properties": {
@@ -349,6 +349,14 @@
             "default": false
           }
         }
+      }
+    },
+    "adminNotes":{
+      "type": "array",
+      "description": "Administrative notes",
+      "minItems": 0,
+      "items": {
+        "type": "string"
       }
     },
     "modeOfIssuanceId": {

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -351,7 +351,7 @@
         }
       }
     },
-    "adminNotes":{
+    "administrativeNotes":{
       "type": "array",
       "description": "Administrative notes",
       "minItems": 0,

--- a/sample-data/instances/bridget-jones-baby.json
+++ b/sample-data/instances/bridget-jones-baby.json
@@ -25,6 +25,9 @@
     "Humorous fiction",
     "Diary fiction"
   ],
+  "adminNotes": [
+    "Cataloging data"
+  ],
   "classifications": [
     {
       "classificationTypeId": "ce176ace-a53e-4b4d-aa89-725ed7b2edac",

--- a/sample-data/instances/bridget-jones-baby.json
+++ b/sample-data/instances/bridget-jones-baby.json
@@ -25,7 +25,7 @@
     "Humorous fiction",
     "Diary fiction"
   ],
-  "adminNotes": [
+  "administrativeNotes": [
     "Cataloging data"
   ],
   "classifications": [

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -157,10 +157,12 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       .toArray(String[]::new);
 
     var publication = new Publication().withDateOfPublication("2000-2001");
+    String adminNote = "Administrative note";
 
     JsonObject instanceToCreate = smallAngryPlanet(id);
     instanceToCreate.put("natureOfContentTermIds", Arrays.asList(natureOfContentIds));
     instanceToCreate.put("publication", new JsonArray().add(JsonObject.mapFrom(publication)));
+    instanceToCreate.put("adminNotes", new JsonArray().add(adminNote));
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
@@ -176,6 +178,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(instance.getString("id"), is(id.toString()));
     assertThat(instance.getString("title"), is("Long Way to a Small Angry Planet"));
     assertThat(instance.getBoolean("previouslyHeld"), is(false));
+    assertThat(instance.getJsonArray("adminNotes").contains(adminNote), is(true));
 
     JsonArray identifiers = instance.getJsonArray("identifiers");
     assertThat(identifiers.size(), is(1));
@@ -379,10 +382,12 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     ExecutionException, TimeoutException {
 
     UUID id = UUID.randomUUID();
+    String adminNote = "An Admin note";
     final IndividualResource createdInstance = createInstance(smallAngryPlanet(id));
 
     JsonObject replacement = createdInstance.copyJson();
     replacement.put("title", "A Long Way to a Small Angry Planet");
+    replacement.put("adminNotes", new JsonArray().add(adminNote));
 
     CompletableFuture<Response> replaceCompleted = new CompletableFuture<>();
 
@@ -406,6 +411,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       is(replacement.getString(STATUS_UPDATED_DATE_PROPERTY)));
     assertThat(itemFromGet.getBoolean(DISCOVERY_SUPPRESS), is(false));
     assertUpdateEventForInstance(createdInstance.getJson(), updatedInstance.getJson());
+    assertThat(itemFromGet.getJsonArray("adminNotes").contains(adminNote), is(true));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -162,7 +162,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     JsonObject instanceToCreate = smallAngryPlanet(id);
     instanceToCreate.put("natureOfContentTermIds", Arrays.asList(natureOfContentIds));
     instanceToCreate.put("publication", new JsonArray().add(JsonObject.mapFrom(publication)));
-    instanceToCreate.put("adminNotes", new JsonArray().add(adminNote));
+    instanceToCreate.put("administrativeNotes", new JsonArray().add(adminNote));
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
@@ -178,7 +178,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(instance.getString("id"), is(id.toString()));
     assertThat(instance.getString("title"), is("Long Way to a Small Angry Planet"));
     assertThat(instance.getBoolean("previouslyHeld"), is(false));
-    assertThat(instance.getJsonArray("adminNotes").contains(adminNote), is(true));
+    assertThat(instance.getJsonArray("administrativeNotes").contains(adminNote), is(true));
 
     JsonArray identifiers = instance.getJsonArray("identifiers");
     assertThat(identifiers.size(), is(1));
@@ -387,7 +387,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject replacement = createdInstance.copyJson();
     replacement.put("title", "A Long Way to a Small Angry Planet");
-    replacement.put("adminNotes", new JsonArray().add(adminNote));
+    replacement.put("administrativeNotes", new JsonArray().add(adminNote));
 
     CompletableFuture<Response> replaceCompleted = new CompletableFuture<>();
 
@@ -411,7 +411,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       is(replacement.getString(STATUS_UPDATED_DATE_PROPERTY)));
     assertThat(itemFromGet.getBoolean(DISCOVERY_SUPPRESS), is(false));
     assertUpdateEventForInstance(createdInstance.getJson(), updatedInstance.getJson());
-    assertThat(itemFromGet.getJsonArray("adminNotes").contains(adminNote), is(true));
+    assertThat(itemFromGet.getJsonArray("administrativeNotes").contains(adminNote), is(true));
   }
 
   @Test


### PR DESCRIPTION
Not a lot to say here-I changed the json description of the records
so that it would have this field.  I also added it to one of the sample 
records.  Then I modified existing tests to set the field to verify 
that it works.