### PR TITLE
Fix test LogToDb..canHandleFailure MODINVSTOR-840

### DIFF
--- a/src/test/java/org/folio/services/domainevent/LogToDbFailureHandlerTest.java
+++ b/src/test/java/org/folio/services/domainevent/LogToDbFailureHandlerTest.java
@@ -40,5 +40,5 @@ public class LogToDbFailureHandlerTest {
     assertThat(notificationSendingError.getPayload(), is("value"));
     assertThat(notificationSendingError.getError(), containsString("IllegalArgumentException: null"));
     assertThat(notificationSendingError.getIncidentDateTime()
-      .before(new Date()), Matchers.is(true));  }
+      .after(new Date()), Matchers.is(false));  }
 }


### PR DESCRIPTION
Loosen date check, as current date and incidental date
may be equal (on a fast system).