### PR TITLE
MODINVSTOR-877 Add Other schema support for effectiveShelvingOrder value

### DIFF
--- a/src/main/java/org/folio/services/CallNumberUtils.java
+++ b/src/main/java/org/folio/services/CallNumberUtils.java
@@ -12,7 +12,9 @@ public class CallNumberUtils {
   public static Optional<String> getShelfKeyFromCallNumber(String callNumber) {
     return Optional.ofNullable(callNumber)
       .flatMap(cn -> getValidShelfKey(new LCCallNumber(cn))
-        .or(() -> getValidShelfKey(new DeweyCallNumber(cn))));
+        .or(() -> getValidShelfKey(new DeweyCallNumber(cn))))
+      .or(() -> Optional.ofNullable(callNumber))
+      .map(String::trim);
   }
 
   private static Optional<String> getValidShelfKey(CallNumber value) {

--- a/src/test/java/org/folio/services/CallNumberUtilsTest.java
+++ b/src/test/java/org/folio/services/CallNumberUtilsTest.java
@@ -35,10 +35,14 @@ public class CallNumberUtilsTest extends TestCase {
     "PR 3919 L33 41990,PR 3919 .L33 41990,,PR919 .L33 1990,,,,,",
     "PR 49199 A39,PR 49199 .A39,,PR9199 .A39,,,,,",
     "PR 49199.48 B3,PR 49199.48 .B3,,PR9199.48 .B3,,,,,",
+    "3341.7,,,341.7,,,,,",
     "3341.7 258 221,,,341.7/58 / 21,,,,,",
     "3341.7 258 221,,T1,341.7/58 / 21,,,,,",
     "3394.1 O41 B,,,394.1 O41b,,,,,",
     "3621.56 W91 M V 13 NO 12 41999,,,621.56 W91m,v.3,no. 2,1999,,",
+    "221 E23,,,21 E23,,,,,",
+    "other,,,other,,,,,",
+    "free-text,,,free-text,,,,,"
   })
   @Test
   public void inputForShelvingNumber(

--- a/src/test/java/org/folio/services/CallNumberUtilsTest.java
+++ b/src/test/java/org/folio/services/CallNumberUtilsTest.java
@@ -41,7 +41,11 @@ public class CallNumberUtilsTest extends TestCase {
     "3394.1 O41 B,,,394.1 O41b,,,,,",
     "3621.56 W91 M V 13 NO 12 41999,,,621.56 W91m,v.3,no. 2,1999,,",
     "221 E23,,,21 E23,,,,,",
-    "other,,,other,,,,,",
+    "11,,,00001,,,,,",
+    "3325 D A 41908 FREETOWN MAP,,,325-d A-1908 (Freetown) Map,,,,,",
+    "45001 MICROFILM,,,5001 Microfilm,,,,,",
+    "19 A2 C 6444218 MUSIC CD,,,9A2 C0444218 Music CD,,,,,",
+    "GROUP Smith,,,GROUP Smith,,,,,",
     "free-text,,,free-text,,,,,"
   })
   @Test


### PR DESCRIPTION
### Purpose 
Populate Shelving order on the item record when the call number type is Other scheme.

### Approach
- Current approach is to add the default behaviour if LcCallNumber or DeweyCallNumber parsers failed to recognize the input value
- Fix the bug with kept trailing space after DeweyCallNumber parsing