### PR TITLE
MODINVSTOR-952 Extend Pre-defined Authority Source file list to include a base URL

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1344,19 +1344,28 @@
           "methods": ["GET"],
           "pathPattern": "/authority-source-files",
           "permissionsRequired": ["inventory-storage.authority-source-files.collection.get"]
-        }, {
+        },
+        {
           "methods": ["GET"],
           "pathPattern": "/authority-source-files/{id}",
           "permissionsRequired": ["inventory-storage.authority-source-files.item.get"]
-        }, {
+        },
+        {
           "methods": ["POST"],
           "pathPattern": "/authority-source-files",
           "permissionsRequired": ["inventory-storage.authority-source-files.item.post"]
-        }, {
+        },
+        {
           "methods": ["PUT"],
           "pathPattern": "/authority-source-files/{id}",
           "permissionsRequired": ["inventory-storage.authority-source-files.item.put"]
-        }, {
+        },
+        {
+          "methods": ["PATCH"],
+          "pathPattern": "/authority-source-files/{id}",
+          "permissionsRequired": ["inventory-storage.authority-source-files.item.patch"]
+        },
+        {
           "methods": ["DELETE"],
           "pathPattern": "/authority-source-files/{id}",
           "permissionsRequired": ["inventory-storage.authority-source-files.item.delete"]
@@ -2565,6 +2574,11 @@
       "permissionName": "inventory-storage.authority-source-files.item.put",
       "displayName": "inventory storage - modify authority-source-file",
       "description": "modify authority-source-file in storage"
+    },
+    {
+      "permissionName": "inventory-storage.authority-source-files.item.patch",
+      "displayName": "inventory storage - patch authority-source-file",
+      "description": "patch authority-source-file in storage"
     },
     {
       "permissionName": "inventory-storage.authority-source-files.item.delete",

--- a/ramls/authority-source-file.raml
+++ b/ramls/authority-source-file.raml
@@ -11,6 +11,7 @@ documentation:
 types:
   authoritySourceFile: !include authoritysourcefile.json
   authoritySourceFiles: !include authoritysourcefiles.json
+  authoritySourceFilePatchRequest: !include authoritysourcefile-patch.json
   errors: !include raml-util/schemas/errors.schema
 
 traits:
@@ -45,3 +46,39 @@ resourceTypes:
       collection-item:
         exampleItem: !include examples/authoritysourcefile.json
         schema: authoritySourceFile
+    patch:
+      description: Update Authority source file
+      body:
+        application/json:
+          description: Patch Authority source file
+          type: authoritySourceFilePatchRequest
+      responses:
+        204:
+          description: No Content
+        400:
+          description: Bad Request
+          body:
+            text/plain:
+              example: |
+                "unable to update <<resourcePathName|!singularize>> -- malformed JSON at 13:4"
+        401:
+          description: "Not authorized to perform requested action"
+          body:
+            text/plain:
+              example: "Invalid token"
+        404:
+          description: "Item with a given ID not found"
+          body:
+            text/plain:
+              example: |
+                "<<resourcePathName|!singularize>> not found"
+        409:
+          description: "Optimistic locking version conflict"
+          body:
+            text/plain:
+              example: "version conflict"
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "internal server error, contact administrator"

--- a/ramls/authoritysourcefile-patch.json
+++ b/ramls/authoritysourcefile-patch.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Authority source file PATCH Request Schema",
+  "description": "Authority source file PATCH Request Schema",
+  "additionalProperties": false,
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "unique ID of the Authority source file; a UUID",
+      "$ref": "uuid.json"
+    },
+    "baseUrl": {
+      "type": "string",
+      "description": "Base URL of the source file origin",
+      "examples": "id.loc.gov/authorities/names/"
+    }
+  },
+  "additionalProperties": false
+}

--- a/ramls/authoritysourcefile.json
+++ b/ramls/authoritysourcefile.json
@@ -23,6 +23,14 @@
       "type": "string",
       "description": "Type of authority records stored in source file"
     },
