### PR TITLE
MODINVSTOR-878 Upgrade RMB/Vertx versions that contain fixes for the connection pool

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   </pluginRepositories>
 
   <properties>
-    <vertx.version>4.1.4</vertx.version>
+    <vertx.version>4.2.4</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.4.0</version>
+      <version>2.5.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   </pluginRepositories>
 
   <properties>
-    <vertx.version>4.2.5</vertx.version>
+    <vertx.version>4.2.3</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>

--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,11 @@
   </pluginRepositories>
 
   <properties>
-    <vertx.version>4.1.4</vertx.version>
+    <vertx.version>4.2.4</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>33.2.4</raml-module-builder-version>
+    <raml-module-builder-version>33.2.5</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/authority-storage/authorities,/record-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances,/inventory-hierarchy/updated-instance-ids,/inventory-hierarchy/items-and-holdings,/inventory-view/instances</generate_routing_context>
     <argLine />
   </properties>
@@ -139,6 +139,12 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-classes</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   </pluginRepositories>
 
   <properties>
-    <vertx.version>4.2.5</vertx.version>
+    <vertx.version>4.1.4</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   </pluginRepositories>
 
   <properties>
-    <vertx.version>4.2.3</vertx.version>
+    <vertx.version>4.2.4</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.4.0</version>
+      <version>2.5.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -120,7 +120,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.1</version>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -139,6 +139,12 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>io.netty</groupId>
+          <artifactId>netty-tcnative-classes</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -159,6 +165,7 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
+      <version>1.15.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>2.5.0-SNAPSHOT</version>
+      <version>2.4.0</version>
     </dependency>
     <dependency>
       <groupId>org.projectlombok</groupId>
@@ -120,7 +120,7 @@
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <version>4.13.1</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -139,12 +139,6 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-tcnative-classes</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -165,7 +159,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
-      <version>1.15.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   </pluginRepositories>
 
   <properties>
-    <vertx.version>4.2.4</vertx.version>
+    <vertx.version>4.2.5</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
@@ -139,12 +139,6 @@
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
       <scope>test</scope>
-      <exclusions>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>netty-tcnative-classes</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
   </pluginRepositories>
 
   <properties>
-    <vertx.version>4.2.4</vertx.version>
+    <vertx.version>4.2.5</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>

--- a/pom.xml
+++ b/pom.xml
@@ -31,11 +31,11 @@
   </pluginRepositories>
 
   <properties>
-    <vertx.version>4.2.4</vertx.version>
+    <vertx.version>4.2.5</vertx.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>33.2.5</raml-module-builder-version>
+    <raml-module-builder-version>33.2.6</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/authority-storage/authorities,/record-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances,/inventory-hierarchy/updated-instance-ids,/inventory-hierarchy/items-and-holdings,/inventory-view/instances</generate_routing_context>
     <argLine />
   </properties>

--- a/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
+++ b/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
@@ -67,8 +67,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.sqlclient.Row;
 
-import javax.ws.rs.core.MediaType;
-
 @RunWith(VertxUnitRunner.class)
 public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
   private static final Logger log = LogManager.getLogger();
@@ -114,8 +112,8 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
 
       requestInventoryHierarchyItemsAndHoldingsViewInstance(instanceIds, false, response -> {
         assertThat(response.getStatusCode(), is(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()));
-        assertThat(response.getContentType(), is(MediaType.TEXT_PLAIN));
         String message = response.getBody();
+        log.error(String.format("serverErrorWrittenOutOnDatabaseError : \n %s", message));
         assertThat(message, containsString("function get_items_and_holdings_view(unknown, unknown) does not exist"));
       });
       return null;

--- a/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
+++ b/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
@@ -112,9 +112,7 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
 
       requestInventoryHierarchyItemsAndHoldingsViewInstance(instanceIds, false, response -> {
         assertThat(response.getStatusCode(), is(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()));
-        String message = response.getBody();
-        log.error(String.format("serverErrorWrittenOutOnDatabaseError : \n %s", message));
-        assertThat(message, containsString("function get_items_and_holdings_view(unknown, unknown) does not exist"));
+        assertThat(response.getBody(), containsString("function get_items_and_holdings_view(unknown, unknown) does not exist"));
       });
       return null;
     });
@@ -454,15 +452,11 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
     client.post(inventoryHierarchyItemsAndHoldings(), instanceIdsPayload, TENANT_ID, ResponseHandler.any(future));
 
     final Response response = future.get(2, TimeUnit.SECONDS);
