### PR TITLE
MODINVSTOR-867 publish isBoundWith in search results

### DIFF
--- a/ramls/inventory-view-instance.json
+++ b/ramls/inventory-view-instance.json
@@ -7,6 +7,10 @@
       "description": "Instance id",
       "$ref": "uuid.json"
     },
+    "isBoundWith": {
+      "description": "Records the relationship between a part of a bound-with (a holdings-record) and the bound-with as a whole (the circulatable item)",
+      "type": "boolean"
+    },
     "instance": {
       "description": "Instance record",
       "$ref": "instance.json"

--- a/src/main/java/org/folio/persist/BoundWithRepository.java
+++ b/src/main/java/org/folio/persist/BoundWithRepository.java
@@ -1,0 +1,15 @@
+package org.folio.persist;
+
+import io.vertx.core.Context;
+import org.folio.rest.jaxrs.model.BoundWithPart;
+
+import java.util.Map;
+
+import static org.folio.rest.impl.BoundWithPartAPI.BOUND_WITH_TABLE;
+import static org.folio.rest.persist.PgUtil.postgresClient;
+
+public class BoundWithRepository extends AbstractRepository<BoundWithPart> {
+  public BoundWithRepository(Context context, Map<String, String> okapiHeaders) {
+    super(postgresClient(context, okapiHeaders), BOUND_WITH_TABLE, BoundWithPart.class);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/BoundWithPartAPI.java
+++ b/src/main/java/org/folio/rest/impl/BoundWithPartAPI.java
@@ -6,26 +6,32 @@ import io.vertx.core.Handler;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.BoundWithPart;
 import org.folio.rest.jaxrs.model.BoundWithParts;
+import org.folio.rest.jaxrs.resource.InventoryStorageBoundWithParts;
 import org.folio.rest.persist.PgUtil;
+import org.folio.services.instance.BoundWithPartService;
 
 import javax.ws.rs.core.Response;
 import java.util.Map;
 
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.rest.support.EndpointFailureHandler.handleFailure;
+
 public class BoundWithPartAPI implements org.folio.rest.jaxrs.resource.InventoryStorageBoundWithParts {
-  private static final String BOUND_WITH_TABLE = "bound_with_part";
+  public static final String BOUND_WITH_TABLE = "bound_with_part";
 
   @Validate
   @Override
   public void getInventoryStorageBoundWithParts(String query, int offset, int limit, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     PgUtil.get(BOUND_WITH_TABLE, BoundWithPart.class, BoundWithParts.class, query, offset, limit,
-      okapiHeaders, vertxContext, org.folio.rest.jaxrs.resource.InventoryStorageBoundWithParts.GetInventoryStorageBoundWithPartsResponse.class, asyncResultHandler);
+      okapiHeaders, vertxContext, InventoryStorageBoundWithParts.GetInventoryStorageBoundWithPartsResponse.class, asyncResultHandler);
   }
 
   @Validate
   @Override
   public void postInventoryStorageBoundWithParts(String lang, BoundWithPart entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.post(BOUND_WITH_TABLE, entity, okapiHeaders, vertxContext,
-      PostInventoryStorageBoundWithPartsResponse.class, asyncResultHandler);
+    new BoundWithPartService(vertxContext, okapiHeaders).create(entity)
+      .onSuccess(response -> asyncResultHandler.handle(succeededFuture(response)))
+      .onFailure(handleFailure(asyncResultHandler));
   }
 
   @Validate
@@ -38,14 +44,16 @@ public class BoundWithPartAPI implements org.folio.rest.jaxrs.resource.Inventory
   @Validate
   @Override
   public void deleteInventoryStorageBoundWithPartsById(String id, String lang, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.deleteById(BOUND_WITH_TABLE, id, okapiHeaders, vertxContext,
-      DeleteInventoryStorageBoundWithPartsByIdResponse.class, asyncResultHandler);
+    new BoundWithPartService(vertxContext, okapiHeaders).delete(id)
+      .onSuccess(response -> asyncResultHandler.handle(succeededFuture(response)))
+      .onFailure(handleFailure(asyncResultHandler));
   }
 
   @Validate
   @Override
   public void putInventoryStorageBoundWithPartsById(String id, String lang, BoundWithPart entity, Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    PgUtil.put(BOUND_WITH_TABLE, entity, id, okapiHeaders, vertxContext,
-      PutInventoryStorageBoundWithPartsByIdResponse.class, asyncResultHandler);
+    new BoundWithPartService(vertxContext, okapiHeaders).update(entity, id)
+      .onSuccess(response -> asyncResultHandler.handle(succeededFuture(response)))
+      .onFailure(handleFailure(asyncResultHandler));
   }
 }

--- a/src/main/java/org/folio/services/domainevent/BoundWithDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/BoundWithDomainEventPublisher.java
@@ -1,0 +1,52 @@
+package org.folio.services.domainevent;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.persist.BoundWithRepository;
+import org.folio.persist.HoldingsRepository;
+import org.folio.rest.jaxrs.model.BoundWithPart;
+import org.folio.rest.jaxrs.model.HoldingsRecord;
+import org.folio.services.kafka.topic.KafkaTopic;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import static java.util.stream.Collectors.toList;
+import static org.folio.Environment.environmentName;
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
+
+public class BoundWithDomainEventPublisher extends AbstractDomainEventPublisher<BoundWithPart, BoundWithInstanceId> {
+
+  private final HoldingsRepository holdingsRepository;
+
+  public BoundWithDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
+    super(new BoundWithRepository(context, okapiHeaders),
+      new CommonDomainEventPublisher<>(context, okapiHeaders,
+        KafkaTopic.boundWith(tenantId(okapiHeaders), environmentName())));
+    holdingsRepository = new HoldingsRepository(context, okapiHeaders);
+  }
+
+  @Override
+  protected Future<List<Pair<String, BoundWithPart>>> getInstanceIds(Collection<BoundWithPart> boundWithParts) {
+    return holdingsRepository.getById(boundWithParts, BoundWithPart::getHoldingsRecordId)
+      .map(holdings -> boundWithParts.stream()
+        .map(bound -> pair(getInstanceId(holdings, bound), bound))
+        .collect(toList()));
+  }
+
+  private String getInstanceId(Map<String, HoldingsRecord> holdings, BoundWithPart bound) {
+    return holdings.get(bound.getHoldingsRecordId()).getInstanceId();
+  }
+
+  @Override
+  protected BoundWithInstanceId convertDomainToEvent(String instanceId, BoundWithPart domain) {
+    return new BoundWithInstanceId(domain, instanceId);
+  }
+
+  @Override
+  protected String getId(BoundWithPart record) {
+    return record.getId();
+  }
+}

--- a/src/main/java/org/folio/services/domainevent/BoundWithInstanceId.java
+++ b/src/main/java/org/folio/services/domainevent/BoundWithInstanceId.java
@@ -1,0 +1,28 @@
+package org.folio.services.domainevent;
+
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.folio.rest.jaxrs.model.BoundWithPart;
+
+public class BoundWithInstanceId {
+  private final String instanceId;
+  @JsonUnwrapped
+  private final BoundWithPart boundWithPart;
+
+  public BoundWithInstanceId(BoundWithPart boundWithPart, String instanceId) {
+    this.instanceId = instanceId;
+    this.boundWithPart = boundWithPart;
+  }
+
+  public String getInstanceId() {
+    return instanceId;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+      .append("instanceId", instanceId)
+      .append("boundWithPart", boundWithPart)
+      .toString();
+  }
+}

--- a/src/main/java/org/folio/services/instance/BoundWithPartService.java
+++ b/src/main/java/org/folio/services/instance/BoundWithPartService.java
@@ -1,0 +1,66 @@
+package org.folio.services.instance;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import org.folio.persist.BoundWithRepository;
+import org.folio.rest.jaxrs.model.BoundWithPart;
+import org.folio.rest.jaxrs.resource.InventoryStorageBoundWithParts;
+import org.folio.services.domainevent.BoundWithDomainEventPublisher;
+import org.folio.validator.CommonValidators;
+
+import javax.ws.rs.core.Response;
+import java.util.Map;
+
+import static io.vertx.core.Promise.promise;
+import static org.folio.rest.impl.BoundWithPartAPI.BOUND_WITH_TABLE;
+import static org.folio.rest.persist.PgUtil.deleteById;
+import static org.folio.rest.persist.PgUtil.post;
+import static org.folio.rest.persist.PgUtil.put;
+
+public class BoundWithPartService {
+
+  private final Context vertxContext;
+  private final Map<String, String> okapiHeaders;
+  private final BoundWithDomainEventPublisher domainEventPublisher;
+  private final BoundWithRepository boundWithRepository;
+
+  public BoundWithPartService(Context vertxContext, Map<String, String> okapiHeaders) {
+    this.vertxContext = vertxContext;
+    this.okapiHeaders = okapiHeaders;
+    domainEventPublisher = new BoundWithDomainEventPublisher(vertxContext, okapiHeaders);
+    boundWithRepository = new BoundWithRepository(vertxContext, okapiHeaders);
+  }
+
+  public Future<Response> create(BoundWithPart entity) {
+    final Promise<Response> postResult = promise();
+    post(BOUND_WITH_TABLE, entity, okapiHeaders, vertxContext,
+      InventoryStorageBoundWithParts.PostInventoryStorageBoundWithPartsResponse.class, postResult);
+
+    return postResult.future()
+      .compose(domainEventPublisher.publishCreated());
+  }
+
+  public Future<Response> update(BoundWithPart entity, String id) {
+    final Promise<Response> putResult = promise();
+    put(BOUND_WITH_TABLE, entity, id, okapiHeaders, vertxContext,
+      InventoryStorageBoundWithParts.PutInventoryStorageBoundWithPartsByIdResponse.class, putResult);
+
+    return putResult.future()
+      .compose(domainEventPublisher.publishUpdated(entity));
+  }
+
+  public Future<Response> delete(String id) {
+    return boundWithRepository.getById(id)
+      .compose(CommonValidators::refuseIfNotFound)
+      .compose(item -> {
+        final Promise<Response> deleteResult = promise();
+
+        deleteById(BOUND_WITH_TABLE, id, okapiHeaders, vertxContext,
+          InventoryStorageBoundWithParts.DeleteInventoryStorageBoundWithPartsByIdResponse.class, deleteResult);
+
+        return deleteResult.future()
+          .compose(domainEventPublisher.publishRemoved(item));
+      });
+  }
+}

--- a/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
+++ b/src/main/java/org/folio/services/kafka/topic/KafkaTopic.java
@@ -18,6 +18,10 @@ public class KafkaTopic {
     return forName("inventory.authority", tenantId, environmentName);
   }
 
+  public static KafkaTopic boundWith(String tenantId, String environmentName) {
+    return forName("inventory.bound-with", tenantId, environmentName);
+  }
+
   public static KafkaTopic forName(String name, String tenantId, String environmentName) {
     return new KafkaTopic(qualifyName(name, environmentName, tenantId));
   }

--- a/src/main/resources/kafka-topics.json
+++ b/src/main/resources/kafka-topics.json
@@ -19,6 +19,10 @@
     {
       "name": "inventory.instance-contribution",
       "numPartitions": 50
+    },
+    {
+      "name": "inventory.bound-with",
+      "numPartitions": 50
     }
   ]
 }

