### PR TITLE
MODINVSTOR-911: Send Kafka message after returning API response

### DIFF
--- a/src/main/java/org/folio/services/authority/AuthorityService.java
+++ b/src/main/java/org/folio/services/authority/AuthorityService.java
@@ -37,7 +37,7 @@ public class AuthorityService {
     final Promise<Response> postResponse = promise();
     post(AUTHORITY_TABLE, entity, okapiHeaders, vertxContext,
       AuthorityStorage.PostAuthorityStorageAuthoritiesResponse.class, postResponse);
-    return postResponse.future().compose(domainEventService.publishCreated());
+    return postResponse.future().onSuccess(domainEventService.publishCreated());
   }
 
   public Future<Response> updateAuthority(String authorityId,
@@ -51,7 +51,7 @@ public class AuthorityService {
           AuthorityStorage.PutAuthorityStorageAuthoritiesByAuthorityIdResponse.class, putResult);
 
         return putResult.future()
-          .compose(domainEventService.publishUpdated(oldRecord));
+          .onSuccess(domainEventService.publishUpdated(oldRecord));
       });
   }
 
@@ -65,7 +65,7 @@ public class AuthorityService {
           AuthorityStorage.DeleteAuthorityStorageAuthoritiesByAuthorityIdResponse.class, deleteResult);
 
         return deleteResult.future()
-          .compose(domainEventService.publishRemoved(authority));
+          .onSuccess(domainEventService.publishRemoved(authority));
       });
   }
 

--- a/src/main/java/org/folio/services/domainevent/AbstractDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/AbstractDomainEventPublisher.java
@@ -77,16 +77,16 @@ abstract class AbstractDomainEventPublisher<DomainType, EventType> {
     };
   }
 
-  public Handler<Response> publishRemoved(DomainType record) {
+  public Handler<Response> publishRemoved(DomainType removedRecord) {
     return response -> {
       if (!isDeleteSuccessResponse(response)) {
         log.warn("Record removal failed, no event will be sent");
         return;
       }
 
-      getInstanceId(record)
+      getInstanceId(removedRecord)
         .compose(instanceId -> domainEventService.publishRecordRemoved(instanceId,
-          convertDomainToEvent(instanceId, record)));
+          convertDomainToEvent(instanceId, removedRecord)));
     };
   }
 

--- a/src/main/java/org/folio/services/domainevent/AbstractDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/AbstractDomainEventPublisher.java
@@ -10,9 +10,9 @@ import static org.folio.rest.support.ResponseUtil.isDeleteSuccessResponse;
 import static org.folio.rest.support.ResponseUtil.isUpdateSuccessResponse;
 
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import java.util.Collection;
 import java.util.List;
-import java.util.function.Function;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
@@ -36,60 +36,57 @@ abstract class AbstractDomainEventPublisher<DomainType, EventType> {
     this.domainEventService = domainEventService;
   }
 
-  public Function<Response, Future<Response>> publishUpdated(DomainType oldRecord) {
+  public Handler<Response> publishUpdated(DomainType oldRecord) {
     return response -> {
       if (!isUpdateSuccessResponse(response)) {
         log.warn("Record update failed, skipping event publishing");
-        return succeededFuture(response);
+        return;
       }
 
-      return publishUpdated(singletonList(oldRecord)).map(response);
+      publishUpdated(singletonList(oldRecord));
     };
   }
 
   @SuppressWarnings("unchecked")
-  public Function<Response, Future<Response>> publishCreated() {
+  public Handler<Response> publishCreated() {
     return response -> {
       if (!isCreateSuccessResponse(response)) {
         log.warn("Record create failed, skipping event publishing");
-        return succeededFuture(response);
+        return;
       }
 
-      return publishCreated(singletonList((DomainType) response.getEntity()))
-        .map(response);
+      publishCreated(singletonList((DomainType) response.getEntity()));
     };
   }
 
-  public Function<Response, Future<Response>> publishCreatedOrUpdated(
+  public Handler<Response> publishCreatedOrUpdated(
     BatchOperationContext<DomainType> batchOperation) {
 
     return response -> {
       if (!isCreateSuccessResponse(response)) {
         log.warn("Records create/update failed, skipping event publishing");
-        return succeededFuture(response);
+        return;
       }
 
       log.info("Records created {}, records updated {}",
         batchOperation.getRecordsToBeCreated().size(),
         batchOperation.getExistingRecords().size());
 
-      return publishCreated(batchOperation.getRecordsToBeCreated())
-        .compose(notUsed -> publishUpdated(batchOperation.getExistingRecords()))
-        .map(response);
+      publishCreated(batchOperation.getRecordsToBeCreated())
+        .compose(notUsed -> publishUpdated(batchOperation.getExistingRecords()));
     };
   }
 
-  public Function<Response, Future<Response>> publishRemoved(DomainType record) {
+  public Handler<Response> publishRemoved(DomainType record) {
     return response -> {
       if (!isDeleteSuccessResponse(response)) {
         log.warn("Record removal failed, no event will be sent");
-        return succeededFuture(response);
+        return;
       }
 
-      return getInstanceId(record)
+      getInstanceId(record)
         .compose(instanceId -> domainEventService.publishRecordRemoved(instanceId,
-          convertDomainToEvent(instanceId, record)))
-        .map(response);
+          convertDomainToEvent(instanceId, record)));
     };
   }
 

--- a/src/main/java/org/folio/services/holding/HoldingsService.java
+++ b/src/main/java/org/folio/services/holding/HoldingsService.java
@@ -61,7 +61,8 @@ public class HoldingsService {
 
   public Future<Void> deleteAllHoldings() {
     return holdingsRepository.deleteAll()
-      .compose(notUsed -> domainEventPublisher.publishAllRemoved());
+      .onSuccess(notUsed -> domainEventPublisher.publishAllRemoved())
+      .mapEmpty();
   }
 
   public Future<Response> updateHoldingRecord(String holdingId, HoldingsRecord holdingsRecord) {
@@ -85,7 +86,7 @@ public class HoldingsService {
           PostHoldingsStorageHoldingsResponse.class, postResponse);
 
         return postResponse.future()
-          .compose(domainEventPublisher.publishCreated());
+          .onSuccess(domainEventPublisher.publishCreated());
       });
   }
 
@@ -104,7 +105,7 @@ public class HoldingsService {
         return overallResult.future()
           .compose(itemsBeforeUpdate -> itemEventService.publishUpdated(newHoldings, itemsBeforeUpdate))
           .<Response>map(res -> PutHoldingsStorageHoldingsByHoldingsRecordIdResponse.respond204())
-          .compose(domainEventPublisher.publishUpdated(oldHoldings));
+          .onSuccess(domainEventPublisher.publishUpdated(oldHoldings));
       });
   }
 