+    "baseUrl": {
+      "type": "string",
+      "description": "Base URL of the source file origin"
+    },
+    "source": {
+      "type": "string",
+      "description": "label indicating where the authority source file entry originates from, i.e. 'folio' or 'local'"
+    },
     "metadata": {
       "type": "object",
       "$ref": "raml-util/schemas/metadata.schema",

--- a/ramls/authoritysourcefile.json
+++ b/ramls/authoritysourcefile.json
@@ -29,7 +29,11 @@
     },
     "source": {
       "type": "string",
-      "description": "label indicating where the authority source file entry originates from, i.e. 'folio' or 'local'"
+      "description": "label indicating where the authority source file entry originates from, i.e. 'folio' or 'local'",
+      "enum": [
+        "folio",
+        "local"
+      ]
     },
     "metadata": {
       "type": "object",
@@ -41,7 +45,8 @@
   "required": [
     "name",
     "codes",
-    "type"
+    "type",
+    "source"
   ]
 }
 

--- a/ramls/examples/authoritysourcefile.json
+++ b/ramls/examples/authoritysourcefile.json
@@ -7,6 +7,8 @@
     "nr",
     "no"
   ],
-  "type": "Names"
+  "type": "Names",
+  "baseUrl": "id.loc.gov/authorities/names/",
+  "source": "folio"
 }
 

--- a/ramls/examples/authoritysourcefiles.json
+++ b/ramls/examples/authoritysourcefiles.json
@@ -9,7 +9,9 @@
         "nr",
         "no"
       ],
-      "type": "Names"
+      "type": "Names",
+      "baseUrl": "id.loc.gov/authorities/names/",
+      "source": "folio"
     },
     {
       "id": "837e2c7b-037b-4113-9dfd-b1b8aeeb1fb8",
@@ -17,7 +19,9 @@
       "codes": [
         "sh"
       ],
-      "type": "Subjects"
+      "type": "Subjects",
+      "baseUrl": "id.loc.gov/authorities/subjects/",
+      "source": "folio"
     }
   ],
   "totalRecords": 2

--- a/reference-data/authority-source-files/AAT.json
+++ b/reference-data/authority-source-files/AAT.json
@@ -5,5 +5,7 @@
     "aat",
     "aatg"
   ],
-  "type": "Subjects"
+  "type": "Subjects",
+  "baseUrl": "vocab.getty.edu/aat/",
+  "source": "folio"
 }

--- a/reference-data/authority-source-files/FAST.json
+++ b/reference-data/authority-source-files/FAST.json
@@ -4,5 +4,7 @@
   "codes": [
     "fst"
   ],
-  "type": "Subjects"
+  "type": "Subjects",
+  "baseUrl": "id.worldcat.org/fast/",
+  "source": "folio"
 }

--- a/reference-data/authority-source-files/GSAFD.json
+++ b/reference-data/authority-source-files/GSAFD.json
@@ -4,5 +4,7 @@
   "codes": [
     "gsafd"
   ],
-  "type": "Subjects"
+  "type": "Subjects",
+  "baseUrl": "vocabularyserver.com/gsafd/",
+  "source": "folio"
 }

--- a/reference-data/authority-source-files/LCCSH.json
+++ b/reference-data/authority-source-files/LCCSH.json
@@ -4,5 +4,7 @@
   "codes": [
     "sj"
   ],
-  "type": "Subjects"
+  "type": "Subjects",
+  "baseUrl": "id.loc.gov/authorities/childrensSubjects/",
+  "source": "folio"
 }

--- a/reference-data/authority-source-files/LCFGT.json
+++ b/reference-data/authority-source-files/LCFGT.json
@@ -4,5 +4,7 @@
   "codes": [
     "dg"
   ],
-  "type": "Subjects"
+  "type": "Subjects",
+  "baseUrl": "id.loc.gov/authorities/demographicTerms/",
+  "source": "folio"
 }

