### PR TITLE
adding related reference types to list

### DIFF
--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -72,7 +72,8 @@ public class TenantRefAPI extends TenantAPI {
     "bound-with/instances",
     "bound-with/holdingsrecords",
     "bound-with/items",
-    "bound-with/bound-with-parts"
+    "bound-with/bound-with-parts",
+    "related-instance-types"
   };
 
   List<JsonObject> servicePoints = null;


### PR DESCRIPTION
Someone noticed that the module does not load
the new related-instance-types with other reference
data.  It looks like this is because it was not put in the 
tenantRefApi with the other reference directory names.