-    log.error("response status {}", response.getStatusCode());
-    log.error("response body {}", response.getBody());
-    log.error("response content type {}", response.getContentType());
-    log.error("response json {}", response.getJson());
     responseMatcher.handle(response);
     log.info("\nResponse from inventory instance ids view: " + response);
 
     final String body = response.getBody();
-    if (StringUtils.isNotEmpty(body)) {
+    if (StringUtils.isNotEmpty(body) && response.getStatusCode() != HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()) {
       results.add(new JsonObject(body));
     }
 

--- a/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
+++ b/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
@@ -113,7 +113,7 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
           .toArray(UUID[]::new);
 
       requestInventoryHierarchyItemsAndHoldingsViewInstance(instanceIds, false, response -> {
-        assertThat(response.getStatusCode(), is(HttpStatus.HTTP_INTERNAL_SERVER_ERROR));
+        assertThat(response.getStatusCode(), is(HttpStatus.HTTP_INTERNAL_SERVER_ERROR.toInt()));
         assertThat(response.getContentType(), is(MediaType.TEXT_PLAIN));
         String message = response.getBody();
         assertThat(message, containsString("function get_items_and_holdings_view(unknown, unknown) does not exist"));

--- a/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
+++ b/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
@@ -454,6 +454,10 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
     client.post(inventoryHierarchyItemsAndHoldings(), instanceIdsPayload, TENANT_ID, ResponseHandler.any(future));
 
     final Response response = future.get(2, TimeUnit.SECONDS);
+    log.error("response status {}", response.getStatusCode());
+    log.error("response body {}", response.getBody());
+    log.error("response content type {}", response.getContentType());
+    log.error("response json {}", response.getJson());
     responseMatcher.handle(response);
     log.info("\nResponse from inventory instance ids view: " + response);
 

--- a/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
+++ b/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
@@ -25,6 +25,7 @@ import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers
 import static org.folio.rest.support.matchers.InventoryHierarchyResponseMatchers.isDeleted;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
@@ -50,6 +51,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.HttpStatus;
 import org.folio.rest.jaxrs.model.InventoryInstanceIds;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.Response;
@@ -64,6 +66,8 @@ import io.vertx.core.json.DecodeException;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import io.vertx.sqlclient.Row;
+
+import javax.ws.rs.core.MediaType;
 
 @RunWith(VertxUnitRunner.class)
 public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
@@ -109,9 +113,10 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
           .toArray(UUID[]::new);
 
       requestInventoryHierarchyItemsAndHoldingsViewInstance(instanceIds, false, response -> {
-        assertThat(response.getStatusCode(), is(500));
-        String message = new JsonObject(response.getBody()).getString("message");
-        assertThat(message, is("function get_items_and_holdings_view(unknown, unknown) does not exist"));
+        assertThat(response.getStatusCode(), is(HttpStatus.HTTP_INTERNAL_SERVER_ERROR));
+        assertThat(response.getContentType(), is(MediaType.TEXT_PLAIN));
+        String message = response.getBody();
+        assertThat(message, containsString("function get_items_and_holdings_view(unknown, unknown) does not exist"));
       });
       return null;
     });

--- a/src/test/java/org/folio/rest/support/matchers/PostgresErrorMessageMatchers.java
+++ b/src/test/java/org/folio/rest/support/matchers/PostgresErrorMessageMatchers.java
@@ -17,11 +17,11 @@ public class PostgresErrorMessageMatchers {
 
   public static Matcher<String> isMaximumSequenceValueError(final String sequenceName) {
     // 2200H = sequence_generator_limit_exceeded
-    return allOf(containsString("\"2200H\""), containsString("\\\"" + sequenceName + "\\\""));
+    return allOf(containsString("2200H"), containsString(String.format("\"%s\"", sequenceName)));
   }
 
   public static Matcher<String> isUniqueViolation(final String uniqueIndexName) {
     // 23505 = unique_violation
-    return allOf(containsString("\"23505\""), containsString("\\\"" + uniqueIndexName + "\\\""));
+    return allOf(containsString("23505"), containsString(String.format("\"%s\"", uniqueIndexName)));
   }
 }


### PR DESCRIPTION
## Purpose
Update the rmb version to prevent problems related to the connection pool.

## Approach
* Upgrade vertx to v4.2.5
* Upgrade rmb to v33.2.6
* Upgrade folio-kafka-wrapper to v2.5.0-SNAPSHOT

## Learning
[MODINVSTOR-878](https://issues.folio.org/browse/MODINVSTOR-878)