### PR TITLE
MODINVSTOR-894 optimize create instance endpoint

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,4 @@
-## 23.1.0 IN-PROGRESS
+d## 23.1.0 IN-PROGRESS
 
 * Add related instances record API (MODINVSTOR-861)
 * Added integrity checks to statisticalCodeIds in instance records (MODINVSTOR-885)
@@ -10,6 +10,7 @@
 * provides `instance-storage-batch 1.1`
 * provides `instance-storage-batch-sync 1.1`
 * provides `inventory-view 1.1`
+* create instance optimization (MODINVSTOR-894)
 
 
 ## 23.0.0 2022-02-22

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,10 @@
-d## 23.1.0 IN-PROGRESS
+## 23.1.0 IN-PROGRESS
 
 * Add related instances record API (MODINVSTOR-861)
 * Added integrity checks to statisticalCodeIds in instance records (MODINVSTOR-885)
 * Removed UUID contraint on statisticalCodeIds in instance Records (MODINVSTOR-885)
+* Combined calls to retrieve HRID settings and getting sequence values (MODINVSTOR-894)
+* Allow response to be returned to the api client without waiting for domain event publishing during instance creation (MODINVSTOR-894)
 * provides `item-storage-dereferenced 0.2`
 * provides `holdings-storage 5.1`
 * provides `holdings-storage-batch-sync 1.1`
@@ -10,7 +12,6 @@ d## 23.1.0 IN-PROGRESS
 * provides `instance-storage-batch 1.1`
 * provides `instance-storage-batch-sync 1.1`
 * provides `inventory-view 1.1`
-* create instance optimization (MODINVSTOR-894)
 
 
 ## 23.0.0 2022-02-22

--- a/src/main/java/org/folio/rest/support/HridManager.java
+++ b/src/main/java/org/folio/rest/support/HridManager.java
@@ -258,8 +258,6 @@ public class HridManager {
   /**
    * Optimized version of getNextHrid that makes a single call to retrieve
    * hridsettings and the next sequence value for the specified inventory type.
-   * @param type
-   * @return
    */
   private Future<String> getNextHrid(InventoryType type) {
     final String sql = "select jsonb::TEXT from hrid_settings " +
@@ -288,8 +286,14 @@ public class HridManager {
           new ArrayTuple(1).addString(sequenceName),
           reply -> {
             var result = reply.result();
-            if (reply.failed() || result.size() != 2) {
+            if (reply.failed()) {
               fail(promise, "Failed to get hridsettings and next sequence value from the database", reply.cause());
+              return;
+            }
+            if (result.size() != 2) {
+              String errorMessage = "Result set contains " + result.size() + " items instead of 2 items";
+              fail(promise, errorMessage,
+                new IllegalStateException(errorMessage));
               return;
             }
             RowIterator<Row> iterator = result.iterator();

--- a/src/main/java/org/folio/rest/support/HridManager.java
+++ b/src/main/java/org/folio/rest/support/HridManager.java
@@ -288,8 +288,9 @@ public class HridManager {
           new ArrayTuple(1).addString(sequenceName),
           reply -> {
             var result = reply.result();
-            if (result.size() != 2) {
-              promise.complete(null);
+            if (reply.failed() || result.size() != 2) {
+              fail(promise, "Failed to get hridsettings and next sequence value from the database", reply.cause());
+              return;
             }
             RowIterator<Row> iterator = result.iterator();
             // get hridSettings
@@ -306,7 +307,7 @@ public class HridManager {
           });
       });
     } catch (Exception e) {
-      fail(promise, "Failed to get the next sequence value from the database", e);
+      fail(promise, "Failed to get hridsettings and next sequence value from the database", e);
     }
 
     return promise.future();

--- a/src/main/java/org/folio/rest/support/StatusUpdatedDateGenerator.java
+++ b/src/main/java/org/folio/rest/support/StatusUpdatedDateGenerator.java
@@ -1,11 +1,12 @@
 package org.folio.rest.support;
 
+import java.time.ZoneOffset;
 import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;
 
 public final class StatusUpdatedDateGenerator {
     private final static DateTimeFormatter df = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
     public static String generateStatusUpdatedDate() {
-      return df.format(ZonedDateTime.now());
+      return df.format(ZonedDateTime.now(ZoneOffset.UTC));
     }
 }

--- a/src/main/java/org/folio/rest/support/StatusUpdatedDateGenerator.java
+++ b/src/main/java/org/folio/rest/support/StatusUpdatedDateGenerator.java
@@ -1,11 +1,11 @@
 package org.folio.rest.support;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
 
 public final class StatusUpdatedDateGenerator {
+    private final static DateTimeFormatter df = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
     public static String generateStatusUpdatedDate() {
-      SimpleDateFormat sdf = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSZ");
-      return sdf.format(new Date());
-    } 
+      return df.format(ZonedDateTime.now());
+    }
 }

--- a/src/main/java/org/folio/services/instance/InstanceService.java
+++ b/src/main/java/org/folio/services/instance/InstanceService.java
@@ -65,7 +65,12 @@ public class InstanceService {
 
         return postResponse.future()
           .compose(response -> {
-            // return response without waiting for event publish
+            // Return the response without waiting for a domain event publish
+            // to complete. Units of work performed by this service is the same
+            // but the ordering of the units of work provides a benefit to the
+            // api client invoking this endpoint. The response is returned
+            // a little earlier so the api client can continue its processing
+            // while the domain event publish is satisfied.
             domainEventPublisher.publishCreated().apply(response);
             return Future.succeededFuture(response);
           });

--- a/src/main/java/org/folio/services/instance/InstanceService.java
+++ b/src/main/java/org/folio/services/instance/InstanceService.java
@@ -64,15 +64,15 @@ public class InstanceService {
           InstanceStorage.PostInstanceStorageInstancesResponse.class, postResponse);
 
         return postResponse.future()
-          .onSuccess(response ->
+          .onSuccess(response -> {
             // Return the response without waiting for a domain event publish
             // to complete. Units of work performed by this service is the same
             // but the ordering of the units of work provides a benefit to the
             // api client invoking this endpoint. The response is returned
             // a little earlier so the api client can continue its processing
             // while the domain event publish is satisfied.
-            domainEventPublisher.publishCreated()
-          );
+            domainEventPublisher.publishCreated().apply(response);
+          });
       });
   }
 

--- a/src/main/java/org/folio/services/instance/InstanceService.java
+++ b/src/main/java/org/folio/services/instance/InstanceService.java
@@ -64,7 +64,11 @@ public class InstanceService {
           InstanceStorage.PostInstanceStorageInstancesResponse.class, postResponse);
 
         return postResponse.future()
-          .compose(domainEventPublisher.publishCreated());
+          .compose(response -> {
+            // return response without waiting for event publish
+            domainEventPublisher.publishCreated().apply(response);
+            return Future.succeededFuture(response);
+          });
       });
   }
 