--- a/reference-data/authority-source-files/LCGFT.json
+++ b/reference-data/authority-source-files/LCGFT.json
@@ -4,5 +4,7 @@
   "codes": [
     "gf"
   ],
-  "type": "Subjects"
+  "type": "Subjects",
+  "baseUrl": "id.loc.gov/authorities/genreForms/",
+  "source": "folio"
 }

--- a/reference-data/authority-source-files/LCMPT.json
+++ b/reference-data/authority-source-files/LCMPT.json
@@ -4,5 +4,7 @@
   "codes": [
     "mp"
   ],
-  "type": "Subjects"
+  "type": "Subjects",
+  "baseUrl": "id.loc.gov/authorities/performanceMediums/",
+  "source": "folio"
 }

--- a/reference-data/authority-source-files/LCNAF.json
+++ b/reference-data/authority-source-files/LCNAF.json
@@ -7,5 +7,7 @@
     "nr",
     "no"
   ],
-  "type": "Names"
+  "type": "Names",
+  "baseUrl": "id.loc.gov/authorities/names/",
+  "source": "folio"
 }

--- a/reference-data/authority-source-files/LCSH.json
+++ b/reference-data/authority-source-files/LCSH.json
@@ -4,5 +4,7 @@
   "codes": [
     "sh"
   ],
-  "type": "Subjects"
+  "type": "Subjects",
+  "baseUrl": "id.loc.gov/authorities/subjects/",
+  "source": "folio"
 }

--- a/reference-data/authority-source-files/MeSH.json
+++ b/reference-data/authority-source-files/MeSH.json
@@ -4,5 +4,7 @@
   "codes": [
     "D"
   ],
-  "type": "Subjects"
+  "type": "Subjects",
+  "baseUrl": "id.nlm.nih.gov/mesh/",
+  "source": "folio"
 }

--- a/reference-data/authority-source-files/RBMS.json
+++ b/reference-data/authority-source-files/RBMS.json
@@ -4,5 +4,6 @@
   "codes": [
     "rbmscv"
   ],
-  "type": "Subjects"
+  "type": "Subjects",
+  "source": "folio"
 }

--- a/reference-data/authority-source-files/TGM.json
+++ b/reference-data/authority-source-files/TGM.json
@@ -5,5 +5,7 @@
     "lcgtm",
     "tgm"
   ],
-  "type": "Subjects"
+  "type": "Subjects",
+  "baseUrl": "id.loc.gov/vocabulary/graphicMaterials/",
+  "source": "folio"
 }

--- a/src/main/java/org/folio/persist/AuthoritySourceFileRepository.java
+++ b/src/main/java/org/folio/persist/AuthoritySourceFileRepository.java
@@ -1,0 +1,14 @@
+package org.folio.persist;
+
+import static org.folio.rest.impl.AuthoritySourceFileAPI.AUTHORITY_SOURCE_FILE_TABLE;
+import static org.folio.rest.persist.PgUtil.postgresClient;
+
+import io.vertx.core.Context;
+import java.util.Map;
+import org.folio.rest.jaxrs.model.AuthoritySourceFile;
+
+public class AuthoritySourceFileRepository extends AbstractRepository<AuthoritySourceFile> {
+  public AuthoritySourceFileRepository(Context context, Map<String, String> okapiHeaders) {
+    super(postgresClient(context, okapiHeaders), AUTHORITY_SOURCE_FILE_TABLE, AuthoritySourceFile.class);
+  }
+}

