### PR TITLE
MODINVSTOR-971: KafkaException: Producer closed while send in progress

### DIFF
--- a/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
@@ -149,7 +149,7 @@ public class CommonDomainEventPublisher<T> {
       });
 
     return promise.future()
-      .onComplete(e -> kafkaProducer.end(ear -> kafkaProducer.close()))
+      .onComplete(e -> kafkaProducer.close())
       .onSuccess(records -> log.info("Total records published from stream {}", records));
   }
 
@@ -165,7 +165,7 @@ public class CommonDomainEventPublisher<T> {
     return producer.send(producerRecord)
       .<Void>map(notUsed -> null)
       .onComplete(result -> {
-        producer.end(par -> producer.close());
+        producer.close();
 
         if (result.failed()) {
           log.error("Unable to send domain event [{}], payload - [{}]",


### PR DESCRIPTION
Steps to Reproduce:
mvn test

Expected Results:
test phase of build succeeds

Actual Results:
About 70% of builds fail with `AsyncMigrationTest.canMigrateItemsInstances:92 » ConditionTimeout Condition wi...`

Complete error message:
```
09:06:55 [] [test_tenant] [] [mod_inventory_storage] ERROR DomainEventPublisher Unable to send event [{"type":"MIGRATION","tenant":"test_tenant","new":{"id":"c1c1ab9c-facd-464f-ac13-07cc57ead051","migrations":["publicationPeriodMigration","itemShelvingOrderMigration"],"affectedEntities":["ITEM","INSTANCE"],"published":[],"processed":[],"jobStatus":"In progress","submittedDate":"2022-10-17T07:06:55.264+00:00"}}]
org.apache.kafka.common.KafkaException: Producer closed while send in progress
        at org.apache.kafka.clients.producer.internals.RecordAccumulator.append(RecordAccumulator.java:199) ~[kafka-clients-3.0.2.jar:?]
        at org.apache.kafka.clients.producer.KafkaProducer.doSend(KafkaProducer.java:926) ~[kafka-clients-3.0.2.jar:?]
        at org.apache.kafka.clients.producer.KafkaProducer.send(KafkaProducer.java:861) ~[kafka-clients-3.0.2.jar:?]
        at io.vertx.kafka.client.producer.impl.KafkaWriteStreamImpl.lambda$send$4(KafkaWriteStreamImpl.java:79) ~[vertx-kafka-client-4.3.4.jar:4.3.4]
        at io.vertx.core.impl.ContextBase.lambda$null$0(ContextBase.java:137) ~[vertx-core-4.3.4.jar:4.3.4]
        at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:264) ~[vertx-core-4.3.4.jar:4.3.4]
        at io.vertx.core.impl.ContextBase.lambda$executeBlocking$1(ContextBase.java:135) ~[vertx-core-4.3.4.jar:4.3.4]
        at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76) ~[vertx-core-4.3.4.jar:4.3.4]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.82.Final.jar:4.1.82.Final]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
09:06:55 [] [test_tenant] [] [mod_inventory_storage] ERROR DomainEventPublisher Unable to send event [{"type":"MIGRATION","tenant":"test_tenant","new":{"id":"c1c1ab9c-facd-464f-ac13-07cc57ead051","migrations":["publicationPeriodMigration","itemShelvingOrderMigration"],"affectedEntities":["ITEM","INSTANCE"],"published":[],"processed":[],"jobStatus":"In progress","submittedDate":"2022-10-17T07:06:55.264+00:00"}}]
java.lang.IllegalStateException: Cannot perform operation after producer has been closed
        at org.apache.kafka.clients.producer.KafkaProducer.throwIfProducerClosed(KafkaProducer.java:868) ~[kafka-clients-3.0.2.jar:?]
        at org.apache.kafka.clients.producer.KafkaProducer.doSend(KafkaProducer.java:877) ~[kafka-clients-3.0.2.jar:?]
        at org.apache.kafka.clients.producer.KafkaProducer.send(KafkaProducer.java:861) ~[kafka-clients-3.0.2.jar:?]
        at io.vertx.kafka.client.producer.impl.KafkaWriteStreamImpl.lambda$send$4(KafkaWriteStreamImpl.java:79) ~[vertx-kafka-client-4.3.4.jar:4.3.4]
        at io.vertx.core.impl.ContextBase.lambda$null$0(ContextBase.java:137) ~[vertx-core-4.3.4.jar:4.3.4]
        at io.vertx.core.impl.ContextInternal.dispatch(ContextInternal.java:264) ~[vertx-core-4.3.4.jar:4.3.4]
        at io.vertx.core.impl.ContextBase.lambda$executeBlocking$1(ContextBase.java:135) ~[vertx-core-4.3.4.jar:4.3.4]
        at io.vertx.core.impl.TaskQueue.run(TaskQueue.java:76) ~[vertx-core-4.3.4.jar:4.3.4]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635) ~[?:?]
        at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30) ~[netty-common-4.1.82.Final.jar:4.1.82.Final]
        at java.lang.Thread.run(Thread.java:833) ~[?:?]
```

Cause:
The shared KafkaProducer is closed with the `end` method:
https://github.com/folio-org/mod-inventory-storage/blob/v24.1.0/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java#L146
https://github.com/folio-org/mod-inventory-storage/blob/v24.1.0/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java#L162
https://github.com/folio-org/mod-inventory-storage/blob/v24.1.0/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java#L178
https://github.com/folio-org/folio-kafka-wrapper/blob/v2.6.0/src/main/java/org/folio/kafka/SimpleKafkaProducerManager.java#L20

A shared KafkaProducer should be closed with the `close` method, not with the `end` method:
https://vertx.io/docs/apidocs/io/vertx/kafka/client/producer/KafkaProducer.html#createShared-io.vertx.core.Vertx-java.lang.String-java.util.Map-

Using the `end` method closes all other shared KafkaProducers.

Several migrations run in parallel:
https://github.com/folio-org/mod-inventory-storage/blob/v24.1.0/src/main/java/org/folio/services/migration/async/AsyncMigrationJobService.java#L61-L63

Migrations to run in parallel:
* itemShelvingOrderMigration
* publicationPeriodMigration

Depending on the hardware and the Vert.x version used their execution may or may not overlap. If they overlap the first migration shuts down the KafkaProducer the second migration has created making the second migration fail with the errors shown above.