--- a/src/main/java/org/folio/services/instance/InstanceService.java
+++ b/src/main/java/org/folio/services/instance/InstanceService.java
@@ -64,16 +64,15 @@ public class InstanceService {
           InstanceStorage.PostInstanceStorageInstancesResponse.class, postResponse);
 
         return postResponse.future()
-          .compose(response -> {
+          .onSuccess(response ->
             // Return the response without waiting for a domain event publish
             // to complete. Units of work performed by this service is the same
             // but the ordering of the units of work provides a benefit to the
             // api client invoking this endpoint. The response is returned
             // a little earlier so the api client can continue its processing
             // while the domain event publish is satisfied.
-            domainEventPublisher.publishCreated().apply(response);
-            return Future.succeededFuture(response);
-          });
+            domainEventPublisher.publishCreated()
+          );
       });
   }
 

--- a/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
+++ b/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
@@ -61,7 +61,7 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
     assertThat(boundWithGETResponseForPartById.getStatusCode(), is(HttpURLConnection.HTTP_OK));
     assertThat(getAllPartsForBoundWithItem.size(), is(3));
 
-    await().atMost(5, TimeUnit.SECONDS)
+    await().atMost(10, TimeUnit.SECONDS)
       .until(() -> FakeKafkaConsumer.getAllPublishedBoundWithIdsCount() == 3);
   }
 
@@ -112,7 +112,7 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
     assertThat(oldPart2Gone.size(), is(0));
     assertThat(newPart2.size(), is(1));
 
-    await().atMost(5, TimeUnit.SECONDS)
+    await().atMost(10, TimeUnit.SECONDS)
       .until(() -> FakeKafkaConsumer.getAllPublishedBoundWithIdsCount() == 3);
   }
 


### PR DESCRIPTION
Original premise for this ticket was to only reduce database calls when retrieving HRID value. It appears that the database calls are a smaller fraction of the entire work done. More optimizations were made.

- Single call to retrieve hrid settings and hrid sequence value via UNION ALL select statement rather than database function
- Using a single thread safe date formatter rather than recreating a new one on each call to set status dates.
- Returning response to the api client before domain event publishing is complete.