--- a/src/main/java/org/folio/rest/impl/AuthoritySourceFileAPI.java
+++ b/src/main/java/org/folio/rest/impl/AuthoritySourceFileAPI.java
@@ -13,9 +13,9 @@ import org.folio.rest.persist.PgUtil;
 
 public class AuthoritySourceFileAPI implements org.folio.rest.jaxrs.resource.AuthoritySourceFiles {
 
-  public static final String REFERENCE_TABLE = "authority_source_file";
+  private static final String REFERENCE_TABLE = "authority_source_file";
 
-  public static final String URL_PROTOCOL_PATTERN = "^(https?://www\\.|https?://|www\\.)";
+  private static final String URL_PROTOCOL_PATTERN = "^(https?://www\\.|https?://|www\\.)";
 
   @Override
   @Validate

--- a/src/main/java/org/folio/rest/impl/AuthoritySourceFileAPI.java
+++ b/src/main/java/org/folio/rest/impl/AuthoritySourceFileAPI.java
@@ -5,13 +5,17 @@ import io.vertx.core.Context;
 import io.vertx.core.Handler;
 import java.util.Map;
 import javax.ws.rs.core.Response;
+import org.apache.commons.lang.StringUtils;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.AuthoritySourceFile;
 import org.folio.rest.jaxrs.model.AuthoritySourceFiles;
 import org.folio.rest.persist.PgUtil;
 
 public class AuthoritySourceFileAPI implements org.folio.rest.jaxrs.resource.AuthoritySourceFiles {
+
   public static final String REFERENCE_TABLE = "authority_source_file";
+
+  public static final String ULR_PROTOCOL_PATTERN = "^(http[s]?://www\\.|http[s]?://|www\\.)";
 
   @Override
   @Validate
@@ -31,6 +35,8 @@ public class AuthoritySourceFileAPI implements org.folio.rest.jaxrs.resource.Aut
                                        Map<String, String> okapiHeaders,
                                        Handler<AsyncResult<Response>> asyncResultHandler,
                                        Context vertxContext) {
+    normalizeBaseUrl(entity);
+
     PgUtil.post(REFERENCE_TABLE, entity, okapiHeaders, vertxContext,
       PostAuthoritySourceFilesResponse.class,
       asyncResultHandler);
@@ -65,8 +71,22 @@ public class AuthoritySourceFileAPI implements org.folio.rest.jaxrs.resource.Aut
                                           Map<String, String> okapiHeaders,
                                           Handler<AsyncResult<Response>> asyncResultHandler,
                                           Context vertxContext) {
+    normalizeBaseUrl(entity);
+
     PgUtil.put(REFERENCE_TABLE, entity, id, okapiHeaders, vertxContext,
       PutAuthoritySourceFilesByIdResponse.class,
       asyncResultHandler);
   }
+
+  private static void normalizeBaseUrl(AuthoritySourceFile entity) {
+    var baseUrl = entity.getBaseUrl();
+    if (StringUtils.isNotBlank(baseUrl)) {
+      baseUrl = baseUrl.replaceFirst(ULR_PROTOCOL_PATTERN, "");
+      if (!baseUrl.endsWith("/")) {
+        baseUrl += "/";
+      }
+      entity.setBaseUrl(baseUrl);
+    }
+  }
+
 }

--- a/src/main/java/org/folio/rest/impl/AuthoritySourceFileAPI.java
+++ b/src/main/java/org/folio/rest/impl/AuthoritySourceFileAPI.java
@@ -15,7 +15,7 @@ public class AuthoritySourceFileAPI implements org.folio.rest.jaxrs.resource.Aut
 
   public static final String REFERENCE_TABLE = "authority_source_file";
 
-  public static final String URL_PROTOCOL_PATTERN = "^(http[s]?://www\\.|http[s]?://|www\\.)";
+  public static final String URL_PROTOCOL_PATTERN = "^(https?://www\\.|https?://|www\\.)";
 
   @Override
   @Validate

