### PR TITLE
MODINVSTOR-949: Speed up setEffectiveHoldingsLocation.sql migration

### DIFF
--- a/src/main/resources/templates/db_scripts/setEffectiveHoldingsLocation.sql
+++ b/src/main/resources/templates/db_scripts/setEffectiveHoldingsLocation.sql
@@ -1,11 +1,4 @@
-START TRANSACTION;
-
 UPDATE ${myuniversity}_${mymodule}.holdings_record
-  SET jsonb = JSONB_SET(holdings_record.jsonb, '{effectiveLocationId}', TO_JSONB(holdings_record.jsonb->>'temporaryLocationId'))
-WHERE jsonb->>'temporaryLocationId' IS NOT NULL;
-
-UPDATE ${myuniversity}_${mymodule}.holdings_record
-  SET jsonb = JSONB_SET(holdings_record.jsonb, '{effectiveLocationId}', TO_JSONB(holdings_record.jsonb->>'permanentLocationId'))
-WHERE jsonb->>'temporaryLocationId' IS NULL;
-
-END TRANSACTION;
+  SET jsonb = JSONB_SET(holdings_record.jsonb, '{effectiveLocationId}',
+                        TO_JSONB(COALESCE(temporarylocationid, permanentlocationid)))
+WHERE effectivelocationid IS NULL;


### PR DESCRIPTION
The migration script setEffectiveHoldingsLocation.sql sets the
effective location of all holdings. It should skip all holdings
that already have the effective location been set.

The effective location has a database index because it is a
foreign key to the location table:
https://github.com/folio-org/mod-inventory-storage/blob/v24.0.2/src/main/resources/templates/db_scripts/schema.json#L585-L611

Note that permanentLocationId is a required field:
https://github.com/folio-org/mod-inventory-storage/blob/v24.0.2/ramls/holdingsrecord.json#L371

Unit tests already exist in
src/test/java/org/folio/rest/api/EffectiveLocationMigrationTest.java