### PR TITLE
MODINVSTOR-940: fixing when location migration script runs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+## 24.0.2 2022-08-10
+
+* Fixing when migration script to populate holdings effective locations runs ([MODINVSTOR-940] (https://issues.folio.org/browse/MODINVSTOR-940))
+
 ## 24.0.1 2022-07-18
 
 * Improve populating shelfKey from callNumber ([MODINVSTOR-932](https://issues.folio.org/browse/MODINVSTOR-932))

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>24.0.1</version>
+  <version>24.0.2-SNAPSHOT</version>
   <licenses>
     <license>
       <name>Apache License 2.0</name>

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -875,7 +875,7 @@
     {
       "run":"after",
       "snippetPath":"setEffectiveHoldingsLocation.sql",
-      "fromModuleVersion":"20.1.0"
+      "fromModuleVersion":"24.0.2"
     },
     {
       "run": "after",


### PR DESCRIPTION
It's important to note that in the mainline, we've set this script to run in version 25.0.0 (which is the next release).
Here, we are preparing to release it as a backported fix for morning glory (24.0.2)