### PR TITLE
MODINVSTOR-915: upgrading RMB to 34.0.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## 23.1.0 IN-PROGRESS
 
-* Upgraded RMB to 33.2.10 (MODINVSTOR-915)
+* Upgraded RMB to 34.0.0 (MODINVSTOR-915)
 * Added integrity checks to statisticalCodeIds in instance records (MODINVSTOR-885)
 * Removed UUID contraint on statisticalCodeIds in instance Records (MODINVSTOR-885)
 * Combined calls to retrieve HRID settings and getting sequence values (MODINVSTOR-894)

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <raml-module-builder-version>33.2.10</raml-module-builder-version>
+    <raml-module-builder-version>34.0.0</raml-module-builder-version>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/authority-storage/authorities,/record-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances,/inventory-hierarchy/updated-instance-ids,/inventory-hierarchy/items-and-holdings,/inventory-view/instances</generate_routing_context>
     <argLine />
   </properties>
@@ -65,6 +65,12 @@
       <groupId>org.marc4j</groupId>
       <artifactId>marc4j</artifactId>
       <version>2.9.1</version>
+    </dependency>
+    <dependency>
+      <groupId>org.folio.okapi</groupId>
+      <artifactId>okapi-testing</artifactId>
+      <version>4.12.0</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>joda-time</groupId>

--- a/src/test/java/org/folio/rest/api/AsyncMigrationTest.java
+++ b/src/test/java/org/folio/rest/api/AsyncMigrationTest.java
@@ -31,6 +31,7 @@ import java.util.stream.IntStream;
 
 import static io.vertx.core.Future.succeededFuture;
 import static java.util.concurrent.TimeUnit.SECONDS;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import static org.awaitility.Awaitility.await;
 import static org.folio.okapi.common.XOkapiHeaders.TENANT;
 import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
@@ -151,7 +152,7 @@ public class AsyncMigrationTest extends TestBaseWithInventoryUtil {
   }
 
   private static Map<String, String> okapiHeaders() {
-    return Map.of(TENANT.toLowerCase(), TENANT_ID);
+    return new CaseInsensitiveMap<>(Map.of(TENANT.toLowerCase(), TENANT_ID));
   }
 
   private static Context getContext() {

--- a/src/test/java/org/folio/rest/api/IterationJobRunnerTest.java
+++ b/src/test/java/org/folio/rest/api/IterationJobRunnerTest.java
@@ -21,6 +21,7 @@ import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
 
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import io.vertx.core.Context;
 import org.folio.persist.InstanceRepository;
 import org.folio.persist.IterationJobRepository;
@@ -131,7 +132,7 @@ public class IterationJobRunnerTest extends TestBaseWithInventoryUtil {
   }
 
   private static Map<String, String> okapiHeaders() {
-    return Map.of(TENANT.toLowerCase(), TENANT_ID);
+    return new CaseInsensitiveMap<>(Map.of(TENANT.toLowerCase(), TENANT_ID));
   }
 
   private static Context getContext() {

--- a/src/test/java/org/folio/rest/api/NotificationSendingErrorRepositoryTest.java
+++ b/src/test/java/org/folio/rest/api/NotificationSendingErrorRepositoryTest.java
@@ -12,6 +12,7 @@ import org.folio.persist.NotificationSendingErrorRepository;
 import org.folio.persist.entity.NotificationSendingError;
 import org.folio.rest.persist.PgUtil;
 import org.junit.Test;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 
 public class NotificationSendingErrorRepositoryTest extends TestBaseWithInventoryUtil {
   @Test
@@ -32,7 +33,7 @@ public class NotificationSendingErrorRepositoryTest extends TestBaseWithInventor
 
   private NotificationSendingErrorRepository createRepository() {
     var postgresClient = PgUtil.postgresClient(getVertx().getOrCreateContext(),
-      Map.of("x-okapi-tenant", TENANT_ID));
+    new CaseInsensitiveMap<>(Map.of("x-okapi-tenant", TENANT_ID)));
 
     return new NotificationSendingErrorRepository(postgresClient);
   }

--- a/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
+++ b/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
@@ -31,7 +31,7 @@ import org.folio.rest.jaxrs.model.ReindexJob;
 import org.folio.rest.persist.PostgresClientFuturized;
 import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.folio.rest.support.sql.TestRowStream;
-import org.folio.services.domainevent.AuthorityDomainEventPublisher;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.folio.services.domainevent.CommonDomainEventPublisher;
 import org.folio.services.kafka.topic.KafkaTopic;
 import org.folio.services.reindex.ReindexJobRunner;
@@ -41,10 +41,10 @@ import org.junit.Test;
 public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
   private final ReindexJobRepository repository = getRepository();
   private final CommonDomainEventPublisher<Instance> instanceEventPublisher =
-    new CommonDomainEventPublisher<>(getContext(), Map.of(TENANT, TENANT_ID),
+    new CommonDomainEventPublisher<>(getContext(), new CaseInsensitiveMap<>(Map.of(TENANT, TENANT_ID)),
       KafkaTopic.instance(TENANT_ID, environmentName()));
   private final CommonDomainEventPublisher<Authority> authorityEventPublisher =
-    new CommonDomainEventPublisher(getContext(), Map.of(TENANT, TENANT_ID),
+    new CommonDomainEventPublisher(getContext(), new CaseInsensitiveMap<>(Map.of(TENANT, TENANT_ID)),
       KafkaTopic.authority(TENANT_ID, environmentName()));
 
   @Test
@@ -182,7 +182,7 @@ public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
   }
 
   private static Map<String, String> okapiHeaders() {
-    return Map.of(TENANT.toLowerCase(), TENANT_ID);
+    return new CaseInsensitiveMap<>(Map.of(TENANT.toLowerCase(), TENANT_ID));
   }
 
   private static Context getContext() {

--- a/src/test/java/org/folio/rest/impl/StorageHelperTest.java
+++ b/src/test/java/org/folio/rest/impl/StorageHelperTest.java
@@ -1,6 +1,6 @@
 package org.folio.rest.impl;
 
-import org.folio.rest.testing.UtilityClassTester;
+import org.folio.okapi.testing.UtilityClassTester;
 import org.junit.Test;
 
 public class StorageHelperTest {

--- a/src/test/java/org/folio/services/domainevent/CommonDomainEventPublisherTest.java
+++ b/src/test/java/org/folio/services/domainevent/CommonDomainEventPublisherTest.java
@@ -24,6 +24,7 @@ import org.folio.kafka.KafkaProducerManager;
 import org.folio.rest.api.entities.Instance;
 import org.folio.rest.support.sql.TestRowStream;
 import org.folio.services.kafka.InventoryProducerRecordBuilder;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.folio.services.kafka.topic.KafkaTopic;
 import org.junit.Before;
 import org.junit.Test;
@@ -42,7 +43,7 @@ public class CommonDomainEventPublisherTest {
   @Before
   public void setUpPublisher() {
     eventPublisher = new CommonDomainEventPublisher<>(
-      Map.of(), KafkaTopic.instance("foo-tenant", environmentName()),
+      new CaseInsensitiveMap<>(Map.of()), KafkaTopic.instance("foo-tenant", environmentName()),
         producerManager, failureHandler);
   }
 


### PR DESCRIPTION
The test changes are required to address a case-sensitivity issue in RMB 34 that was causing these tests
to fail.  For more details on this, see:  https://github.com/folio-org/raml-module-builder/pull/1058