### PR TITLE
FOLIO supports PostgreSQL 12 only.

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -16,7 +16,7 @@ Provides PostgreSQL based storage to complement the [inventory module](http://gi
 - Java 11 JDK
 - Maven 3.3.9
 - Docker ([minimum requirements](https://www.testcontainers.org/supported_docker_environment/))
-- Postgres 9.6.1 (running and listening on localhost:5432, logged in user must have admin rights)
+- Postgres 12 (running and listening on localhost:5432, logged in user must have admin rights)
 - Kafka 2.6 (running and listening on localhost:9092)
 - Node 6.4.0 (for API linting and documentation generation)
 - NPM 3.10.3 (for API linting and documentation generation)


### PR DESCRIPTION
For development and reference environments FOLIO uses PostgreSQL 12,
this is the only version that FOLIO officially supports:
https://issues.folio.org/browse/FOLIO-2145

This pull request
https://github.com/folio-org/mod-inventory-storage/pull/700/files
https://issues.folio.org/browse/MODINVSTOR-676
"Add statistical code ids exists constraint for item create/update"
uses
`CREATE TRIGGER ... EXECUTE FUNCTION` syntax that is available
from PostgreSQL 11 but not in older versions:
https://www.postgresql.org/docs/11/sql-createtrigger.html
https://www.postgresql.org/docs/10/sql-createtrigger.html