### PR TITLE
Use streams for sorting received kafka messages MODINVSTOR-982

### DIFF
--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -5,21 +5,21 @@ import static java.util.Collections.emptyList;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.kafka.common.serialization.StringDeserializer;
+import org.folio.kafka.services.KafkaEnvironmentProperties;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.serialization.JsonObjectDeserializer;
-import org.folio.kafka.services.KafkaEnvironmentProperties;
 
 public final class FakeKafkaConsumer {
   private final static Map<String, List<KafkaConsumerRecord<String, JsonObject>>> itemEvents =
@@ -133,36 +133,19 @@ public final class FakeKafkaConsumer {
     // The testing paradigm needs to account for the asynchronous nature rather
     // than assuming the "first" or "last" event represent the expected
     // response.
-    Iterator<KafkaConsumerRecord<String, JsonObject>> iter = events.stream().iterator();
-    KafkaConsumerRecord<String, JsonObject> last = null;
 
-    while (iter.hasNext()) {
-      KafkaConsumerRecord<String, JsonObject> record = iter.next();
-
-      if (last == null || record.timestamp() > last.timestamp()) {
-        last = record;
-      }
-    }
-
-    return last;
+    return events.stream()
+      .max(Comparator.comparing(KafkaConsumerRecord::timestamp))
+      .orElse(null);
   }
 
   private static KafkaConsumerRecord<String, JsonObject>  getFirstEvent(
     Collection<KafkaConsumerRecord<String, JsonObject> > events) {
 
     // See also the comment in getLastEvent() above.
-    Iterator<KafkaConsumerRecord<String, JsonObject>> iter = events.stream().iterator();
-    KafkaConsumerRecord<String, JsonObject> first = null;
-
-    while (iter.hasNext()) {
-      KafkaConsumerRecord<String, JsonObject> record = iter.next();
-
-      if (first == null || record.timestamp() < first.timestamp()) {
-        first = record;
-      }
-    }
-
-    return first;
+    return events.stream()
+      .min(Comparator.comparing(KafkaConsumerRecord::timestamp))
+      .orElse(null);
   }
 
   public static KafkaConsumerRecord<String, JsonObject> getLastInstanceEvent(

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -135,7 +135,8 @@ public final class FakeKafkaConsumer {
     // response.
 
     return events.stream()
-      .max(Comparator.comparing(KafkaConsumerRecord::timestamp))
+      .sorted(timestampComparator().reversed())
+      .findFirst()
       .orElse(null);
   }
 
@@ -144,8 +145,13 @@ public final class FakeKafkaConsumer {
 
     // See also the comment in getLastEvent() above.
     return events.stream()
-      .min(Comparator.comparing(KafkaConsumerRecord::timestamp))
+      .sorted(timestampComparator())
+      .findFirst()
       .orElse(null);
+  }
+
+  private static Comparator<KafkaConsumerRecord<String, JsonObject>> timestampComparator() {
+    return Comparator.comparing(KafkaConsumerRecord::timestamp);
   }
 
   public static KafkaConsumerRecord<String, JsonObject> getLastInstanceEvent(


### PR DESCRIPTION
Following the work to improve stability of the tests that check published messages, I thought I'd experiment with what a streams implementation of getting the last / first message published was like.

I'd welcome thoughts on whether folks think this expresses intent better or worse than the current iterator based implementation.

(Note: work is needed to reduce the reliance on first / last message because the sequencing should be relied on, rather specific characteristics of the message should be to avoid ordering or concurrency issues)