### PR TITLE
MODINVSTOR-1002: Fix Kafka test failures in BoundWithStorageTest

### DIFF
--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -97,6 +97,12 @@ public final class FakeKafkaConsumer {
     return boundWith.size();
   }
 
+  public static Collection<JsonObject> getAllPublishedBoundWithEvents() {
+    List<JsonObject> list = new ArrayList<>();
+    boundWith.values().forEach(collection -> collection.forEach(record -> list.add(record.value())));
+    return list;
+  }
+
   public static int getAllPublishedAuthoritiesCount() {
     return authorityEvents.size();
   }


### PR DESCRIPTION
About 5% of all GitHub Actions builds fail with one of these Kafka CondittionTimeouts:

`BoundWithStorageTest.canCreateAndRetrieveBoundWithParts:65 » ConditionTimeout ...`

`BoundWithStorageTest.canChangeOnePartOfABoundWith:116 » ConditionTimeout Condi...`

This happens before and after the upgrade to RMB 35.0.4 and Vert.x 4.3.5: https://issues.folio.org/browse/MODINVSTOR-996 = https://github.com/folio-org/mod-inventory-storage/pull/858

This is caused by spurious Kafka messages from other test methods of BoundWithStorageTest.

This fix matches the holdingsRecordId in the Kafka message and ignores other Kafka messages.