--- a/src/main/resources/templates/db_scripts/instance-hr-item/instance-hr-item-view.sql
+++ b/src/main/resources/templates/db_scripts/instance-hr-item/instance-hr-item-view.sql
@@ -7,6 +7,12 @@ SELECT instance.id as id, JSONB_BUILD_OBJECT(
 	                      WHERE holdings_record.instanceId = instance.id),
 	  'items',           (SELECT jsonb_agg(item.jsonb) FROM ${myuniversity}_${mymodule}.holdings_record as hr
 	                      JOIN ${myuniversity}_${mymodule}.item
-	                        ON item.holdingsRecordId=hr.id AND hr.instanceId = instance.id)
+	                        ON item.holdingsRecordId=hr.id AND hr.instanceId = instance.id),
+    'isBoundWith',     (SELECT EXISTS(SELECT 1 FROM diku_mod_inventory_storage.bound_with_part as bw
+                        JOIN diku_mod_inventory_storage.item as it
+                          ON it.id = bw.itemid
+                        JOIN diku_mod_inventory_storage.holdings_record as hr
+                          ON hr.id = bw.holdingsrecordid
+                        WHERE hr.instanceId = instance.id LIMIT 1))
 	) AS jsonb
   FROM ${myuniversity}_${mymodule}.instance;

