### PR TITLE
MODINVSTOR-950 Extend instance contributors schema with Authority ID

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 * GET Instance Set by CQL ([MODINVSTOR-918](https://issues.folio.org/browse/MODINVSTOR-918))
 * provides `inventory-view-instance-set 1.0`
 * Added Alternative title and Former title to alternative title default types ([MODINVSTOR-389] (https://issues.folio.org/browse/MODINVSTOR-389))
+* Extend instance contributors schema with Authority ID ([MODINVSTOR-950](https://issues.folio.org/browse/MODINVSTOR-950))
+* provides `instance-storage 8.2`
 
 ## 24.0.3 2022-08-17
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -154,7 +154,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "8.1",
+      "version": "8.2",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/instance-storage.raml
+++ b/ramls/instance-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Instance Storage
-version: v8.1
+version: v8.2
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -127,11 +127,15 @@
             "description": "UUID of contributor name type term defined by the MARC code list for relators",
             "$ref": "uuid.json"
           },
+          "authorityId": {
+            "type": "string",
+            "description": "UUID of authority record that controls the contributor",
+            "$ref": "uuid.json"
+          },
           "contributorNameType": {
             "type": "object",
             "description": "Dereferenced contributor-name type",
             "javaType": "org.folio.rest.jaxrs.model.contributorNameTypeVirtual",
-            "readonly": true,
             "folio:$ref": "contributornametype.json",
             "readonly": true,
             "folio:isVirtual": true,


### PR DESCRIPTION
## Purpose
It's needed to have information if a contributor is controlled by authority

## Approach
Extend instance.contributors with authorityId