### PR TITLE
MODINVSTOR-964: Intermittend even assert failures

### DIFF
--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -259,10 +259,15 @@ public final class DomainEventAssertions {
     await()
       .until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(1));
 
+    var lastUpdateEvent = getItemEvents(instanceIdForItem, itemId).stream()
+        .filter(event -> "UPDATE".equals(event.value().getString("type")))
+        .reduce((a, b) -> b)
+        .get();
+
     // Domain event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
     // so we have to add it manually
-    assertUpdateEvent(getLastItemEvent(instanceIdForItem, itemId),
+    assertUpdateEvent(lastUpdateEvent,
       addInstanceIdForItem(oldItem, getInstanceIdForItem(oldItem)),
       addInstanceIdForItem(newItem, instanceIdForItem));
   }


### PR DESCRIPTION
There is a race condition with the "UPDATE" and the "CREATE" event.

This can be fixed by testing the last "UPDATE" event, not the last event.