### PR TITLE
MODINVSTOR-841: Spurious failures canCalculateEffectiveCallNumberPropertyOnUpdate

### DIFF
--- a/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
@@ -257,9 +257,9 @@ public class ItemEffectiveCallNumberComponentsTest extends TestBaseWithInventory
         var lastItemEvent = getLastItemEvent(instanceId, itemId);
         assertTrue(lastItemEvent
           .value().getJsonObject("new").getInteger("_version") > 1);
+        assertUpdateEventForItem(itemAfterHoldingsUpdate,
+            itemsClient.getById(createdItem.getId()).getJson());
       });
-      assertUpdateEventForItem(itemAfterHoldingsUpdate,
-        itemsClient.getById(createdItem.getId()).getJson());
     }
 
     final JsonObject updatedItem = itemsClient.getById(createdItem.getId()).getJson();


### PR DESCRIPTION
The spurious test failures indicate that the _version property
is still 1 but is expected to be 2.