### PR TITLE
MODINVSTOR-817 Remove "bound-with" tag

### DIFF
--- a/sample-data/bound-with/instances/bwinst0001.json
+++ b/sample-data/bound-with/instances/bwinst0001.json
@@ -27,7 +27,7 @@
   "statisticalCodeIds" : [ ],
   "statusId" : "9634a5ab-9228-4703-baf2-4d12ebc77d56",
   "tags" : {
-    "tagList" : [ "bound-with" ]
+    "tagList" : [ ]
   },
   "natureOfContentTermIds" : [ ],
   "publicationPeriod" : {

--- a/sample-data/bound-with/instances/bwinst0002.json
+++ b/sample-data/bound-with/instances/bwinst0002.json
@@ -35,7 +35,7 @@
   "discoverySuppress" : false,
   "statusId" : "9634a5ab-9228-4703-baf2-4d12ebc77d56",
   "tags" : {
-    "tagList" : [ "bound-with" ]
+    "tagList" : [ ]
   },
   "publicationPeriod" : {
     "start" : 1942

--- a/sample-data/bound-with/instances/bwinst0003.json
+++ b/sample-data/bound-with/instances/bwinst0003.json
@@ -29,7 +29,7 @@
   "discoverySuppress" : false,
   "statusId" : "9634a5ab-9228-4703-baf2-4d12ebc77d56",
   "tags" : {
-    "tagList" : [ "bound-with" ]
+    "tagList" : [ ]
   },
   "publicationPeriod" : {
     "start" : 1942

--- a/sample-data/bound-with/items/bwit000000001.json
+++ b/sample-data/bound-with/items/bwit000000001.json
@@ -9,6 +9,6 @@
   "materialTypeId" : "d9acad2f-2aac-4b48-9097-e6ab85906b25",
   "permanentLoanTypeId" : "2b94c631-fca9-4892-a730-03ee529ffe27",
   "tags" : {
-    "tagList" : [ "bound-with" ]
+    "tagList" : [ ]
   }
 }


### PR DESCRIPTION
### Purpose/Overview:
On references env some tags from instances presented in ES indeed, but not in mod-tags

### Approach:
Remove tags from sample data that are not presented into the mod-tags

### Learn
[MODINVSTOR-817](https://issues.folio.org/browse/MODINVSTOR-817)
[UI Bugfest](https://issues.folio.org/browse/UIIN-1809)

