### PR TITLE
Fix AsyncMigrationTest:92 ConditionTimeout MODINVSTOR-976

### DIFF
--- a/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
@@ -149,7 +149,6 @@ public class CommonDomainEventPublisher<T> {
       });
 
     return promise.future()
-      .onComplete(e -> kafkaProducer.close())
       .onSuccess(records -> log.info("Total records published from stream {}", records));
   }
 
@@ -163,16 +162,14 @@ public class CommonDomainEventPublisher<T> {
     KafkaProducer<String, String> producer = getOrCreateProducer();
 
     return producer.send(producerRecord)
-      .<Void>map(notUsed -> null)
-      .onComplete(result -> {
-        producer.close();
+      .<Void>mapEmpty()
+      .eventually(x -> producer.flush())
+      .eventually(x -> producer.close())
+      .onFailure(cause -> {
+        log.error("Unable to send domain event [{}], payload - [{}]",
+          key, value, cause);
 
-        if (result.failed()) {
-          log.error("Unable to send domain event [{}], payload - [{}]",
-            key, value, result.cause());
-
-          failureHandler.handleFailure(result.cause(), producerRecord);
-        }
+        failureHandler.handleFailure(cause, producerRecord);
       });
   }
 

--- a/src/test/java/org/folio/services/domainevent/CommonDomainEventPublisherTest.java
+++ b/src/test/java/org/folio/services/domainevent/CommonDomainEventPublisherTest.java
@@ -126,6 +126,8 @@ public class CommonDomainEventPublisherTest {
     var causeError = new IllegalArgumentException("error");
 
     when(producerManager.<String, String>createShared(any())).thenReturn(producer);
+    when(producer.close()).thenReturn(succeededFuture());
+    when(producer.flush()).thenReturn(succeededFuture());
     when(producer.send(any())).thenReturn(failedFuture(causeError));
 
     var e = assertThrows(RuntimeException.class,


### PR DESCRIPTION
Streams are reused and closing a stream will make exceptions like java.lang.IllegalStateException:
 Cannot perform operation after producer has been closed