### PR TITLE
MODINVSTOR-874 publicationPeriod not changed after record update

### DIFF
--- a/src/main/java/org/folio/services/instance/InstanceEffectiveValuesService.java
+++ b/src/main/java/org/folio/services/instance/InstanceEffectiveValuesService.java
@@ -22,7 +22,7 @@ public class InstanceEffectiveValuesService {
 
   public void populateEffectiveValues(Instance newInstance, Instance oldInstance) {
     if (instancePublicationsChanged(newInstance, oldInstance)) {
-      populateEffectiveValues(newInstance);
+      populatePublicationPeriod(newInstance);
     }
   }
 

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -18,6 +18,7 @@ import static org.hamcrest.Matchers.not;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.joda.time.Seconds.seconds;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
@@ -53,6 +54,7 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -76,6 +78,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.rest.jaxrs.model.Instance;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -2725,6 +2728,21 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertSuppressedFromDiscovery(instance.getId().toString());
     assertUpdateEventForInstance(instance.getJson(), updateInstance.getJson());
+  }
+
+  @Test
+  public void canUpdateInstanceWithPublicationPeriod() throws Exception {
+    var entity = smallAngryPlanet(UUID.randomUUID()).mapTo(Instance.class)
+      .withPublication(Collections.singletonList(new Publication().withDateOfPublication("1997")));
+
+    IndividualResource instance = createInstance(JsonObject.mapFrom(entity));
+    entity = instance.getJson().mapTo(Instance.class)
+      .withPublication(Collections.singletonList(new Publication().withDateOfPublication("2006")));
+
+    final IndividualResource updateInstance = updateInstance(JsonObject.mapFrom(entity));
+
+    assertEquals(Integer.valueOf(2006), updateInstance.getJson().mapTo(Instance.class).getPublicationPeriod().getStart());
+
   }
 
   @Test

--- a/src/test/java/org/folio/services/instance/InstanceEffectiveValuesServiceTest.java
+++ b/src/test/java/org/folio/services/instance/InstanceEffectiveValuesServiceTest.java
@@ -106,6 +106,18 @@ public class InstanceEffectiveValuesServiceTest {
   }
 
   @Test
+  public void shouldPopulatePeriodWhenDateOfPublicationChanged() {
+    var newInstance = createInstance("2019");
+    var oldInstance = createInstance("2020");
+
+    service.populateEffectiveValues(newInstance, oldInstance);
+
+    assertThat(newInstance.getPublicationPeriod(), notNullValue());
+    assertThat(newInstance.getPublicationPeriod().getStart(), is(2019));
+    assertThat(newInstance.getPublicationPeriod().getEnd(), is(nullValue()));
+  }
+
+  @Test
   public void shouldPopulatePeriodWhenLastDateOfPublicationChanged() {
     var newInstance = createInstance("2020", "2023");
     var oldInstance = createInstance("2020", "2021");


### PR DESCRIPTION
### Overview:
Any changes to the publicatioPeriod after the instance record has been created are being ignored.

### Steps to Reproduce:

- Create an instance record in the inventory with date of Publication populated
- Check if the publicationPeriod has been populate according to the rules from [MODINVSTOR-724](https://issues.folio.org/browse/MODINVSTOR-724)
- Edit the instance record by modifying date of Publication

### Expected Results:
publicationPeriod start and end date change according to the rules (as specified in [MODINVSTOR-724](https://issues.folio.org/browse/MODINVSTOR-724))