### PR TITLE
MODINVSTOR-976: AsyncMigrationTest:92 ConditionTimeout

### DIFF
--- a/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
@@ -149,7 +149,7 @@ public class CommonDomainEventPublisher<T> {
       });
 
     return promise.future()
-      .onComplete(e -> kafkaProducer.close())
+      .onComplete(e -> kafkaProducer.flush(x -> kafkaProducer.close()))
       .onSuccess(records -> log.info("Total records published from stream {}", records));
   }
 
@@ -165,7 +165,7 @@ public class CommonDomainEventPublisher<T> {
     return producer.send(producerRecord)
       .<Void>map(notUsed -> null)
       .onComplete(result -> {
-        producer.close();
+        producer.flush(x -> producer.close());
 
         if (result.failed()) {
           log.error("Unable to send domain event [{}], payload - [{}]",


### PR DESCRIPTION
80% of all builds fail with a ConditionTimeout in AsyncMigrationTest.canMigrateItemsInstances:92

Replacing
`kafkaProducer.close()`
by
`kafkaProducer.flush(x -> kafkaProducer.close())`
in CommonDomainEventPublisher reduces this to 50%.