--- a/src/main/java/org/folio/rest/impl/AuthoritySourceFileAPI.java
+++ b/src/main/java/org/folio/rest/impl/AuthoritySourceFileAPI.java
@@ -58,12 +58,12 @@ public class AuthoritySourceFileAPI implements org.folio.rest.jaxrs.resource.Aut
                                             Context vertxContext) {
     new AuthoritySourceFileRepository(vertxContext, okapiHeaders).getById(id)
       .compose(CommonValidators::refuseIfNotFound)
-      .compose(record -> {
-        record.setBaseUrl(patchData.getBaseUrl());
+      .compose(entity -> {
+        entity.setBaseUrl(patchData.getBaseUrl());
 
-        normalizeBaseUrl(record);
+        normalizeBaseUrl(entity);
 
-        return put(AUTHORITY_SOURCE_FILE_TABLE, record, id, okapiHeaders, vertxContext,
+        return put(AUTHORITY_SOURCE_FILE_TABLE, entity, id, okapiHeaders, vertxContext,
           PatchAuthoritySourceFilesByIdResponse.class);
       })
       .onSuccess(response -> asyncResultHandler.handle(succeededFuture(response)))

--- a/src/main/java/org/folio/rest/impl/AuthoritySourceFileAPI.java
+++ b/src/main/java/org/folio/rest/impl/AuthoritySourceFileAPI.java
@@ -15,7 +15,7 @@ public class AuthoritySourceFileAPI implements org.folio.rest.jaxrs.resource.Aut
 
   public static final String REFERENCE_TABLE = "authority_source_file";
 
-  public static final String ULR_PROTOCOL_PATTERN = "^(http[s]?://www\\.|http[s]?://|www\\.)";
+  public static final String URL_PROTOCOL_PATTERN = "^(http[s]?://www\\.|http[s]?://|www\\.)";
 
   @Override
   @Validate
@@ -81,7 +81,7 @@ public class AuthoritySourceFileAPI implements org.folio.rest.jaxrs.resource.Aut
   private static void normalizeBaseUrl(AuthoritySourceFile entity) {
     var baseUrl = entity.getBaseUrl();
     if (StringUtils.isNotBlank(baseUrl)) {
-      baseUrl = baseUrl.replaceFirst(ULR_PROTOCOL_PATTERN, "");
+      baseUrl = baseUrl.replaceFirst(URL_PROTOCOL_PATTERN, "");
       if (!baseUrl.endsWith("/")) {
         baseUrl += "/";
       }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -868,6 +868,10 @@
         {
           "fieldName": "codes",
           "tOps": "ADD"
+        },
+        {
+          "fieldName": "baseUrl",
+          "tOps": "ADD"
         }
       ]
     }

--- a/src/test/java/org/folio/rest/api/AuthoritySourceFileAPITest.java
+++ b/src/test/java/org/folio/rest/api/AuthoritySourceFileAPITest.java
@@ -1,0 +1,54 @@
+package org.folio.rest.api;
+
+import static org.folio.rest.api.entities.AuthoritySourceFile.BASE_URL_KEY;
+import static org.folio.rest.api.entities.AuthoritySourceFile.CODES_KEY;
+import static org.folio.rest.api.entities.AuthoritySourceFile.NAME_KEY;
+import static org.folio.rest.api.entities.AuthoritySourceFile.SOURCE_KEY;
+import static org.folio.rest.api.entities.AuthoritySourceFile.TYPE_KEY;
+import static org.folio.rest.api.entities.JsonEntity.ID_KEY;
+import static org.junit.Assert.assertEquals;
+
+import io.vertx.core.json.JsonObject;
+import java.util.List;
+import java.util.UUID;
+import junitparams.JUnitParamsRunner;
+import org.folio.rest.support.http.ResourceClient;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitParamsRunner.class)
+public class AuthoritySourceFileAPITest extends TestBase {
+
+  private static ResourceClient authoritySourceFileClient = ResourceClient.forAuthoritySourceFiles(client);
+
+  @Test
+  public void shouldNormalizeBaseUrl() {
+    var nonNormalizedBaseUrl = "https://www.id.loc.gov/authoritiesq/subjects";
+    var entityId = UUID.randomUUID();
+
+    var creationResponse = authoritySourceFileClient.create(
+      prepareTestEntity(entityId, nonNormalizedBaseUrl));
+    var entity = creationResponse.getJson();
+
+    assertEquals("id.loc.gov/authoritiesq/subjects/", entity.getString(BASE_URL_KEY));
+
+    // Test baseUrl normalization on PUT
+    entity.put(BASE_URL_KEY, "http://example.com/authorities/");
+
+    authoritySourceFileClient.replace(entityId, entity);
+    var updatedEntity = authoritySourceFileClient.getById(entityId).getJson();
+
+    assertEquals("example.com/authorities/", updatedEntity.getString(BASE_URL_KEY));
+  }
+
+  private static JsonObject prepareTestEntity(UUID id, String baseUrl) {
+    return new JsonObject()
+      .put(ID_KEY, id)
+      .put(CODES_KEY, List.of("tst1"))
+      .put(TYPE_KEY, "Subjects")
+      .put(SOURCE_KEY, "local")
+      .put(BASE_URL_KEY, baseUrl)
+      .put(NAME_KEY, "test");
+  }
+
+}

--- a/src/test/java/org/folio/rest/api/ReferenceTablesTest.java
+++ b/src/test/java/org/folio/rest/api/ReferenceTablesTest.java
@@ -639,8 +639,8 @@ public class ReferenceTablesTest extends TestBase {
     TimeoutException,
     ExecutionException {
     String entityPath = "/authority-source-files";
-    AuthoritySourceFile entity =
-      new AuthoritySourceFile("Test authority source file", List.of("test"), "Subjects");
+    AuthoritySourceFile entity = new AuthoritySourceFile("Test authority source file", List.of("test"),
+        "Subjects", "example.com/sources/", "folio");
 
     Response postResponse = createReferenceRecord(entityPath, entity);
     assertThat(postResponse.getStatusCode(),

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -88,7 +88,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
   LegacyItemEffectiveLocationMigrationScriptTest.class,
   IterationJobRunnerTest.class,
   AuthorityStorageTest.class,
-  SampleDataTest.class
+  SampleDataTest.class,
+  AuthoritySourceFileAPITest.class
 })
 public class StorageTestSuite {
   public static final String TENANT_ID = "test_tenant";

--- a/src/test/java/org/folio/rest/api/entities/AuthoritySourceFile.java
+++ b/src/test/java/org/folio/rest/api/entities/AuthoritySourceFile.java
@@ -6,11 +6,15 @@ public class AuthoritySourceFile extends JsonEntity {
   public static final String NAME_KEY = "name";
   public static final String CODES_KEY = "codes";
   public static final String TYPE_KEY = "type";
+  public static final String BASE_URL_KEY = "baseUrl";
+  public static final String SOURCE_KEY = "source";
 
-  public AuthoritySourceFile(String name, List<String> codes, String type) {
+  public AuthoritySourceFile(String name, List<String> codes, String type, String baseUrl, String source) {
     super.setProperty(NAME_KEY, name);
     super.setProperty(CODES_KEY, codes);
     super.setProperty(TYPE_KEY, type);
+    super.setProperty(BASE_URL_KEY, baseUrl);
+    super.setProperty(SOURCE_KEY, source);
   }
 
   @Override

--- a/src/test/java/org/folio/rest/support/HttpClient.java
+++ b/src/test/java/org/folio/rest/support/HttpClient.java
@@ -219,4 +219,8 @@ public class HttpClient {
   public CompletableFuture<Response> delete(URL url, String tenantId) {
     return asResponse(request(HttpMethod.DELETE, url, tenantId));
   }
+
+  public CompletableFuture<Response> patch(URL url, Object body, String tenantId) {
+    return asResponse(request(HttpMethod.PATCH, url, body, tenantId));
+  }
 }


### PR DESCRIPTION
**Purpose**
We need to populate a linked bib field $0 with a valid URI so that it's easier to support updating this information with rollout of additional capabilities. 

JIRA: https://issues.folio.org/browse/MODINVSTOR-952

**Approach**
- AuthoritySourceFile schema is updated with 'baseUrl' field
- AuthoritySourceFile schema is updated with 'source' field to distinguish pre-defined and custom records.