--- a/src/main/resources/templates/db_scripts/instance-hr-item/instance-hr-item-view.sql
+++ b/src/main/resources/templates/db_scripts/instance-hr-item/instance-hr-item-view.sql
@@ -8,10 +8,10 @@ SELECT instance.id as id, JSONB_BUILD_OBJECT(
 	  'items',           (SELECT jsonb_agg(item.jsonb) FROM ${myuniversity}_${mymodule}.holdings_record as hr
 	                      JOIN ${myuniversity}_${mymodule}.item
 	                        ON item.holdingsRecordId=hr.id AND hr.instanceId = instance.id),
-    'isBoundWith',     (SELECT EXISTS(SELECT 1 FROM diku_mod_inventory_storage.bound_with_part as bw
-                        JOIN diku_mod_inventory_storage.item as it
+    'isBoundWith',     (SELECT EXISTS(SELECT 1 FROM ${myuniversity}_${mymodule}.bound_with_part as bw
+                        JOIN ${myuniversity}_${mymodule}.item as it
                           ON it.id = bw.itemid
-                        JOIN diku_mod_inventory_storage.holdings_record as hr
+                        JOIN ${myuniversity}_${mymodule}.holdings_record as hr
                           ON hr.id = bw.holdingsrecordid
                         WHERE hr.instanceId = instance.id LIMIT 1))
 	) AS jsonb

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1080,7 +1080,7 @@
     {
       "run": "after",
       "snippetPath": "instance-hr-item/instance-hr-item-view.sql",
-      "fromModuleVersion": "19.5.0"
+      "fromModuleVersion": "23.0.0"
     },
     {
       "run": "after",

--- a/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
+++ b/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
@@ -8,6 +8,7 @@ import org.folio.rest.support.Response;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.builders.ItemRequestBuilder;
 import org.folio.rest.support.http.ResourceClient;
+import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.junit.After;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,8 +16,12 @@ import org.junit.runner.RunWith;
 import java.net.HttpURLConnection;
 import java.util.List;
 import java.util.UUID;
+import java.util.concurrent.TimeUnit;
 
-import static org.folio.rest.support.http.InterfaceUrls.*;
+import static org.awaitility.Awaitility.await;
+import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -34,6 +39,7 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void canCreateAndRetrieveBoundWithParts() {
+    FakeKafkaConsumer.removeAllEvents();
     IndividualResource mainInstance = createInstance("Main Instance");
     IndividualResource mainHoldingsRecord = createHoldingsRecord(mainInstance.getId());
     IndividualResource item = createItem(mainHoldingsRecord.getId());
@@ -54,6 +60,9 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(boundWithGETResponseForPartById.getStatusCode(), is(HttpURLConnection.HTTP_OK));
     assertThat(getAllPartsForBoundWithItem.size(), is(3));
+
+    await().atMost(5, TimeUnit.SECONDS)
+      .until(() -> FakeKafkaConsumer.getAllPublishedBoundWithIdsCount() == 3);
   }
 
   @Test
@@ -72,6 +81,7 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void canChangeOnePartOfABoundWith() {
+    FakeKafkaConsumer.removeAllEvents();
     IndividualResource instance1 = createInstance("Instance 1");
     IndividualResource holdingsRecord1 = createHoldingsRecord(instance1.getId());
     IndividualResource instance2 = createInstance("Instance 2");
@@ -101,6 +111,9 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
     assertThat(getAllPartsForBoundWithItemAgain.size(), is(2));
     assertThat(oldPart2Gone.size(), is(0));
     assertThat(newPart2.size(), is(1));
+
+    await().atMost(5, TimeUnit.SECONDS)
+      .until(() -> FakeKafkaConsumer.getAllPublishedBoundWithIdsCount() == 3);
   }
 
   private JsonObject createBoundWithPartJson(UUID holdingsRecordId, UUID itemId) {

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -29,6 +29,8 @@ public final class FakeKafkaConsumer {
     new ConcurrentHashMap<>();
   private final static Map<String, List<KafkaConsumerRecord<String, JsonObject>>> authorityEvents =
     new ConcurrentHashMap<>();
+  private final static Map<String, List<KafkaConsumerRecord<String, JsonObject>>> boundWith =
+    new ConcurrentHashMap<>();
 
   public FakeKafkaConsumer consume(Vertx vertx) {
     final KafkaConsumer<String, JsonObject> consumer = create(vertx, consumerProperties());
@@ -40,8 +42,10 @@ public final class FakeKafkaConsumer {
     final var HOLDINGS_TOPIC_NAME = "folio.test_tenant.inventory.holdings-record";
     final var ITEM_TOPIC_NAME = "folio.test_tenant.inventory.item";
     final var AUTHORITY_TOPIC_NAME = "folio.test_tenant.inventory.authority";
+    final var BOUND_TOPIC_NAME = "folio.test_tenant.inventory.bound-with";
 
-    consumer.subscribe(Set.of(INSTANCE_TOPIC_NAME, HOLDINGS_TOPIC_NAME, ITEM_TOPIC_NAME, AUTHORITY_TOPIC_NAME));
+    consumer.subscribe(Set.of(INSTANCE_TOPIC_NAME, HOLDINGS_TOPIC_NAME, ITEM_TOPIC_NAME,
+      AUTHORITY_TOPIC_NAME, BOUND_TOPIC_NAME));
     consumer.handler(message -> {
       final List<KafkaConsumerRecord<String, JsonObject>> storageList;
 
@@ -62,6 +66,10 @@ public final class FakeKafkaConsumer {
           storageList = authorityEvents.computeIfAbsent(message.key(),
             k -> new ArrayList<>());
           break;
+        case BOUND_TOPIC_NAME:
+          storageList = boundWith.computeIfAbsent(message.key(),
+            k -> new ArrayList<>());
+          break;
         default:
           throw new IllegalArgumentException("Undefined topic");
       }
@@ -76,10 +84,16 @@ public final class FakeKafkaConsumer {
     itemEvents.clear();
     instanceEvents.clear();
     holdingsEvents.clear();
+    authorityEvents.clear();
+    boundWith.clear();
   }
 
   public static int getAllPublishedInstanceIdsCount() {
     return instanceEvents.size();
+  }
+
+  public static int getAllPublishedBoundWithIdsCount() {
+    return boundWith.size();
   }
 
   public static int getAllPublishedAuthoritiesCount() {

--- a/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -31,7 +31,8 @@ import org.mockito.ArgumentCaptor;
 public class KafkaAdminClientServiceTest {
   private final Set<String> allExpectedTopics = Set.of("folio.foo-tenant.inventory.instance",
     "folio.foo-tenant.inventory.holdings-record", "folio.foo-tenant.inventory.item",
-    "folio.foo-tenant.inventory.instance-contribution", "folio.foo-tenant.inventory.authority");
+    "folio.foo-tenant.inventory.instance-contribution", "folio.foo-tenant.inventory.authority",
+    "folio.foo-tenant.inventory.bound-with");
 
   @Test
   public void shouldCreateTopicIfAlreadyExist(TestContext testContext) {


### PR DESCRIPTION
### Purpose
`mod-search` must receive the isBoundWith attribute of instances in the Kafka message

### Approach
- Add field `isBoundWith` to the view model and resource description
-  Create Kafka topic
-  Publish messages when BoundWithParts created/updated/deleted 
- Update integration tests to verify that the new field is included in the response
