### PR TITLE
MODINVSTOR-944: GET Instance Set by CQL - MG back-port

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+## 24.1.0 IN-PROGRESS
+
+* GET Instance Set by CQL ([MODINVSTOR-918](https://issues.folio.org/browse/MODINVSTOR-918))
+* provides `inventory-view-instance-set 1.0`
+
 ## 24.0.4 2022-08-24
 
 * Adds integrity checks for statistical code types during upgrade ([MODINVSTOR-935](https://issues.folio.org/browse/MODINVSTOR-935))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1253,6 +1253,17 @@
       ]
     },
     {
+      "id": "inventory-view-instance-set",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": ["GET"],
+          "pathPattern": "/inventory-view/instance-set",
+          "permissionsRequired": ["inventory-storage.inventory-view.instance-set.get"]
+        }
+      ]
+    },
+    {
       "id": "instance-reindex",
       "version": "0.1",
       "handlers": [
@@ -2484,6 +2495,11 @@
       "description": "get instances by query with their holdings and items"
     },
     {
+      "permissionName": "inventory-storage.inventory-view.instance-set.get",
+      "displayName": "inventory view - get instances by query with a set of related records",
+      "description": "get instances by query with a set of related records"
+    },
+    {
       "permissionName": "inventory-storage.migration.job.item.delete",
       "displayName": "inventory storage - cancel migration job",
       "description": "cancel a running migration job"
@@ -2731,6 +2747,7 @@
         "inventory-storage.inventory-hierarchy.updated-instances-ids.collection.get",
         "inventory-storage.inventory-hierarchy.items-and-holdings.collection.post",
         "inventory-storage.inventory-view.instances.collection.get",
+        "inventory-storage.inventory-view.instance-set.get",
         "inventory-storage.inventory-hierarchy.items-and-holdings.collection.post",
         "inventory-storage.instance.reindex.item.delete",
         "inventory-storage.instance.reindex.item.get",

--- a/ramls/examples/instance-set.json
+++ b/ramls/examples/instance-set.json
@@ -1,0 +1,223 @@
+{
+  "instanceSet": [
+    {
+      "id": "4b763e7c-2470-4d31-91b0-23a606b7d55e",
+      "instance": {
+        "id": "4b763e7c-2470-4d31-91b0-23a606b7d55e",
+        "_version": 1,
+        "hrid": "in00000000002",
+        "source": "TEST",
+        "title": "Long Way to a Small Angry Planet",
+        "alternativeTitles": [],
+        "editions": [],
+        "series": [],
+        "identifiers": [
+          {
+            "value": "9781473619777",
+            "identifierTypeId": "8261054f-be78-422d-bd51-4ed9f33c3422"
+          }
+        ],
+        "contributors": [
+          {
+            "name": "Chambers, Becky",
+            "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a"
+          }
+        ],
+        "subjects": [],
+        "classifications": [],
+        "publication": [],
+        "publicationFrequency": [],
+        "publicationRange": [],
+        "electronicAccess": [],
+        "instanceTypeId": "535e3160-763a-42f9-b0c0-d8ed7df6e2a2",
+        "instanceFormatIds": [],
+        "instanceFormats": [],
+        "physicalDescriptions": [],
+        "languages": [],
+        "notes": [],
+        "discoverySuppress": false,
+        "statisticalCodeIds": [],
+        "statusUpdatedDate": "2021-02-24T11:30:15.752+0200",
+        "tags": {
+          "tagList": [
+            "test-tag"
+          ]
+        },
+        "metadata": {
+          "createdDate": "2021-02-24T09:30:15.752+00:00",
+          "updatedDate": "2021-02-24T09:30:15.752+00:00"
+        },
+        "holdingsRecords2": [],
+        "natureOfContentTermIds": []
+      },
+      "holdingsRecords": [
+        {
+          "id": "2a4cad3d-d978-4404-88f3-f4c2b04f254c",
+          "_version": 1,
+          "hrid": "ho00000000003",
+          "formerIds": [],
+          "instanceId": "4b763e7c-2470-4d31-91b0-23a606b7d55e",
+          "permanentLocationId": "9f551ce9-ac88-4f89-970d-b00e4b69edf2",
+          "electronicAccess": [],
+          "notes": [],
+          "holdingsStatements": [],
+          "holdingsStatementsForIndexes": [],
+          "holdingsStatementsForSupplements": [],
+          "statisticalCodeIds": [],
+          "holdingsItems": [],
+          "bareHoldingsItems": [],
+          "metadata": {
+            "createdDate": "2021-02-24T09:30:15.770+00:00",
+            "updatedDate": "2021-02-24T09:30:15.770+00:00"
+          }
+        },
+        {
+          "id": "3dac5efd-f778-498c-9e58-bea2473694b1",
+          "_version": 1,
+          "hrid": "ho00000000004",
+          "formerIds": [],
+          "instanceId": "4b763e7c-2470-4d31-91b0-23a606b7d55e",
+          "permanentLocationId": "ded842f9-cd42-43f5-bc9c-e54cb1bfa2e0",
+          "electronicAccess": [],
+          "notes": [],
+          "holdingsStatements": [],
+          "holdingsStatementsForIndexes": [],
+          "holdingsStatementsForSupplements": [],
+          "statisticalCodeIds": [],
+          "holdingsItems": [],
+          "bareHoldingsItems": [],
+          "metadata": {
+            "createdDate": "2021-02-24T09:30:15.786+00:00",
+            "updatedDate": "2021-02-24T09:30:15.786+00:00"
+          }
+        },
+        {
+          "id": "5508aa51-dc6c-4bd5-8b88-2773cf3f2978",
+          "_version": 1,
+          "hrid": "ho00000000005",
+          "formerIds": [],
+          "instanceId": "4b763e7c-2470-4d31-91b0-23a606b7d55e",
+          "permanentLocationId": "ce97794f-2729-49c7-8561-d7016816b685",
+          "electronicAccess": [],
+          "notes": [],
+          "holdingsStatements": [],
+          "holdingsStatementsForIndexes": [],
+          "holdingsStatementsForSupplements": [],
+          "statisticalCodeIds": [],
+          "holdingsItems": [],
+          "bareHoldingsItems": [],
+          "metadata": {
+            "createdDate": "2021-02-24T09:30:15.811+00:00",
+            "updatedDate": "2021-02-24T09:30:15.811+00:00"
+          }
+        }
+      ],
+      "items": [
+        {
+          "id": "c83efee3-ebbc-4772-ab34-1918381da2c7",
+          "_version": 1,
+          "hrid": "it00000000003",
+          "holdingsRecordId": "2a4cad3d-d978-4404-88f3-f4c2b04f254c",
+          "formerIds": [],
+          "barcode": "565578437802",
+          "effectiveCallNumberComponents": {},
+          "yearCaption": [],
+          "notes": [],
+          "circulationNotes": [],
+          "status": {
+            "name": "Available",
+            "date": "2021-02-24T09:30:15.828+00:00"
+          },
+          "materialTypeId": "0c7ff668-08d4-47b5-ae64-f5a31b757e1c",
+          "permanentLoanTypeId": "81ebe45c-f4df-4b92-afab-90b4f433f6b3",
+          "temporaryLocationId": "bbe659bf-fb2d-44b2-bd1a-7f968993bca0",
+          "effectiveLocationId": "bbe659bf-fb2d-44b2-bd1a-7f968993bca0",
+          "electronicAccess": [],
+          "statisticalCodeIds": [],
+          "metadata": {
+            "createdDate": "2021-02-24T09:30:15.828+00:00",
+            "updatedDate": "2021-02-24T09:30:15.828+00:00"
+          }
+        },
+        {
+          "id": "bf6b5993-7f0a-4bcf-9b48-fac7e4405a48",
+          "_version": 1,
+          "hrid": "it00000000004",
+          "holdingsRecordId": "2a4cad3d-d978-4404-88f3-f4c2b04f254c",
+          "formerIds": [],
+          "barcode": "565578437802",
+          "effectiveCallNumberComponents": {},
+          "yearCaption": [],
+          "notes": [],
+          "circulationNotes": [],
+          "status": {
+            "name": "Available",
+            "date": "2021-02-24T09:30:15.848+00:00"
+          },
+          "materialTypeId": "0c7ff668-08d4-47b5-ae64-f5a31b757e1c",
+          "permanentLoanTypeId": "81ebe45c-f4df-4b92-afab-90b4f433f6b3",
+          "temporaryLocationId": "bbe659bf-fb2d-44b2-bd1a-7f968993bca0",
+          "effectiveLocationId": "bbe659bf-fb2d-44b2-bd1a-7f968993bca0",
+          "electronicAccess": [],
+          "statisticalCodeIds": [],
+          "metadata": {
+            "createdDate": "2021-02-24T09:30:15.848+00:00",
+            "updatedDate": "2021-02-24T09:30:15.848+00:00"
+          }
+        },
+        {
+          "id": "6f3a5084-75a6-4065-9b8e-19cf62a64b01",
+          "_version": 1,
+          "hrid": "it00000000005",
+          "holdingsRecordId": "3dac5efd-f778-498c-9e58-bea2473694b1",
+          "formerIds": [],
+          "barcode": "565578437802",
+          "effectiveCallNumberComponents": {},
+          "yearCaption": [],
+          "notes": [],
+          "circulationNotes": [],
+          "status": {
+            "name": "Available",
+            "date": "2021-02-24T09:30:15.868+00:00"
+          },
+          "materialTypeId": "0c7ff668-08d4-47b5-ae64-f5a31b757e1c",
+          "permanentLoanTypeId": "81ebe45c-f4df-4b92-afab-90b4f433f6b3",
+          "temporaryLocationId": "bbe659bf-fb2d-44b2-bd1a-7f968993bca0",
+          "effectiveLocationId": "bbe659bf-fb2d-44b2-bd1a-7f968993bca0",
+          "electronicAccess": [],
+          "statisticalCodeIds": [],
+          "metadata": {
+            "createdDate": "2021-02-24T09:30:15.868+00:00",
+            "updatedDate": "2021-02-24T09:30:15.868+00:00"
+          }
+        },
+        {
+          "id": "e6febf5b-e931-473c-b9a5-60e9cfc27ce1",
+          "_version": 1,
+          "hrid": "it00000000006",
+          "holdingsRecordId": "5508aa51-dc6c-4bd5-8b88-2773cf3f2978",
+          "formerIds": [],
+          "barcode": "565578437802",
+          "effectiveCallNumberComponents": {},
+          "yearCaption": [],
+          "notes": [],
+          "circulationNotes": [],
+          "status": {
+            "name": "Available",
+            "date": "2021-02-24T09:30:15.885+00:00"
+          },
+          "materialTypeId": "0c7ff668-08d4-47b5-ae64-f5a31b757e1c",
+          "permanentLoanTypeId": "81ebe45c-f4df-4b92-afab-90b4f433f6b3",
+          "temporaryLocationId": "bbe659bf-fb2d-44b2-bd1a-7f968993bca0",
+          "effectiveLocationId": "bbe659bf-fb2d-44b2-bd1a-7f968993bca0",
+          "electronicAccess": [],
+          "statisticalCodeIds": [],
+          "metadata": {
+            "createdDate": "2021-02-24T09:30:15.885+00:00",
+            "updatedDate": "2021-02-24T09:30:15.885+00:00"
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/ramls/instance-set.json
+++ b/ramls/instance-set.json
@@ -1,0 +1,59 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "Instance with holdings, items, preceding titles, succeeding titles, super instances, sub instances",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Instance id",
+      "$ref": "uuid.json"
+    },
+    "instance": {
+      "description": "Instance record",
+      "$ref": "instance.json"
+    },
+    "holdingsRecords": {
+      "type": "array",
+      "description": "Holdings records of the instance",
+      "items": {
+        "$ref": "holdingsrecord.json"
+      }
+    },
+    "items": {
+      "type": "array",
+      "description": "Items of the instance",
+      "items": {
+        "$ref": "item.json"
+      }
+    },
+    "precedingTitles": {
+      "type": "array",
+      "description": "Instances that are preceding titles of the instance",
+      "items": {
+        "$ref": "instance.json"
+      }
+    },
+    "succeedingTitles": {
+      "type": "array",
+      "description": "Instances that are succeeding titles of the instance",
+      "items": {
+        "$ref": "instance.json"
+      }
+    },
+    "superInstanceRelationships": {
+      "type": "array",
+      "description": "Instances that are super instances of the instance",
+      "items": {
+        "$ref": "instance.json"
+      }
+    },
+    "subInstanceRelationships": {
+      "type": "array",
+      "description": "Instances that are sub instances of the instance",
+      "items": {
+        "$ref": "instance.json"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": ["id"]
+}

--- a/ramls/instance-set.raml
+++ b/ramls/instance-set.raml
@@ -1,0 +1,81 @@
+#%RAML 1.0
+title: Instance Set API
+version: v1.0
+protocols: [ HTTP, HTTPS ]
+baseUri: http://github.com/org/folio/mod-inventory-storage
+
+documentation:
+  - title: Instance Set
+    content: Get instances, for each instance get related records
+
+types:
+  instanceSet: !include instance-set.json
+  errors: !include raml-util/schemas/errors.schema
+
+traits:
+  language: !include raml-util/traits/language.raml
+  validate: !include raml-util/traits/validation.raml
+  searchable: !include raml-util/traits/searchable.raml
+
+resourceTypes:
+  collection-stream: !include raml-util/rtypes/collection-stream.raml
+
+/inventory-view/instance-set:
+  type:
+    collection-stream:
+     schemaCollection: instanceSet
+     exampleCollection: !include examples/instance-set.json
+  get:
+    description: Get instances, for each instance get related records
+    is: [searchable: {description: "using CQL", example: "hrid==\"in007\""}]
+    queryParameters:
+      instance:
+        description: Add "instance" property with the instance JSON
+        type: boolean
+        required: false
+        default: false
+      holdingsRecords:
+        description: Add "holdingsRecords" array with all holdings record JSONs that belong to the instance
+        type: boolean
+        required: false
+        default: false
+      items:
+        description: Add "items" array with all item JSONs that belong to the instance
+        type: boolean
+        required: false
+        default: false
+      precedingTitles:
+        description: Add "precedingTitles" array with relationship records, each has a precedingInstanceId property
+        type: boolean
+        required: false
+        default: false
+      succeedingTitles:
+        description: Add "succeedingTitles" array with relationship records, each has a succeedingInstanceId property
+        type: boolean
+        required: false
+        default: false
+      superInstanceRelationships:
+        description: Add "superInstanceRelationships" array with relationship records, each has a superInstanceId property
+        type: boolean
+        required: false
+        default: false
+      subInstanceRelationships:
+        description: Add "subInstanceRelationships" array with relationship records, each has a subInstanceId property
+        type: boolean
+        required: false
+        default: false
+      offset:
+        description: Skip over a number of elements by specifying an offset value for the query
+        type: integer
+        required: false
+        example: 0
+        default: 0
+        minimum: 0
+        maximum: 2147483647
+      limit:
+        description: Limit the number of instance records to return data for; small maximum avoids out of memory
+        type: integer
+        required: true
+        example: 1
+        minimum: 1
+        maximum: 10

--- a/ramls/instance-sets.json
+++ b/ramls/instance-sets.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "List of instance sets",
+  "type": "object",
+  "properties": {
+    "instanceSets": {
+      "type": "array",
+      "description": "List of instance sets",
+      "items": {
+        "$ref": "instance-set.json"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": ["instanceSets"]
+}

--- a/src/main/java/org/folio/persist/InstanceRepository.java
+++ b/src/main/java/org/folio/persist/InstanceRepository.java
@@ -8,7 +8,6 @@ import io.vertx.sqlclient.RowStream;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.rest.exceptions.BadRequestException;
 import org.folio.rest.jaxrs.model.Instance;
-import org.folio.rest.jaxrs.resource.InventoryViewInstanceSet;
 import org.folio.rest.persist.SQLConnection;
 import org.folio.rest.persist.cql.CQLQueryValidationException;
 import org.folio.rest.persist.cql.CQLWrapper;
@@ -29,6 +28,7 @@ public class InstanceRepository extends AbstractRepository<Instance> {
       "SELECT id FROM " + postgresClientFuturized.getFullTableName(INSTANCE_TABLE));
   }
 
+  @SuppressWarnings("java:S107") // suppress "Methods should not have too many parameters"
   public Future<Response> getInstanceSet(boolean instance, boolean holdingsRecords, boolean items,
       boolean precedingTitles, boolean succeedingTitles,
       boolean superInstanceRelationships, boolean subInstanceRelationships,
@@ -82,14 +82,11 @@ public class InstanceRepository extends AbstractRepository<Instance> {
               json.append(iterator.next().getString(0));
             }
             json.append("\n]}");
-            return InventoryViewInstanceSet.GetInventoryViewInstanceSetResponse
-                .ok(json.toString(), MediaType.APPLICATION_JSON_TYPE)
-                .build();
+            return Response.ok(json.toString(), MediaType.APPLICATION_JSON_TYPE).build();
           });
+    } catch (CQLQueryValidationException e) {
+      return Future.failedFuture(new BadRequestException(e.getMessage()));
     } catch (Exception e) {
-      if (e instanceof CQLQueryValidationException) {
-        e = new BadRequestException(e.getMessage());
-      }
       return Future.failedFuture(e);
     }
   }

--- a/src/main/java/org/folio/persist/InstanceRepository.java
+++ b/src/main/java/org/folio/persist/InstanceRepository.java
@@ -1,18 +1,24 @@
 package org.folio.persist;
 
+import static org.folio.rest.persist.PgUtil.postgresClient;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowStream;
+import org.folio.cql2pgjson.CQL2PgJSON;
+import org.folio.rest.exceptions.BadRequestException;
 import org.folio.rest.jaxrs.model.Instance;
+import org.folio.rest.jaxrs.resource.InventoryViewInstanceSet;
 import org.folio.rest.persist.SQLConnection;
-
+import org.folio.rest.persist.cql.CQLQueryValidationException;
+import org.folio.rest.persist.cql.CQLWrapper;
 import java.util.Map;
-
-import static org.folio.rest.persist.PgUtil.postgresClient;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 public class InstanceRepository extends AbstractRepository<Instance> {
   public static final String INSTANCE_TABLE = "instance";
+  private static final String INSTANCE_SET_VIEW = "instance_set";
 
   public InstanceRepository(Context context, Map<String, String> okapiHeaders) {
     super(postgresClient(context, okapiHeaders), INSTANCE_TABLE, Instance.class);
@@ -21,5 +27,70 @@ public class InstanceRepository extends AbstractRepository<Instance> {
   public Future<RowStream<Row>> getAllIds(SQLConnection connection) {
     return postgresClientFuturized.selectStream(connection,
       "SELECT id FROM " + postgresClientFuturized.getFullTableName(INSTANCE_TABLE));
+  }
+
+  public Future<Response> getInstanceSet(boolean instance, boolean holdingsRecords, boolean items,
+      boolean precedingTitles, boolean succeedingTitles,
+      boolean superInstanceRelationships, boolean subInstanceRelationships,
+      int offset, int limit, String query) {
+
+    try {
+      StringBuilder sql = new StringBuilder(200);
+      sql.append("SELECT jsonb_build_object('id', id");
+      if (instance) {
+        sql.append(", 'instance', jsonb");
+      }
+      if (holdingsRecords) {
+        sql.append(", 'holdingsRecords', holdings_records");
+      }
+      if (items) {
+        sql.append(", 'items', items");
+      }
+      if (precedingTitles) {
+        sql.append(", 'precedingTitles', preceding_titles");
+      }
+      if (succeedingTitles) {
+        sql.append(", 'succeedingTitles', succeeding_titles");
+      }
+      if (superInstanceRelationships) {
+        sql.append(", 'superInstanceRelationships', super_instance_relationships");
+      }
+      if (subInstanceRelationships) {
+        sql.append(", 'subInstanceRelationships', sub_instance_relationships");
+      }
+      sql.append(")::text FROM ")
+      .append(postgresClientFuturized.getFullTableName(INSTANCE_SET_VIEW))
+      .append(" JOIN ")
+      .append(postgresClientFuturized.getFullTableName(INSTANCE_TABLE))
+      .append(" USING (id) ");
+
+      var field = new CQL2PgJSON(INSTANCE_TABLE + ".jsonb");
+      var cqlWrapper = new CQLWrapper(field, query, limit, offset, "none");
+      sql.append(cqlWrapper.toString());
+
+      return postgresClient.select(sql.toString())
+          .map(rowSet -> {
+            StringBuilder json = new StringBuilder("{\"instanceSets\":[\n");
+            boolean first = true;
+            var iterator = rowSet.iterator();
+            while (iterator.hasNext()) {
+              if (first) {
+                first = false;
+              } else {
+                json.append(",\n");
+              }
+              json.append(iterator.next().getString(0));
+            }
+            json.append("\n]}");
+            return InventoryViewInstanceSet.GetInventoryViewInstanceSetResponse
+                .ok(json.toString(), MediaType.APPLICATION_JSON_TYPE)
+                .build();
+          });
+    } catch (Exception e) {
+      if (e instanceof CQLQueryValidationException) {
+        e = new BadRequestException(e.getMessage());
+      }
+      return Future.failedFuture(e);
+    }
   }
 }

--- a/src/main/java/org/folio/rest/impl/InstanceSetAPI.java
+++ b/src/main/java/org/folio/rest/impl/InstanceSetAPI.java
@@ -1,0 +1,30 @@
+package org.folio.rest.impl;
+
+import java.util.Map;
+import javax.ws.rs.core.Response;
+
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.resource.InventoryViewInstanceSet;
+import org.folio.rest.support.EndpointHandler;
+import org.folio.services.instance.InstanceService;
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Handler;
+
+public class InstanceSetAPI implements InventoryViewInstanceSet {
+
+  @Validate
+  @Override
+  public void getInventoryViewInstanceSet(boolean instance, boolean holdingsRecords, boolean items,
+      boolean precedingTitles, boolean succeedingTitles,
+      boolean superInstanceRelationships, boolean subInstanceRelationships,
+      int offset, int limit, String query, String lang, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+
+    new InstanceService(vertxContext, okapiHeaders)
+    .getInstanceSet(instance, holdingsRecords, items,
+        precedingTitles, succeedingTitles, superInstanceRelationships, subInstanceRelationships,
+        offset, limit, query)
+    .onComplete(EndpointHandler.handle(asyncResultHandler));
+  }
+}

--- a/src/main/java/org/folio/rest/support/EndpointHandler.java
+++ b/src/main/java/org/folio/rest/support/EndpointHandler.java
@@ -1,0 +1,26 @@
+package org.folio.rest.support;
+
+import static io.vertx.core.Future.succeededFuture;
+import javax.ws.rs.core.Response;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Handler;
+
+public final class EndpointHandler {
+  private EndpointHandler() {}
+
+  /**
+   * On success pass the result to asyncResultHandler. On failure use
+   * {@link EndpointFailureHandler} to create an error Response for the Throwable
+   * and pass it to asyncResultHandler.
+   */
+  public static Handler<AsyncResult<Response>> handle(Handler<AsyncResult<Response>> asyncResultHandler) {
+    return result -> {
+      if (result.succeeded()) {
+        asyncResultHandler.handle(succeededFuture(result.result()));
+      } else {
+        EndpointFailureHandler.handleFailure(asyncResultHandler).handle(result.cause());
+      }
+    };
+  }
+}

--- a/src/main/java/org/folio/services/instance/InstanceService.java
+++ b/src/main/java/org/folio/services/instance/InstanceService.java
@@ -52,6 +52,7 @@ public class InstanceService {
     effectiveValuesService = new InstanceEffectiveValuesService();
   }
 
+  @SuppressWarnings("java:S107") // suppress "Methods should not have too many parameters"
   public Future<Response> getInstanceSet(boolean instance, boolean holdingsRecords, boolean items,
       boolean precedingTitles, boolean succeedingTitles,
       boolean superInstanceRelationships, boolean subInstanceRelationships,

--- a/src/main/java/org/folio/services/instance/InstanceService.java
+++ b/src/main/java/org/folio/services/instance/InstanceService.java
@@ -52,6 +52,16 @@ public class InstanceService {
     effectiveValuesService = new InstanceEffectiveValuesService();
   }
 
+  public Future<Response> getInstanceSet(boolean instance, boolean holdingsRecords, boolean items,
+      boolean precedingTitles, boolean succeedingTitles,
+      boolean superInstanceRelationships, boolean subInstanceRelationships,
+      int offset, int limit, String query) {
+
+    return instanceRepository.getInstanceSet(instance, holdingsRecords, items,
+        precedingTitles, succeedingTitles, superInstanceRelationships, subInstanceRelationships,
+        offset, limit, query);
+  }
+
   public Future<Response> createInstance(Instance entity) {
     entity.setStatusUpdatedDate(generateStatusUpdatedDate());
     effectiveValuesService.populateEffectiveValues(entity);

--- a/src/main/resources/templates/db_scripts/createInstanceSetView.sql
+++ b/src/main/resources/templates/db_scripts/createInstanceSetView.sql
@@ -1,0 +1,16 @@
+CREATE OR REPLACE VIEW ${myuniversity}_${mymodule}.instance_set AS
+  SELECT
+    instance.id,
+    (SELECT jsonb_agg(holdings_record.jsonb) FROM holdings_record WHERE holdings_record.instanceid = instance.id)
+      AS holdings_records,
+    (SELECT jsonb_agg(item.jsonb) FROM holdings_record hr JOIN item ON item.holdingsrecordid = hr.id AND hr.instanceid = instance.id)
+      AS items,
+    (SELECT jsonb_agg(jsonb) FROM preceding_succeeding_title WHERE preceding_succeeding_title.succeedinginstanceid=instance.id)
+      AS preceding_titles,
+    (SELECT jsonb_agg(jsonb) FROM preceding_succeeding_title WHERE preceding_succeeding_title.precedinginstanceid=instance.id)
+      AS succeeding_titles,
+    (SELECT jsonb_agg(jsonb) FROM instance_relationship WHERE instance_relationship.subinstanceid=instance.id)
+      AS super_instance_relationships,
+    (SELECT jsonb_agg(jsonb) FROM instance_relationship WHERE instance_relationship.superinstanceid=instance.id)
+      AS sub_instance_relationships
+  FROM instance;

--- a/src/main/resources/templates/db_scripts/createInstanceSetView.sql
+++ b/src/main/resources/templates/db_scripts/createInstanceSetView.sql
@@ -1,16 +1,22 @@
 CREATE OR REPLACE VIEW ${myuniversity}_${mymodule}.instance_set AS
   SELECT
     instance.id,
-    (SELECT jsonb_agg(holdings_record.jsonb) FROM holdings_record WHERE holdings_record.instanceid = instance.id)
+    (SELECT COALESCE(jsonb_agg(holdings_record.jsonb), '[]'::jsonb) FROM holdings_record
+      WHERE holdings_record.instanceid = instance.id)
       AS holdings_records,
-    (SELECT jsonb_agg(item.jsonb) FROM holdings_record hr JOIN item ON item.holdingsrecordid = hr.id AND hr.instanceid = instance.id)
+    (SELECT COALESCE(jsonb_agg(item.jsonb), '[]'::jsonb) FROM holdings_record hr
+      JOIN item ON item.holdingsrecordid = hr.id AND hr.instanceid = instance.id)
       AS items,
-    (SELECT jsonb_agg(jsonb) FROM preceding_succeeding_title WHERE preceding_succeeding_title.succeedinginstanceid=instance.id)
+    (SELECT COALESCE(jsonb_agg(jsonb), '[]'::jsonb) FROM preceding_succeeding_title
+      WHERE preceding_succeeding_title.succeedinginstanceid=instance.id)
       AS preceding_titles,
-    (SELECT jsonb_agg(jsonb) FROM preceding_succeeding_title WHERE preceding_succeeding_title.precedinginstanceid=instance.id)
+    (SELECT COALESCE(jsonb_agg(jsonb), '[]'::jsonb) FROM preceding_succeeding_title
+      WHERE preceding_succeeding_title.precedinginstanceid=instance.id)
       AS succeeding_titles,
-    (SELECT jsonb_agg(jsonb) FROM instance_relationship WHERE instance_relationship.subinstanceid=instance.id)
+    (SELECT COALESCE(jsonb_agg(jsonb), '[]'::jsonb) FROM instance_relationship
+      WHERE instance_relationship.subinstanceid=instance.id)
       AS super_instance_relationships,
-    (SELECT jsonb_agg(jsonb) FROM instance_relationship WHERE instance_relationship.superinstanceid=instance.id)
+    (SELECT COALESCE(jsonb_agg(jsonb), '[]'::jsonb) FROM instance_relationship
+      WHERE instance_relationship.superinstanceid=instance.id)
       AS sub_instance_relationships
   FROM instance;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1036,6 +1036,11 @@
         "run":"after",
         "snippetPath":"dropCallNumberNormalizationFunctions.sql",
         "fromModuleVersion":"24.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "createInstanceSetView.sql",
+      "fromModuleVersion": "25.0.0"
     }
   ]
 }

--- a/src/test/java/org/folio/rest/api/InstanceRelationshipsTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceRelationshipsTest.java
@@ -25,7 +25,7 @@ import io.vertx.core.json.JsonObject;
 
 public class InstanceRelationshipsTest extends TestBaseWithInventoryUtil {
   private final static String INSTANCE_TYPE_ID_TEXT = "6312d172-f0cf-40f6-b27d-9fa8feaf332f";
-  private final static String INSTANCE_RELATIONSHIP_TYPE_ID_BOUNDWITH = "758f13db-ffb4-440e-bb10-8a364aa6cb4a";
+  final static String INSTANCE_RELATIONSHIP_TYPE_ID_BOUNDWITH = "758f13db-ffb4-440e-bb10-8a364aa6cb4a";
 
   @Before
   public void beforeEach() {

--- a/src/test/java/org/folio/rest/api/InstanceSetTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceSetTest.java
@@ -1,0 +1,238 @@
+package org.folio.rest.api;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.folio.rest.api.StorageTestSuite.TENANT_ID;
+import static org.folio.rest.support.ResponseHandler.json;
+import static org.folio.rest.support.ResponseHandler.text;
+import static org.folio.rest.support.http.InterfaceUrls.instanceSetUrl;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.net.URL;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.stream.Collectors;
+import lombok.SneakyThrows;
+import org.folio.rest.support.Response;
+import org.folio.rest.support.builders.HoldingRequestBuilder;
+import org.folio.rest.support.builders.ItemRequestBuilder;
+import org.folio.util.PercentCodec;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class InstanceSetTest extends TestBaseWithInventoryUtil {
+  private static final UUID instanceId1 = UUID.fromString("10000000-0000-4000-8000-000000000000");
+  private static final UUID instanceId2 = UUID.fromString("20000000-0000-4000-8000-000000000000");
+  private static final UUID instanceId3 = UUID.fromString("30000000-0000-4000-8000-000000000000");
+  private static final UUID instanceId4 = UUID.fromString("40000000-0000-4000-8000-000000000000");
+  private static final UUID instanceId5 = UUID.fromString("50000000-0000-4000-8000-000000000000");
+  private static final UUID instanceId6 = UUID.fromString("60000000-0000-4000-8000-000000000000");
+  private static final UUID holdingId11 = UUID.fromString("11000000-0000-4000-8000-000000000000");
+  private static final UUID holdingId61 = UUID.fromString("61000000-0000-4000-8000-000000000000");
+  private static final UUID holdingId62 = UUID.fromString("62000000-0000-4000-8000-000000000000");
+  private static final UUID itemId111   = UUID.fromString("11100000-0000-4000-8000-000000000000");
+  private static final UUID itemId611   = UUID.fromString("61100000-0000-4000-8000-000000000000");
+  private static final UUID itemId612   = UUID.fromString("61200000-0000-4000-8000-000000000000");
+  private static final UUID itemId621   = UUID.fromString("62100000-0000-4000-8000-000000000000");
+
+  @BeforeClass
+  public static void setupRecords() {
+    createInstance(instanceId1);
+    createInstance(instanceId2);
+    createInstance(instanceId3);
+    createInstance(instanceId4);
+    createInstance(instanceId5);
+    createInstance(instanceId6);
+    createHolding(instanceId1, holdingId11);
+    createHolding(instanceId6, holdingId61);
+    createHolding(instanceId6, holdingId62);
+    createItem(holdingId11, itemId111);
+    createItem(holdingId61, itemId611);
+    createItem(holdingId61, itemId612);
+    createItem(holdingId62, itemId621);
+    createPrecedingSucceeding(instanceId1, instanceId6);
+    createPrecedingSucceeding(instanceId2, instanceId6);
+    createPrecedingSucceeding(instanceId6, instanceId3);
+    createPrecedingSucceeding(instanceId6, instanceId4);
+    createRelationship(instanceId1, instanceId6);
+    createRelationship(instanceId4, instanceId6);
+    createRelationship(instanceId6, instanceId3);
+    createRelationship(instanceId6, instanceId5);
+  }
+
+  @Test
+  public void shouldReturnAllInstancesWhenNoCql() {
+    assertThat(getInstanceSets(null).size(), is(6));
+  }
+
+  @Test
+  public void canQueryTwoInstances() {
+    var sets = getInstanceSets("id==" + instanceId3 + " OR id==" + instanceId5 + " sortBy id");
+    assertThat(ids(sets), contains(instanceId3, instanceId5));
+  }
+
+  @Test
+  public void canQueryByHrid() {
+    var sets = getInstanceSets("hrid==in2");
+    assertThat(ids(sets), contains(instanceId2));
+  }
+
+  @Test
+  public void canQueryByItemBarcode() {
+    var sets = getInstanceSets("item.barcode==111");
+    assertThat(ids(sets), contains(instanceId1));
+  }
+
+  @Test
+  @SneakyThrows
+  public void invalidCqlReturns400() {
+    CompletableFuture<Response> getCompleted = new CompletableFuture<>();
+    client.get(instanceSetUrl("?limit=1&query=id=="), TENANT_ID, text(getCompleted));
+    assertThat(getCompleted.get(5, SECONDS).getStatusCode(), is(400));
+  }
+
+  @Test
+  public void canQueryWithLimitAndOffset() {
+    var sets = getInstanceSets("cql.allRecords=1 sortBy id/sort.ascending", 2, 3);
+    assertThat(ids(sets), contains(instanceId4, instanceId5));
+    sets = getInstanceSets("cql.allRecords=1 sortBy id/sort.descending", 2, 3);
+    assertThat(ids(sets), contains(instanceId3, instanceId2));
+  }
+
+  @Test
+  public void canGetInstance() {
+    var set = getInstance6("instance=true");
+    assertThat(set.fieldNames(), containsInAnyOrder("id", "instance"));
+    assertThat(set.getJsonObject("instance").getString("id"), is(instanceId6.toString()));
+  }
+
+  @Test
+  public void canGetHoldingsRecords() {
+    var set = getInstance6("holdingsRecords=true");
+    assertThat(set.fieldNames(), containsInAnyOrder("id", "holdingsRecords"));
+    var holdingsRecords = set.getJsonArray("holdingsRecords");
+    assertThat(ids(holdingsRecords), containsInAnyOrder(holdingId61, holdingId62));
+  }
+
+  @Test
+  public void canGetItems() {
+    var set = getInstance6("items=true");
+    assertThat(set.fieldNames(), containsInAnyOrder("id", "items"));
+    var items = set.getJsonArray("items");
+    assertThat(ids(items), containsInAnyOrder(itemId611, itemId612, itemId621));
+  }
+
+  @Test
+  public void canGetPrecedingTitles() {
+    var set = getInstance6("precedingTitles=true");
+    assertThat(set.fieldNames(), containsInAnyOrder("id", "precedingTitles"));
+    var ids = ids(set, "precedingTitles", "precedingInstanceId");
+    assertThat(ids, containsInAnyOrder(instanceId1, instanceId2));
+  }
+
+  @Test
+  public void canGetSucceedingTitles() {
+    var set = getInstance6("succeedingTitles=true");
+    assertThat(set.fieldNames(), containsInAnyOrder("id", "succeedingTitles"));
+    var ids = ids(set, "succeedingTitles", "succeedingInstanceId");
+    assertThat(ids, containsInAnyOrder(instanceId3, instanceId4));
+  }
+
+  @Test
+  public void canGetSuperInstanceRelationships() {
+    var set = getInstance6("superInstanceRelationships=true");
+    assertThat(set.fieldNames(), containsInAnyOrder("id", "superInstanceRelationships"));
+    var ids = ids(set, "superInstanceRelationships", "superInstanceId");
+    assertThat(ids, containsInAnyOrder(instanceId1, instanceId4));
+  }
+
+  @Test
+  public void canGetSubInstanceRelationships() {
+    var set = getInstance6("subInstanceRelationships=true");
+    assertThat(set.fieldNames(), containsInAnyOrder("id", "subInstanceRelationships"));
+    var ids = ids(set, "subInstanceRelationships", "subInstanceId");
+    assertThat(ids, containsInAnyOrder(instanceId3, instanceId5));
+  }
+
+  private static void createHolding(UUID instanceId, UUID holdingId) {
+    holdingsClient.create(
+        new HoldingRequestBuilder()
+          .withId(holdingId)
+          .forInstance(instanceId)
+          .withPermanentLocation(mainLibraryLocationId));
+  }
+
+  private static void createItem(UUID holdingId, UUID itemId) {
+    itemsClient.create(
+        new ItemRequestBuilder()
+        .forHolding(holdingId)
+        .withId(itemId)
+        .withBarcode(itemId.toString().substring(0, 3))
+        .withMaterialType(bookMaterialTypeId)
+        .withPermanentLoanTypeId(canCirculateLoanTypeId));
+  }
+
+  private static void createInstance(UUID instanceId) {
+    var hrid = "in" + instanceId.toString().substring(0, 1);
+    instancesClient.create(instance(instanceId).put("hrid", hrid));
+  }
+
+  private static void createPrecedingSucceeding(UUID precedingInstanceId, UUID succeedingInstanceId) {
+    precedingSucceedingTitleClient.create(new JsonObject()
+        .put("precedingInstanceId", precedingInstanceId.toString())
+        .put("succeedingInstanceId", succeedingInstanceId.toString()));
+  }
+
+  private static void createRelationship(UUID superInstanceId, UUID subInstanceId) {
+    instanceRelationshipsClient.create(new JsonObject()
+        .put("superInstanceId", superInstanceId.toString())
+        .put("subInstanceId", subInstanceId.toString())
+        .put("instanceRelationshipTypeId", InstanceRelationshipsTest.INSTANCE_RELATIONSHIP_TYPE_ID_BOUNDWITH));
+  }
+
+  private JsonArray getInstanceSets(String cql) {
+    return getInstanceSets(cql, 10, 0);
+  }
+
+  @SneakyThrows
+  private JsonArray getInstanceSets(String cql, int limit, int offset) {
+    String query = cql == null ? "" : "&query=" + PercentCodec.encode(cql);
+    URL url = instanceSetUrl("?limit=" + limit + "&offset=" + offset + query);
+    CompletableFuture<Response> getCompleted = new CompletableFuture<>();
+    client.get(url, TENANT_ID, json(getCompleted));
+    Response response = getCompleted.get(5, SECONDS);
+    return response.getJson().getJsonArray("instanceSets");
+  }
+
+  @SneakyThrows
+  private JsonObject getInstance6(String parameters) {
+    URL url = instanceSetUrl("?limit=10&query=id==" + instanceId6.toString() + "&" + parameters);
+    CompletableFuture<Response> getCompleted = new CompletableFuture<>();
+    client.get(url, TENANT_ID, json(getCompleted));
+    var sets = getCompleted.get(5, SECONDS).getJson().getJsonArray("instanceSets");
+    assertThat(ids(sets), contains(instanceId6));
+    assertThat(sets.size(), is(1));
+    return sets.getJsonObject(0);
+  }
+
+  private List<UUID> ids(JsonArray sets) {
+    return sets
+        .stream()
+        .map(o -> ((JsonObject)o).getString("id"))
+        .map(UUID::fromString)
+        .collect(Collectors.toList());
+  }
+
+  private List<UUID> ids(JsonObject set, String arrayName, String stringName) {
+    return set.getJsonArray(arrayName)
+      .stream()
+      .map(o -> ((JsonObject)o).getString(stringName))
+      .map(UUID::fromString)
+      .collect(Collectors.toList());
+  }
+}

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -78,6 +78,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
   HoldingsSourceTest.class,
   InstanceDomainEventTest.class,
   InventoryViewTest.class,
+  InstanceSetTest.class,
   BoundWithStorageTest.class,
   ReindexJobRunnerTest.class,
   EffectiveLocationMigrationTest.class,

--- a/src/test/java/org/folio/rest/support/http/InterfaceUrls.java
+++ b/src/test/java/org/folio/rest/support/http/InterfaceUrls.java
@@ -62,6 +62,10 @@ public class InterfaceUrls {
     return StorageTestSuite.storageUrl("/instance-storage/batch/synchronous" + subPath);
   }
 
+  public static URL instanceSetUrl(String subPath) {
+    return StorageTestSuite.storageUrl("/inventory-view/instance-set" + subPath);
+  }
+
   public static URL instanceRelationshipsUrl(String subPath) {
     return StorageTestSuite.storageUrl("/instance-storage/instance-relationships" + subPath);
   }
@@ -231,7 +235,7 @@ public class InterfaceUrls {
   public static URL instanceIteration(String path) {
     return StorageTestSuite.storageUrl("/instance-storage/instances/iteration" + path);
   }
-  
+
   public static URL migrationsUrl(String subPath) {
     return StorageTestSuite.storageUrl("/inventory-storage/migrations" + subPath);
   }


### PR DESCRIPTION
The "GET Instance Set by CQL" API ([MODINVSTOR-918](https://issues.folio.org/browse/MODINVSTOR-918)) speeds up mod-inventory-update: initial load is 30% faster, updates are more than 100% faster.

Therefore we need this back-ported to Morning Glory. It's low risk as the API is separate from other code.