### PR TITLE
MODINVSTOR-974: Remove DB_*_READER env var from ModuleDescriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -2900,8 +2900,6 @@
       { "name": "ENV", "value": "folio" },
       { "name": "DB_HOST", "value": "postgres" },
       { "name": "DB_PORT", "value": "5432" },
-      { "name": "DB_HOST_READER", "value": "postgres-read" },
-      { "name": "DB_PORT_READER", "value": "5432" },
       { "name": "DB_USERNAME", "value": "folio_admin" },
       { "name": "DB_PASSWORD", "value": "folio_admin" },
       { "name": "DB_DATABASE", "value": "okapi_modules" },


### PR DESCRIPTION
Remove the DB_*_READER environment variables from ModuleDescriptor, they are non-default values and fail the installation because most environments neither have a postgres-read host nor any other PostgreSQL reader host.