### PR TITLE
Upgrade to lombok 1.18.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
     <dependency>
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
-      <version>1.18.16</version>
+      <version>1.18.24</version>
       <scope>provided</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
This makes mod-inventory-storage compile with OpenJDK 17.