### PR TITLE
MODINVSTOR-883 Exclude authority-collection.raml rtype from API lint and doc

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,6 +7,7 @@ buildMvn {
   doApiLint = true
   apiTypes = 'RAML'
   apiDirectories = 'ramls'
+  apiExcludes = 'authority-collection.raml'
 
   mvnDeploy = 'yes'
   doKubeDeploy = true


### PR DESCRIPTION
This is a ResourceType file.

As alerted when authorities was first added.
See comment at [mod-inventory-storage/pull/690](https://github.com/folio-org/mod-inventory-storage/pull/690#issuecomment-958579789):

> Note that the file "./ramls/authorities/authority-collection.raml" is a RAML ResourceType and not a root-level RAML file. As such it should be in a directory "./ramls/rtypes" (similar to how raml-util/rtypes is organised). That directory would then be excluded by default from the detection of RAML files to be processed for validation and docs generation.

So specifically excluding this rtype file from processing with api-lint and api-doc.