### PR TITLE
MODINVSTOR-895: bad data in item.statisticalCodeIds stops harvest

### DIFF
--- a/src/main/resources/templates/db_scripts/changeUUIDCastInGetStatisticalCodesFunction.sql
+++ b/src/main/resources/templates/db_scripts/changeUUIDCastInGetStatisticalCodesFunction.sql
@@ -1,0 +1,18 @@
+DROP FUNCTION IF EXISTS ${myuniversity}_${mymodule}.getStatisticalCodes;
+
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.getStatisticalCodes(val jsonb) RETURNS jsonb AS
+$$
+WITH stat_codes(statCodeId, statCodeJsonb, statCodeTypeJsonb) AS (
+SELECT sc.id, sc.jsonb, sct.jsonb
+FROM statistical_code sc
+JOIN statistical_code_type sct ON sct.id = sc.statisticalcodetypeid
+)
+SELECT jsonb_agg(DISTINCT jsonb_build_object('id', sc.statCodeJsonb ->> 'id') ||
+							  jsonb_build_object('code', sc.statCodeJsonb ->> 'code') ||
+							  jsonb_build_object('name', sc.statCodeJsonb ->> 'name') ||
+							  jsonb_build_object('statisticalCodeType', sc.statCodeTypeJsonb ->> 'name') ||
+							  jsonb_build_object('source', sc.statCodeTypeJsonb ->> 'source'))
+FROM jsonb_array_elements( $1 ) AS e,
+     stat_codes sc
+WHERE sc.statCodeId::text = (e ->> 0)::text
+$$ LANGUAGE sql strict;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -968,7 +968,7 @@
           "fieldName": "relatedInstanceId",
           "targetTable": "instance",
           "tOps": "ADD"
-        },       
+        },
         {
           "fieldName": "relatedInstanceType",
           "targetTable": "related_instance_type",
@@ -1146,6 +1146,11 @@
     {
       "run": "after",
       "snippetPath": "statisticalCodeIdReferenceCheckTrigger.sql",
+      "fromModuleVersion": "23.1.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "changeUUIDCastInGetStatisticalCodesFunction.sql",
       "fromModuleVersion": "23.1.0"
     }
   ]


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MODINVSTOR-895

### PURPOSE

Remove the UUID casting within the WHERE clause of the accepted item ids array in order to prevent the failure of the entire getItemsAndHoldingsData SQL when the item statistical codes array contains bad data.