### PR TITLE
FOLIO-3541 api-doc verify replace JSON schema folio:$ref

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,6 +1,6 @@
 # mod-inventory-storage
 
-Copyright (C) 2016-2021 The Open Library Foundation
+Copyright (C) 2016-2022 The Open Library Foundation
 
 This software is distributed under the terms of the Apache License,
 Version 2.0. See the file "[LICENSE](LICENSE)" for more information.


### PR DESCRIPTION
This PR verifies the api-doc tool generation of API documentation during merge to mainline. Some schemas that contain references to child schema using "folio:$ref" could not be dereferenced. The api-doc now temporarily replaces those references during processing.

See [FOLIO-3541](https://issues.folio.org/browse/FOLIO-3541).