### PR TITLE
[MODINVSTOR-849] New API for item checkout

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -6,12 +6,12 @@ buildMvn {
   mvnDeploy = 'yes'
   runLintRamlCop = 'yes'
   doKubeDeploy = true
-  publishPreview = false
+  publishPreview = true
   buildNode = 'jenkins-agent-java11'
 
   doDocker = {
     buildJavaDocker {
-      publishPreview = false
+      publishPreview = true
       publishMaster = 'yes'
       healthChk = 'yes'
       healthChkCmd = 'curl -sS --fail -o /dev/null  http://localhost:8081/apidocs/ || exit 1'

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -69,7 +69,7 @@
     },
     {
       "id": "item-storage",
-      "version": "9.0",
+      "version": "9.1",
       "handlers": [
         {
           "methods": ["GET"],
@@ -95,6 +95,11 @@
           "methods": ["DELETE"],
           "pathPattern": "/item-storage/items",
           "permissionsRequired": ["inventory-storage.items.collection.delete"]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/item-storage/items/{id}/check-out",
+          "permissionsRequired": ["inventory-storage.items.item.check-out.post"]
         }
       ]
     },
@@ -1421,6 +1426,11 @@
       "description": "delete individual item from storage"
     },
     {
+      "permissionName": "inventory-storage.items.item.check-out.post",
+      "displayName": "inventory storage - check out an item",
+      "description": "check out an item"
+    },
+    {
       "permissionName": "inventory-storage.items.batch.post",
       "displayName": "inventory storage - create a number of items",
       "description": "create a number of items in storage"
@@ -2463,6 +2473,7 @@
         "inventory-storage.items.item.post",
         "inventory-storage.items.item.put",
         "inventory-storage.items.item.delete",
+        "inventory-storage.items.item.check-out.post",
         "inventory-storage.items.collection.delete",
         "inventory-storage.items.batch.post",
         "inventory-storage.authorities.collection.get",

--- a/ramls/item-storage.raml
+++ b/ramls/item-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Item Storage
-version: v9.0
+version: v9.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 
@@ -55,3 +55,24 @@ resourceTypes:
           exampleItem: !include examples/item_get.json
           schema: item
       get:
+      /check-out:
+        post:
+          description: "Update item record to mark it as checked out"
+          responses:
+            204:
+              description: "Item was updated successfully"
+            404:
+              description: "Item was not found"
+              body:
+                text/plain:
+                  example: "Item was not found"
+            422:
+              description: "Validation errors"
+              body:
+                application/json:
+                  type: errors
+            500:
+              description: "Internal server error"
+              body:
+                text/plain:
+                  example: "Internal server error"

--- a/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageAPI.java
@@ -95,4 +95,14 @@ public class ItemStorageAPI implements ItemStorage {
       .onSuccess(response -> asyncResultHandler.handle(succeededFuture(response)))
       .onFailure(handleFailure(asyncResultHandler));
   }
+
+  @Override
+  @Validate
+  public void postItemStorageItemsCheckOutByItemId(String itemId, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    new ItemService(vertxContext, okapiHeaders).checkOutItem(itemId)
+      .onSuccess(response -> asyncResultHandler.handle(succeededFuture(response)))
+      .onFailure(handleFailure(asyncResultHandler));
+  }
 }

--- a/src/main/java/org/folio/services/item/ItemService.java
+++ b/src/main/java/org/folio/services/item/ItemService.java
@@ -196,6 +196,7 @@ public class ItemService {
       .mapTo(Item.class);
 
     newItem.getStatus().setName(CHECKED_OUT);
+    newItem.setInTransitDestinationServicePointId(null);
 
     return updateExistingItem(item, newItem);
   }

--- a/src/main/java/org/folio/validator/ItemValidator.java
+++ b/src/main/java/org/folio/validator/ItemValidator.java
@@ -1,0 +1,31 @@
+package org.folio.validator;
+
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.rest.jaxrs.model.Status.Name.CHECKED_OUT;
+
+import java.util.List;
+
+import org.folio.rest.exceptions.ValidationException;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.jaxrs.model.Parameter;
+
+import io.vertx.core.Future;
+import lombok.experimental.UtilityClass;
+
+@UtilityClass
+public class ItemValidator {
+
+  public static Future<Item> refuseIfAlreadyCheckedOut(Item item) {
+    return item.getStatus().getName() != CHECKED_OUT
+      ? succeededFuture(item)
+      : failedFuture(new ValidationException(
+        new Errors().withErrors(List.of(
+          new Error().withMessage("Item " + item.getId() + " is already checked out")
+            .withParameters(List.of(
+              new Parameter().withKey("status.name").withValue(CHECKED_OUT.value())))))));
+  }
+
+}

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -2826,14 +2826,12 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(item.getJsonObject("status").getString("name"), is(status.value()));
   }
 
+  @SneakyThrows
   private Response checkOutItem(String itemId) {
     CompletableFuture<Response> postCompleted = new CompletableFuture<>();
     client.post(itemsStorageUrl("/" + itemId + "/check-out"), null,
       StorageTestSuite.TENANT_ID, ResponseHandler.empty(postCompleted));
-    try {
-      return postCompleted.get(5, TimeUnit.SECONDS);
-    } catch (InterruptedException | ExecutionException | TimeoutException e) {
-      throw new RuntimeException(e);
-    }
+
+    return postCompleted.get(5, TimeUnit.SECONDS);
   }
 }


### PR DESCRIPTION
**Purpose**
Expose a new API for updating the item record in scope of a checkout process.
See [MODINVSTOR-849](https://issues.folio.org/browse/MODINVSTOR-849).

**Approach**
- make sure that item exists
- make sure that item is not already checked out
- change item status to `Checked out`
- if item contains `inTransitDestinationServicePointId` property, then remove it (this step was copied from current checkout implementation of mod-circulation)