### PR TITLE
MODINVSTOR-940:  Change when holdings effective location script runs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 25.0.0 IN-PROGRESS
+
+* Fixed effective location migration script for holdings records (MODINVSTOR-940)
+
 ## 24.0.1 2022-07-18
 
 * Improve populating shelfKey from callNumber ([MODINVSTOR-932](https://issues.folio.org/browse/MODINVSTOR-932))

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -875,7 +875,7 @@
     {
       "run":"after",
       "snippetPath":"setEffectiveHoldingsLocation.sql",
-      "fromModuleVersion":"20.1.0"
+      "fromModuleVersion":"24.0.2"
     },
     {
       "run": "after",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -875,7 +875,7 @@
     {
       "run":"after",
       "snippetPath":"setEffectiveHoldingsLocation.sql",
-      "fromModuleVersion":"24.0.2"
+      "fromModuleVersion":"25.0.0"
     },
     {
       "run": "after",


### PR DESCRIPTION
This script should have run for juniper, but had a bad version number (20.1.0).  To 
rectify, we are going to set it to run in the next version (25.0.0).  We will also issue 
a bugfix release for the current version (which will be 24.0.2).