### PR TITLE
MODINVSTOR-851: Upgrade to RMB 33.1.3 (Juniper).

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 21.0.10 2021-12-15
+
+* Upgrade to RMB 33.1.3. (CVE-2021-44228) (MODINVSTOR-851)
+
 ## 21.0.9 2021-10-05
 
 * Fix memory leaks by closing Vertx Kafka producers (MODINVSTOR-794)

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>33.1.1</raml-module-builder-version>
+    <raml-module-builder-version>33.1.3</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/record-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances,/inventory-hierarchy/updated-instance-ids,/inventory-hierarchy/items-and-holdings,/inventory-view/instances</generate_routing_context>
     <argLine />
   </properties>


### PR DESCRIPTION
Resolve CVE-2021-44228 as per [MODINVSTOR-851](https://issues.folio.org/browse/MODINVSTOR-851).