### PR TITLE
MODINVSTOR-909 Optimistic locking message does not return from back-end

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,7 @@
 * Removed UUID contraint on statisticalCodeIds in instance Records (MODINVSTOR-885)
 * Combined calls to retrieve HRID settings and getting sequence values (MODINVSTOR-894)
 * Allow response to be returned to the api client without waiting for domain event publishing during instance creation (MODINVSTOR-894)
+* Enable optimistic locking 'failOnConflict' for authorities (MODINVSTOR-909)
 * provides `item-storage-dereferenced 0.2`
 * provides `holdings-storage 5.1`
 * provides `holdings-storage-batch-sync 1.1`

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -5,7 +5,7 @@
       "fromModuleVersion": "22.1.0",
       "withMetadata": true,
       "withAuditing": false,
-      "withOptimisticLocking": "logOnConflict"
+      "withOptimisticLocking": "failOnConflict"
     },
     {
       "tableName": "loan_type",


### PR DESCRIPTION
## Purpose
Fix "Optimistic locking" message does not return from back-end side
## Approach
- enable 'failOnConflict' for authorities
## Learning
[MODINVSTOR-909](https://issues.folio.org/browse/MODINVSTOR-909)