### PR TITLE
MODINVSTOR-955 Extend authority schema with Authority Natural ID

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 ## 25.0.0 IN-PROGRESS
 
+* Extend authority schema with Authority Natural ID ([MODINVSTOR-955](https://issues.folio.org/browse/MODINVSTOR-955))
 * Create a pre-defined Authority Source file list, extend authority schema with sourceFileId ([MODINVSTOR-892](https://issues.folio.org/browse/MODINVSTOR-892))
 * provides `authority-storage 1.1`
 * provides `authority-source-files 1.0`

--- a/ramls/authorities/authority.json
+++ b/ramls/authorities/authority.json
@@ -250,6 +250,10 @@
       "description": "Authority source file id; UUID",
       "$ref": "../uuid.json"
     },
+    "naturalId": {
+      "type": "string",
+      "description": "Authority Natural ID"
+    },
     "metadata": {
       "type": "object",
       "description": "Creater, updater, creation date, last updated date",


### PR DESCRIPTION
**Purpose**
It's needed to have information of an Authority Natural ID to use it in a link in $0 subfield of linked bib fields.

JIRA: https://issues.folio.org/browse/MODINVSTOR-955

**Approach**
- Extend authority schema with `naturalId` field