@@ -118,7 +119,7 @@ public class HoldingsService {
           DeleteHoldingsStorageHoldingsByHoldingsRecordIdResponse.class, deleteResult);
 
         return deleteResult.future()
-          .compose(domainEventPublisher.publishRemoved(hr));
+          .onSuccess(domainEventPublisher.publishRemoved(hr));
       });
   }
 
@@ -138,7 +139,7 @@ public class HoldingsService {
           postSyncResult);
 
         return postSyncResult.future()
-          .compose(domainEventPublisher.publishCreatedOrUpdated(batchOperation));
+          .onSuccess(domainEventPublisher.publishCreatedOrUpdated(batchOperation));
       });
   }
 

--- a/src/main/java/org/folio/services/instance/BoundWithPartService.java
+++ b/src/main/java/org/folio/services/instance/BoundWithPartService.java
@@ -38,7 +38,7 @@ public class BoundWithPartService {
       InventoryStorageBoundWithParts.PostInventoryStorageBoundWithPartsResponse.class, postResult);
 
     return postResult.future()
-      .compose(domainEventPublisher.publishCreated());
+      .onSuccess(domainEventPublisher.publishCreated());
   }
 
   public Future<Response> update(BoundWithPart entity, String id) {
@@ -47,7 +47,7 @@ public class BoundWithPartService {
       InventoryStorageBoundWithParts.PutInventoryStorageBoundWithPartsByIdResponse.class, putResult);
 
     return putResult.future()
-      .compose(domainEventPublisher.publishUpdated(entity));
+      .onSuccess(domainEventPublisher.publishUpdated(entity));
   }
 
   public Future<Response> delete(String id) {
@@ -60,7 +60,7 @@ public class BoundWithPartService {
           InventoryStorageBoundWithParts.DeleteInventoryStorageBoundWithPartsByIdResponse.class, deleteResult);
 
         return deleteResult.future()
-          .compose(domainEventPublisher.publishRemoved(item));
+          .onSuccess(domainEventPublisher.publishRemoved(item));
       });
   }
 }

--- a/src/main/java/org/folio/services/item/ItemService.java
+++ b/src/main/java/org/folio/services/item/ItemService.java
@@ -95,7 +95,7 @@ public class ItemService {
           PostItemStorageItemsResponse.class, postResponse);
 
         return postResponse.future()
-          .compose(domainEventService.publishCreated());
+          .onSuccess(domainEventService.publishCreated());
       });
   }
 
@@ -115,7 +115,7 @@ public class ItemService {
           okapiHeaders, vertxContext, PostItemStorageBatchSynchronousResponse.class, postSyncResult);
 
         return postSyncResult.future()
-          .compose(domainEventService.publishCreatedOrUpdated(batchOperation));
+          .onSuccess(domainEventService.publishCreatedOrUpdated(batchOperation));
       });
   }
 
@@ -131,7 +131,7 @@ public class ItemService {
       .compose(x -> refuseWhenHridChanged(putData.item, newItem))
       .map(x -> effectiveValuesService.populateEffectiveValues(newItem, putData.holdingsRecord))
       .compose(x -> updateItem(newItem))
-      .compose(finalItem -> domainEventService.publishUpdated(finalItem, putData.item, putData.holdingsRecord))
+      .onSuccess(finalItem -> domainEventService.publishUpdated(finalItem, putData.item, putData.holdingsRecord))
       .<Response>map(x -> PutItemStorageItemsByItemIdResponse.respond204())
       .otherwise(e -> {
         if (e instanceof ResponseException) {
@@ -155,13 +155,14 @@ public class ItemService {
           DeleteItemStorageItemsByItemIdResponse.class, deleteResult);
 
         return deleteResult.future()
-          .compose(domainEventService.publishRemoved(item));
+          .onSuccess(domainEventService.publishRemoved(item));
       });
   }
 
   public Future<Void> deleteAllItems() {
     return itemRepository.deleteAll()
-      .compose(notUsed -> domainEventService.publishAllRemoved());
+      .onSuccess(notUsed -> domainEventService.publishAllRemoved())
+      .mapEmpty();
   }
 
   /**


### PR DESCRIPTION
When changing data domain events get published via Kafka.

After the domain event has been published mod-inventory-storage sends the response to its client.

This delay is not needed.

mod-inventory-storage should respond to its client and then publish the domain event to Kafka.

Performance gains:

From 25 ms to 18 ms for POST /item-storage/items API response time. (Caused by fetching item and holding to calculate the domain event.)

From 19 ms to 18 ms for POST /holdings-storage/holdings response time.