### PR TITLE
MODINVSTOR-913: Enhance inventory-hierarchy view to make it return instances by date search criteria that have holdings only - Lotus release

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+## 23.0.3 2022-05-26
+
+### Stories
+
+* [MODINVSTOR-913](https://issues.folio.org/browse/MODINVSTOR-913) Enhance inventory-hierarchy view to make it return instances by date search criteria that have holdings only - Lotus
+
+  [Full Changelog](https://github.com/folio-org/mod-inventory-storage/compare/v23.0.2...v23.0.3)
+
 ## 23.0.2 2022-03-30
 
 * Removes undefined permissions (MODINVSTOR-882)

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>23.0.3-SNAPSHOT</version>
+  <version>23.0.3</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -184,7 +184,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>v23.0.0</tag>
+    <tag>v23.0.3</tag>
   </scm>
 
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>23.0.3</version>
+  <version>23.0.4-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>
@@ -184,7 +184,7 @@
     <url>https://github.com/folio-org/mod-inventory-storage</url>
     <connection>scm:git:git://github.com:folio-org/mod-inventory-storage.git</connection>
     <developerConnection>scm:git:git@github.com:folio-org/mod-inventory-storage.git</developerConnection>
-    <tag>v23.0.3</tag>
+    <tag>v23.0.0</tag>
   </scm>
 
   <build>

--- a/src/main/resources/templates/db_scripts/inventory-hierarchy/correctGetUpdatedInstanceIdsView.sql
+++ b/src/main/resources/templates/db_scripts/inventory-hierarchy/correctGetUpdatedInstanceIdsView.sql
@@ -1,0 +1,66 @@
+drop function if exists ${myuniversity}_${mymodule}.get_updated_instance_ids_view;
+-- Correct joining(JOIN -> LEFT JOIN line 28) operation for holdings and items tables to get instances ids also when they have holdings being updated only
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.get_updated_instance_ids_view(startDate                          timestamptz,
+                                                                                     endDate                            timestamptz,
+                                                                                     deletedRecordSupport               bool DEFAULT TRUE,
+                                                                                     skipSuppressedFromDiscoveryRecords bool DEFAULT TRUE,
+                                                                                     onlyInstanceUpdateDate             bool DEFAULT TRUE)
+    RETURNS TABLE
+            (
+                "instanceId"            uuid,
+                "source"                varchar,
+                "updatedDate"           timestamptz,
+                "suppressFromDiscovery" boolean,
+                "deleted"               boolean
+            )
+AS
+$BODY$
+WITH instanceIdsInRange AS ( SELECT inst.id AS instanceId,
+                                    (strToTimestamp(inst.jsonb -> 'metadata' ->> 'updatedDate')) AS maxDate
+                             FROM ${myuniversity}_${mymodule}.instance inst
+                             WHERE (strToTimestamp(inst.jsonb -> 'metadata' ->> 'updatedDate')) BETWEEN dateOrMin($1) AND dateOrMax($2)
+
+                             UNION ALL
+                             SELECT instanceid,
+                                    greatest((strToTimestamp(item.jsonb -> 'metadata' ->> 'updatedDate')),
+                                             (strToTimestamp(hr.jsonb -> 'metadata' ->> 'updatedDate'))) AS maxDate
+                             FROM ${myuniversity}_${mymodule}.holdings_record hr
+                                      LEFT JOIN ${myuniversity}_${mymodule}.item item ON item.holdingsrecordid = hr.id
+                             WHERE ((strToTimestamp(hr.jsonb -> 'metadata' ->> 'updatedDate')) BETWEEN dateOrMin($1) AND dateOrMax($2) OR
+                                    (strToTimestamp(item.jsonb -> 'metadata' ->> 'updatedDate')) BETWEEN dateOrMin($1) AND dateOrMax($2))
+                                    AND NOT EXISTS (SELECT NULL WHERE $5)
+
+                             UNION ALL
+                             SELECT (audit_holdings_record.jsonb #>> '{record,instanceId}')::uuid,
+                                    greatest((strToTimestamp(audit_item.jsonb -> 'record' ->> 'updatedDate')),
+                                             (strToTimestamp(audit_holdings_record.jsonb -> 'record' ->> 'updatedDate'))) AS maxDate
+                             FROM ${myuniversity}_${mymodule}.audit_holdings_record audit_holdings_record
+                                      JOIN ${myuniversity}_${mymodule}.audit_item audit_item
+                                           ON (audit_item.jsonb ->> '{record,holdingsRecordId}')::uuid =
+                                              audit_holdings_record.id
+                             WHERE ((strToTimestamp(audit_holdings_record.jsonb -> 'record' ->> 'updatedDate')) BETWEEN dateOrMin($1) AND dateOrMax($2) OR
+                                    (strToTimestamp(audit_item.jsonb #>> '{record,updatedDate}')) BETWEEN dateOrMin($1) AND dateOrMax($2))
+                                    AND NOT EXISTS (SELECT NULL WHERE $5) )
+SELECT instanceId,
+       instance.jsonb ->> 'source' AS source,
+       MAX(instanceIdsInRange.maxDate) AS maxDate,
+       (instance.jsonb ->> 'discoverySuppress')::bool AS suppressFromDiscovery,
+       false AS deleted
+FROM instanceIdsInRange,
+    ${myuniversity}_${mymodule}.instance
+WHERE instanceIdsInRange.maxDate BETWEEN dateOrMin($1) AND dateOrMax($2)
+      AND instance.id = instanceIdsInRange.instanceId
+      AND NOT ($4 AND COALESCE((instance.jsonb ->> 'discoverySuppress')::bool, false))
+GROUP BY 1, 2, 4
+
+UNION ALL
+SELECT (jsonb #>> '{record,id}')::uuid              AS instanceId,
+        jsonb #>> '{record,source}'                 AS source,
+        strToTimestamp(jsonb ->> 'createdDate')     AS maxDate,
+        false                                       AS suppressFromDiscovery,
+        true                                        AS deleted
+FROM ${myuniversity}_${mymodule}.audit_instance
+WHERE $3
+      AND strToTimestamp(jsonb ->> 'createdDate') BETWEEN dateOrMin($1) AND dateOrMax($2)
+
+$BODY$ LANGUAGE sql;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1121,6 +1121,11 @@
       "run": "after",
       "snippetPath": "itemStatisticalCodeReferenceCheckTrigger.sql",
       "fromModuleVersion": "22.1.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "inventory-hierarchy/correctGetUpdatedInstanceIdsView.sql",
+      "fromModuleVersion": "23.0.3"
     }
   ]
 }


### PR DESCRIPTION
Jira: https://issues.folio.org/browse/MODINVSTOR-913
Jira: https://issues.folio.org/browse/MODINVSTOR-914

### PURPOSE

Backport for mod-inventory-storage Lotus release that includes improvement [MODINVSTOR-913](https://issues.folio.org/browse/MODINVSTOR-913).