### PR TITLE
MODINVSTOR-977: hasRemoveEvent fixing sporadic unit test failures

### DIFF
--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -38,6 +38,7 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.producer.KafkaHeader;
+import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -77,6 +78,21 @@ public final class DomainEventAssertions {
     assertThat(deleteEvent.value().getJsonObject("old"), equalsIgnoringMetadata(record));
 
     assertHeaders(deleteEvent.headers());
+  }
+
+  private static boolean hasRemoveEvent(Collection<KafkaConsumerRecord<String, JsonObject>> events, JsonObject record) {
+    if (events == null) {
+      return false;
+    }
+    for (var event : events) {
+      try {
+        assertRemoveEvent(event, record);
+        return true;
+      } catch (AssertionError e) {
+        // ignore
+      }
+    }
+    return false;
   }
 
   private static void assertRemoveAllEvent(KafkaConsumerRecord<String, JsonObject> deleteEvent) {
@@ -171,10 +187,7 @@ public final class DomainEventAssertions {
   public static void assertRemoveEventForInstance(JsonObject instance) {
     final String instanceId = instance.getString("id");
 
-    await()
-      .until(() -> getInstanceEvents(instanceId).size(), greaterThan(1));
-
-    assertRemoveEvent(getLastInstanceEvent(instanceId), instance);
+    await().until(() -> hasRemoveEvent(getInstanceEvents(instanceId), instance));
   }
 
   public static void assertRemoveAllEventForInstance() {
@@ -187,10 +200,7 @@ public final class DomainEventAssertions {
   public static void assertRemoveEventForAuthority(JsonObject authority) {
     final String id = authority.getString("id");
 
-    await()
-      .until(() -> getAuthorityEvents(id).size(), greaterThan(1));
-
-    assertRemoveEvent(getLastAuthorityEvent(id), authority);
+    await().until(() -> hasRemoveEvent(getAuthorityEvents(id), authority));
   }
 
   public static void assertRemoveAllEventForAuthority() {
@@ -235,15 +245,11 @@ public final class DomainEventAssertions {
   public static void assertRemoveEventForItem(JsonObject item) {
     final String itemId = item.getString("id");
     final String instanceIdForItem = getInstanceIdForItem(item);
-
-    await()
-      .until(() -> getItemEvents(instanceIdForItem, itemId).size(), greaterThan(1));
-
     // Domain event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
     // so we have to add it manually
-    assertRemoveEvent(getLastItemEvent(instanceIdForItem, itemId),
-      addInstanceIdForItem(item, instanceIdForItem));
+    final JsonObject expectedItem = addInstanceIdForItem(item, instanceIdForItem);
+    await().until(() -> hasRemoveEvent(getItemEvents(instanceIdForItem, itemId), expectedItem));
   }
 
   public static void assertRemoveAllEventForItem() {
@@ -292,10 +298,7 @@ public final class DomainEventAssertions {
     final String id = hr.getString("id");
     final String instanceId = hr.getString("instanceId");
 
-    await()
-      .until(() -> getHoldingsEvents(instanceId, id).size(), greaterThan(1));
-
-    assertRemoveEvent(getLastHoldingEvent(instanceId, id), hr);
+    await().until(() -> hasRemoveEvent(getHoldingsEvents(instanceId, id), hr));
   }
 
   public static void assertRemoveAllEventForHolding() {


### PR DESCRIPTION
About 30% of all builds fail because of at least one of these failures:

```
InstanceStorageTest.canDeleteInstancesByCql:487
  Expected: is "DELETE"
       but: was "CREATE"
```

```
  HoldingsStorageTest.canDeleteHoldingsByCql:647
Expected: is "DELETE"
     but: was "CREATE"
```

```
ItemStorageTest.canDeleteItemsByCql:2045
  Expected: is "DELETE"
       but: was "CREATE"
```

The current tests assert that the last event is the expected DELETE event. Due to the async nature of Kafka messages there might be a CREATE event.

Rewrite the test so that it succeeds if the expected DELETE event exists at any position in the event stream.

Write a hasRemoveEvent method that can be used with await().until(() -> hasRemoveEvent(...));