### PR TITLE
MODINVSTOR-389: changing alternative title to variant title

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
 * Adds integrity checks for statistical code types during upgrade ([MODINVSTOR-935] (https://issues.folio.org/browse/MODINVSTOR-935))
 * GET Instance Set by CQL ([MODINVSTOR-918](https://issues.folio.org/browse/MODINVSTOR-918))
 * provides `inventory-view-instance-set 1.0`
-* Added Alternative title and Former title to alternative title default types ([MODINVSTOR-389] (https://issues.folio.org/browse/MODINVSTOR-389))
+* Added Variant title and Former title to alternative title default types ([MODINVSTOR-389] (https://issues.folio.org/browse/MODINVSTOR-389))
 * Extend instance contributors schema with Authority ID ([MODINVSTOR-950](https://issues.folio.org/browse/MODINVSTOR-950))
 * provides `instance-storage 8.2`
 

--- a/reference-data/alternative-title-types/VariantTitle.json
+++ b/reference-data/alternative-title-types/VariantTitle.json
@@ -1,5 +1,5 @@
 {
   "id": "35bbe7f2-1a49-11ed-861d-0242ac120002",
-  "name": "Alternative title",
+  "name": "Variant title",
   "source": "folio"
 }


### PR DESCRIPTION
Apparently, there was a mix-up in the issue and "alternative title" was supposed to be "variant title."