### PR TITLE
MODINVSTOR-851: Upgrade to RMB 33.1.3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 ## 22.1.0 IN-PROGRESS
 
 * Added administrative notes to item, instance, and holdings records (MODINVSTOR-834, MODINVSTOR-833, MODINVSTOR-832)
+* Upgrade to RMB 33.1.3. (CVE-2021-44228) (MODINVSTOR-851)
 
 ## 22.0.0 2021-10-06
 

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>33.1.1</raml-module-builder-version>
+    <raml-module-builder-version>33.1.3</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/authority-storage/authorities,/record-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances,/inventory-hierarchy/updated-instance-ids,/inventory-hierarchy/items-and-holdings,/inventory-view/instances</generate_routing_context>
     <argLine />
   </properties>


### PR DESCRIPTION
Resolve CVE-2021-44228 as per [MODINVSTOR-851](https://issues.folio.org/browse/MODINVSTOR-851).