### PR TITLE
MODINVSTOR-875 Rename fields in Authority schema

### DIFF
--- a/ramls/authorities/authority.json
+++ b/ramls/authorities/authority.json
@@ -170,14 +170,14 @@
       "type": "string",
       "description": "Heading geographic name"
     },
-    "sftGeographicTerm": {
+    "sftGeographicName": {
       "type": "array",
       "description": "See from tracing geographic name",
       "items": {
         "type": "string"
       }
     },
-    "saftGeographicTerm": {
+    "saftGeographicName": {
       "type": "array",
       "description": "See also from tracing geographic name",
       "items": {


### PR DESCRIPTION
## Purpose
For correct MARC-to-Authority mapping several fields should be renamed:
 * sftGeographicTerm -> sftGeographicName
 * saftGeographicTerm -> saftGeographicName