### PR TITLE
Use Awaitility Matcher when Creating and Deleting Instances MODINVSTOR-1001

### DIFF
--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -16,7 +16,7 @@ import static org.folio.rest.support.http.InterfaceUrls.instancesStorageSyncUnsa
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageSyncUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.natureOfContentTermsUrl;
-import static org.folio.rest.support.kafka.FakeKafkaConsumer.getInstanceEvents;
+import static org.folio.rest.support.kafka.FakeKafkaConsumer.getMessagesForInstance;
 import static org.folio.rest.support.matchers.DateTimeMatchers.hasIsoFormat;
 import static org.folio.rest.support.matchers.DateTimeMatchers.withinSecondsBeforeNow;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertCreateEventForInstance;
@@ -58,7 +58,6 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -97,7 +96,7 @@ import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.builders.ItemRequestBuilder;
 import org.folio.rest.support.db.OptimisticLocking;
-import org.folio.rest.support.messages.EventMessage;
+import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.folio.rest.support.messages.matchers.EventMessageMatchers;
 import org.folio.rest.tools.utils.OptimisticLockingUtil;
 import org.folio.utility.LocationUtility;
@@ -471,13 +470,6 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     await().atMost(2, SECONDS)
       .until(() -> getMessagesForInstance(instanceId),
         eventMessageMatchers.hasDeleteEventFor(instance));
-  }
-
-  private Collection<EventMessage> getMessagesForInstance(String instanceId) {
-    return getInstanceEvents(instanceId)
-      .stream()
-      .map(EventMessage::fromConsumerRecord)
-      .collect(Collectors.toList());
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -476,7 +476,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final String instanceId = instance.getString("id");
 
     Awaitility.await().atMost(1, SECONDS)
-        .until(() -> getMessagesForInstance(instanceId), hasDeleteEvent(TENANT_ID));
+        .until(() -> getMessagesForInstance(instanceId),
+          hasDeleteEvent(TENANT_ID));
 
     Awaitility.await().atMost(10, SECONDS)
       .until(() -> {
@@ -517,7 +518,15 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   private Matcher<Iterable<? super InstanceEventMessage>> hasDeleteEvent(
     String tenantId) {
 
-    return hasItem(allOf(isDeleteEvent(), isForTenant(tenantId)));
+    return hasItem(allOf(
+      isDeleteEvent(),
+      isForTenant(tenantId),
+      hasNoNewRepresentation()));
+  }
+
+  @NotNull
+  private Matcher<InstanceEventMessage> hasNoNewRepresentation() {
+    return hasProperty("newRepresentation", is(nullValue()));
   }
 
   @NotNull

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -17,11 +17,11 @@ import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.natureOfContentTermsUrl;
 import static org.folio.rest.support.matchers.DateTimeMatchers.hasIsoFormat;
 import static org.folio.rest.support.matchers.DateTimeMatchers.withinSecondsBeforeNow;
-import static org.folio.rest.support.matchers.DomainEventAssertions.assertCreateEventForInstance;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertCreateEventForInstances;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertNoEvent;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveAllEventForInstance;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertUpdateEventForInstance;
+import static org.folio.rest.support.matchers.DomainEventAssertions.instanceCreatedMessagePublished;
 import static org.folio.rest.support.matchers.DomainEventAssertions.instanceDeletedMessagePublished;
 import static org.folio.rest.support.matchers.PostgresErrorMessageMatchers.isMaximumSequenceValueError;
 import static org.folio.rest.support.matchers.PostgresErrorMessageMatchers.isUniqueViolation;
@@ -93,7 +93,6 @@ import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.builders.ItemRequestBuilder;
 import org.folio.rest.support.db.OptimisticLocking;
-import org.folio.rest.support.matchers.DomainEventAssertions;
 import org.folio.rest.tools.utils.OptimisticLockingUtil;
 import org.folio.utility.LocationUtility;
 import org.junit.After;
@@ -221,7 +220,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       instanceFromGet.getString(STATUS_UPDATED_DATE_PROPERTY), hasIsoFormat());
 
     assertThat(instanceFromGet.getBoolean(DISCOVERY_SUPPRESS), is(false));
-    assertCreateEventForInstance(instanceFromGet);
+    instanceCreatedMessagePublished(instanceFromGet);
 
     var storedPublicationPeriod = instance.getJsonObject("publicationPeriod")
       .mapTo(PublicationPeriod.class);
@@ -457,10 +456,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(deleteResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
 
     assertGetNotFound(url);
-
-    JsonObject instance = createdInstance.getJson();
-
-    instanceDeletedMessagePublished(instance);
+    instanceDeletedMessagePublished(createdInstance.getJson());
   }
 
   @SneakyThrows
@@ -494,9 +490,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertNotExists(instance3);
     assertNotExists(instance5);
     getMarcJsonNotFound(id5);
-    DomainEventAssertions.instanceDeletedMessagePublished(instance1);
-    DomainEventAssertions.instanceDeletedMessagePublished(instance3);
-    DomainEventAssertions.instanceDeletedMessagePublished(instance5);
+    instanceDeletedMessagePublished(instance1);
+    instanceDeletedMessagePublished(instance3);
+    instanceDeletedMessagePublished(instance5);
   }
 
   @SneakyThrows
@@ -2041,8 +2037,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(updatedInstance.getString("title"), is("Long Way to a Small Angry Planet"));
 
     assertUpdateEventForInstance(existingInstance.getJson(), updatedInstance);
-    assertCreateEventForInstance(getById(firstInstanceToCreate.getString("id")).getJson());
-    assertCreateEventForInstance(getById(secondInstanceToCreate.getString("id")).getJson());
+    instanceCreatedMessagePublished(getById(firstInstanceToCreate.getString("id")).getJson());
+    instanceCreatedMessagePublished(getById(secondInstanceToCreate.getString("id")).getJson());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -106,6 +106,7 @@ import org.folio.rest.support.messages.InstanceEventMessage;
 import org.folio.rest.tools.utils.OptimisticLockingUtil;
 import org.folio.utility.LocationUtility;
 import org.hamcrest.Matcher;
+import org.jetbrains.annotations.NotNull;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -475,7 +476,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final String instanceId = instance.getString("id");
 
     Awaitility.await().atMost(1, SECONDS)
-        .until(() -> getMessagesForInstance(instanceId), hasDeleteEvent());
+        .until(() -> getMessagesForInstance(instanceId), hasDeleteEvent(TENANT_ID));
 
     Awaitility.await().atMost(10, SECONDS)
       .until(() -> {
@@ -512,9 +513,21 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       });
   }
 
-  private Matcher<Iterable<? super InstanceEventMessage>> hasDeleteEvent() {
-    final Matcher<InstanceEventMessage> itemMatcher = hasProperty("type", is("DELETE"));
-    return hasItem(itemMatcher);
+  @NotNull
+  private Matcher<Iterable<? super InstanceEventMessage>> hasDeleteEvent(
+    String tenantId) {
+
+    return hasItem(allOf(isDeleteEvent(), isForTenant(tenantId)));
+  }
+
+  @NotNull
+  private static Matcher<InstanceEventMessage> isDeleteEvent() {
+    return hasProperty("type", is("DELETE"));
+  }
+
+  @NotNull
+  private Matcher<InstanceEventMessage> isForTenant(String tenantId) {
+    return hasProperty("tenant", is(tenantId));
   }
 
   private Collection<InstanceEventMessage> getMessagesForInstance(String instanceId) {

--- a/src/test/java/org/folio/rest/support/JsonObjectMatchers.java
+++ b/src/test/java/org/folio/rest/support/JsonObjectMatchers.java
@@ -1,11 +1,12 @@
 package org.folio.rest.support;
 
-import io.vertx.core.json.JsonObject;
+import java.util.List;
+
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
 
-import java.util.List;
+import io.vertx.core.json.JsonObject;
 
 public class JsonObjectMatchers {
   public static Matcher<JsonObject> identifierMatches(String identifierTypeId, String value) {
@@ -62,18 +63,26 @@ public class JsonObjectMatchers {
     };
   }
 
-  public static Matcher<JsonObject> equalsIgnoringMetadata(JsonObject expected) {
-    return new TypeSafeMatcher<JsonObject>() {
+  /**
+   * Ignores change metadata because created and updated date might be represented
+   * with either +00:00 or Z due to differences in serialization / deserialization
+   *
+   * @param expectedRepresentation expected representation of the record
+   *
+   * @return a Hamcrest matcher
+   */
+  public static Matcher<JsonObject> equalsIgnoringMetadata(JsonObject expectedRepresentation) {
+    return new TypeSafeMatcher<>() {
       @Override
       public void describeTo(Description description) {
         description.appendText(
-          "a JsonObject being equal when ignoring metadata property: " + expected);
+          "a JsonObject being equal when ignoring metadata property: " + expectedRepresentation);
       }
 
       @Override
       protected boolean matchesSafely(JsonObject jsonObject) {
         var finalJsonObject = jsonObject.copy();
-        var finalExpected = expected.copy();
+        var finalExpected = expectedRepresentation.copy();
         finalJsonObject.remove("metadata");
         finalExpected.remove("metadata");
         return finalJsonObject.equals(finalExpected);

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -3,11 +3,6 @@ package org.folio.rest.support.kafka;
 import static io.vertx.kafka.client.consumer.KafkaConsumer.create;
 import static java.util.Collections.emptyList;
 
-import io.vertx.core.Vertx;
-import io.vertx.core.json.JsonObject;
-import io.vertx.kafka.client.consumer.KafkaConsumer;
-import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
-import io.vertx.kafka.client.serialization.JsonObjectDeserializer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
@@ -16,11 +11,20 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.kafka.services.KafkaEnvironmentProperties;
+import org.folio.rest.support.messages.EventMessage;
 import org.joda.time.DateTime;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.serialization.JsonObjectDeserializer;
 
 public final class FakeKafkaConsumer {
   private static final Logger logger = LogManager.getLogger();
@@ -128,10 +132,6 @@ public final class FakeKafkaConsumer {
     return instanceEvents.size();
   }
 
-  public static int getAllPublishedBoundWithIdsCount() {
-    return boundWith.size();
-  }
-
   public static Collection<JsonObject> getAllPublishedBoundWithEvents() {
     List<JsonObject> list = new ArrayList<>();
     boundWith.values().forEach(collection -> collection.forEach(record -> list.add(record.value())));
@@ -146,6 +146,13 @@ public final class FakeKafkaConsumer {
     String instanceId) {
 
     return instanceEvents.getOrDefault(instanceId, emptyList());
+  }
+
+  public static Collection<EventMessage> getMessagesForInstance(String instanceId) {
+    return getInstanceEvents(instanceId)
+      .stream()
+      .map(EventMessage::fromConsumerRecord)
+      .collect(Collectors.toList());
   }
 
   public static Collection<KafkaConsumerRecord<String, JsonObject> > getAuthorityEvents(

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -173,15 +173,6 @@ public final class DomainEventAssertions {
       .until(() -> getInstanceEvents(instanceId), is(empty()));
   }
 
-  public static void assertCreateEventForInstance(JsonObject instance) {
-    final String instanceId = instance.getString("id");
-
-    await()
-      .until(() -> getInstanceEvents(instanceId).size(), greaterThan(0));
-
-    assertCreateEvent(getFirstInstanceEvent(instanceId), instance);
-  }
-
   public static void assertCreateEventForAuthority(JsonObject authority) {
     final String id = authority.getString("id");
 
@@ -189,6 +180,15 @@ public final class DomainEventAssertions {
       .until(() -> getAuthorityEvents(id).size(), greaterThan(0));
 
     assertCreateEvent(getFirstAuthorityEvent(id), authority);
+  }
+
+  public static void instanceCreatedMessagePublished(JsonObject instance) {
+    final String instanceId = instance.getString("id");
+
+    final var eventMessageMatchers = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
+
+    await().until(() -> getMessagesForInstance(instanceId),
+      eventMessageMatchers.hasCreateEventMessageFor(instance));
   }
 
   public static void assertCreateEventForInstances(JsonArray instances) {
@@ -208,7 +208,7 @@ public final class DomainEventAssertions {
     final String instanceId = instance.getString("id");
 
     final var eventMessageMatchers = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
-  
+
     await().until(() -> getMessagesForInstance(instanceId),
       eventMessageMatchers.hasDeleteEventMessageFor(instance));
   }

--- a/src/test/java/org/folio/rest/support/messages/EventMessage.java
+++ b/src/test/java/org/folio/rest/support/messages/EventMessage.java
@@ -9,13 +9,13 @@ import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import lombok.Value;
 
 @Value
-public class InstanceEventMessage {
-  public static InstanceEventMessage fromConsumerRecord(
+public class EventMessage {
+  public static EventMessage fromConsumerRecord(
     KafkaConsumerRecord<String, JsonObject> consumerRecord) {
 
     final var value = consumerRecord.value();
 
-    return new InstanceEventMessage(
+    return new EventMessage(
       value.getString("type"),
       value.getString("tenant"),
       value.getJsonObject("new"),

--- a/src/test/java/org/folio/rest/support/messages/InstanceEventMessage.java
+++ b/src/test/java/org/folio/rest/support/messages/InstanceEventMessage.java
@@ -1,0 +1,17 @@
+package org.folio.rest.support.messages;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class InstanceEventMessage {
+  public static InstanceEventMessage fromConsumerRecord(
+    KafkaConsumerRecord<String, JsonObject> consumerRecord) {
+
+    return new InstanceEventMessage(consumerRecord.value().getString("type"));
+  }
+  private final String type;
+}

--- a/src/test/java/org/folio/rest/support/messages/InstanceEventMessage.java
+++ b/src/test/java/org/folio/rest/support/messages/InstanceEventMessage.java
@@ -11,7 +11,11 @@ public class InstanceEventMessage {
   public static InstanceEventMessage fromConsumerRecord(
     KafkaConsumerRecord<String, JsonObject> consumerRecord) {
 
-    return new InstanceEventMessage(consumerRecord.value().getString("type"));
+    final var value = consumerRecord.value();
+
+    return new InstanceEventMessage(value.getString("type"),
+      value.getString("tenant"));
   }
   private final String type;
+  private final String tenant;
 }

--- a/src/test/java/org/folio/rest/support/messages/InstanceEventMessage.java
+++ b/src/test/java/org/folio/rest/support/messages/InstanceEventMessage.java
@@ -6,11 +6,9 @@ import java.util.Map;
 
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import lombok.Value;
 
-@Getter
-@AllArgsConstructor
+@Value
 public class InstanceEventMessage {
   public static InstanceEventMessage fromConsumerRecord(
     KafkaConsumerRecord<String, JsonObject> consumerRecord) {
@@ -25,9 +23,9 @@ public class InstanceEventMessage {
       kafkaHeadersToMap(consumerRecord.headers()));
   }
 
-  private final String type;
-  private final String tenant;
-  private final JsonObject newRepresentation;
-  private final JsonObject oldRepresentation;
-  private final Map<String, String> headers;
+  String type;
+  String tenant;
+  JsonObject newRepresentation;
+  JsonObject oldRepresentation;
+  Map<String, String> headers;
 }

--- a/src/test/java/org/folio/rest/support/messages/InstanceEventMessage.java
+++ b/src/test/java/org/folio/rest/support/messages/InstanceEventMessage.java
@@ -14,8 +14,10 @@ public class InstanceEventMessage {
     final var value = consumerRecord.value();
 
     return new InstanceEventMessage(value.getString("type"),
-      value.getString("tenant"));
+      value.getString("tenant"), value.getJsonObject("new"));
   }
+
   private final String type;
   private final String tenant;
+  private final JsonObject newRepresentation;
 }

--- a/src/test/java/org/folio/rest/support/messages/InstanceEventMessage.java
+++ b/src/test/java/org/folio/rest/support/messages/InstanceEventMessage.java
@@ -14,10 +14,12 @@ public class InstanceEventMessage {
     final var value = consumerRecord.value();
 
     return new InstanceEventMessage(value.getString("type"),
-      value.getString("tenant"), value.getJsonObject("new"));
+      value.getString("tenant"), value.getJsonObject("new"),
+      value.getJsonObject("old"));
   }
 
   private final String type;
   private final String tenant;
   private final JsonObject newRepresentation;
+  private final JsonObject oldRepresentation;
 }

--- a/src/test/java/org/folio/rest/support/messages/InstanceEventMessage.java
+++ b/src/test/java/org/folio/rest/support/messages/InstanceEventMessage.java
@@ -1,5 +1,9 @@
 package org.folio.rest.support.messages;
 
+import static org.folio.kafka.KafkaHeaderUtils.kafkaHeadersToMap;
+
+import java.util.Map;
+
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import lombok.AllArgsConstructor;
@@ -13,13 +17,17 @@ public class InstanceEventMessage {
 
     final var value = consumerRecord.value();
 
-    return new InstanceEventMessage(value.getString("type"),
-      value.getString("tenant"), value.getJsonObject("new"),
-      value.getJsonObject("old"));
+    return new InstanceEventMessage(
+      value.getString("type"),
+      value.getString("tenant"),
+      value.getJsonObject("new"),
+      value.getJsonObject("old"),
+      kafkaHeadersToMap(consumerRecord.headers()));
   }
 
   private final String type;
   private final String tenant;
   private final JsonObject newRepresentation;
   private final JsonObject oldRepresentation;
+  private final Map<String, String> headers;
 }

--- a/src/test/java/org/folio/rest/support/messages/matchers/EventMessageMatchers.java
+++ b/src/test/java/org/folio/rest/support/messages/matchers/EventMessageMatchers.java
@@ -49,12 +49,17 @@ public class EventMessageMatchers {
 
   @NotNull
   private Matcher<EventMessage> isCreateEvent() {
-    return hasProperty("type", is("CREATE"));
+    return hasType("CREATE");
   }
 
   @NotNull
   private Matcher<EventMessage> isDeleteEvent() {
-    return hasProperty("type", is("DELETE"));
+    return hasType("DELETE");
+  }
+
+  @NotNull
+  private static Matcher<EventMessage> hasType(String type) {
+    return hasProperty("type", is(type));
   }
 
   @NotNull
@@ -82,29 +87,32 @@ public class EventMessageMatchers {
 
 
   @NotNull
-  private Matcher<EventMessage> hasOldRepresentation(
-    JsonObject expectedRepresentation) {
-    // ignore metadata because created and updated date might be represented
-    // with either +00:00 or Z due to differences in serialization / deserialization
-    return hasProperty("oldRepresentation",
-      equalsIgnoringMetadata(expectedRepresentation));
+  private Matcher<EventMessage> hasOldRepresentation(JsonObject expectedRepresentation) {
+    return hasOldRepresentationThat(equalsIgnoringMetadata(expectedRepresentation));
   }
 
   @NotNull
   private Matcher<EventMessage> hasNoOldRepresentation() {
-    return hasProperty("oldRepresentation", is(nullValue()));
+    return hasOldRepresentationThat(is(nullValue()));
+  }
+
+  @NotNull
+  private static Matcher<EventMessage> hasOldRepresentationThat(Matcher<?> matcher) {
+    return hasProperty("oldRepresentation", matcher);
   }
 
   @NotNull
   private Matcher<EventMessage> hasNewRepresentation(JsonObject expectedRepresentation) {
-    // ignore metadata because created and updated date might be represented
-    // with either +00:00 or Z due to differences in serialization / deserialization
-    return hasProperty("newRepresentation",
-      equalsIgnoringMetadata(expectedRepresentation));
+    return hasNewRepresentationThat(equalsIgnoringMetadata(expectedRepresentation));
   }
 
   @NotNull
   private Matcher<EventMessage> hasNoNewRepresentation() {
-    return hasProperty("newRepresentation", is(nullValue()));
+    return hasNewRepresentationThat(is(nullValue()));
+  }
+
+  @NotNull
+  private static Matcher<EventMessage> hasNewRepresentationThat(Matcher<?> matcher) {
+    return hasProperty("newRepresentation", matcher);
   }
 }

--- a/src/test/java/org/folio/rest/support/messages/matchers/EventMessageMatchers.java
+++ b/src/test/java/org/folio/rest/support/messages/matchers/EventMessageMatchers.java
@@ -1,0 +1,82 @@
+package org.folio.rest.support.messages.matchers;
+
+import static org.folio.rest.support.JsonObjectMatchers.equalsIgnoringMetadata;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.Matchers.hasEntry;
+import static org.hamcrest.Matchers.hasProperty;
+
+import java.net.URL;
+import java.util.Map;
+
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.rest.support.messages.EventMessage;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matcher;
+import org.jetbrains.annotations.NotNull;
+
+import io.vertx.core.json.JsonObject;
+import lombok.NonNull;
+import lombok.Value;
+
+@Value
+public class EventMessageMatchers {
+  @NonNull
+  String expectedTenantId;
+  @NonNull
+  URL expectedUrl;
+
+  @NotNull
+  public Matcher<Iterable<? super EventMessage>> hasDeleteEventFor(
+    JsonObject representation) {
+
+    return CoreMatchers.hasItem(allOf(
+      isDeleteEvent(),
+      isForTenant(),
+      hasHeaders(),
+      hasNoNewRepresentation(),
+      hasOldRepresentation(representation)));
+  }
+
+  @NotNull
+  public Matcher<EventMessage> isDeleteEvent() {
+    return hasProperty("type", is("DELETE"));
+  }
+
+  @NotNull
+  public Matcher<EventMessage> isForTenant() {
+    return hasProperty("tenant", is(expectedTenantId));
+  }
+
+  @NotNull
+  public Matcher<EventMessage> hasHeaders() {
+    return hasProperty("headers", allOf(
+      hasTenantHeader(),
+      hasUrlHeader()));
+  }
+
+  @NotNull
+  private Matcher<Map<? extends String, ? extends String>> hasUrlHeader() {
+    return hasEntry(XOkapiHeaders.URL.toLowerCase(), expectedUrl.toString());
+  }
+
+  @NotNull
+  private Matcher<Map<? extends String, ? extends String>> hasTenantHeader() {
+    // Needs to be lower case because keys are mapped to lower case
+    return hasEntry(XOkapiHeaders.TENANT.toLowerCase(), expectedTenantId);
+  }
+
+  @NotNull
+  public Matcher<EventMessage> hasOldRepresentation(JsonObject expectedRepresentation) {
+    // ignore metadata because created and updated date might be represented
+    // with either +00:00 or Z due to differences in serialization / deserialization
+    return hasProperty("oldRepresentation",
+      equalsIgnoringMetadata(expectedRepresentation));
+  }
+
+  @NotNull
+  public Matcher<EventMessage> hasNoNewRepresentation() {
+    return hasProperty("newRepresentation", is(nullValue()));
+  }
+}

--- a/src/test/java/org/folio/rest/support/messages/matchers/EventMessageMatchers.java
+++ b/src/test/java/org/folio/rest/support/messages/matchers/EventMessageMatchers.java
@@ -28,9 +28,7 @@ public class EventMessageMatchers {
   URL expectedUrl;
 
   @NotNull
-  public Matcher<Iterable<? super EventMessage>> hasDeleteEventFor(
-    JsonObject representation) {
-
+  public Matcher<Iterable<? super EventMessage>> hasDeleteEventMessageFor(JsonObject representation) {
     return CoreMatchers.hasItem(allOf(
       isDeleteEvent(),
       isForTenant(),


### PR DESCRIPTION
In order to remove the need for catching assertion exceptions and improve the stability of checking for published messages, replace the current use of assertions during awaitility with matcher composition.

The use of a `hasItem` matcher for checking the collection of received messages means that the test will pass when any of the messages matches the expectations, irrespective of ordering. This relies on the matching being sufficiently specific to not produce false matches.

As this is a new approach, the changes have been limited to only messages for creating and deleting instances.

### Approach Taken
* Inline current approach for checking for deleted message (for reference during replacement)
* introduce a type to represent an event message (to ease writing matchers rather than manipulating JSON)
* introduce new approach for deletion message inline in a single test, using matchers each assertion at a time
* move matchers into a separate class
* move method for finding messages related to an instance
* apply same approach for checking creation messages (to demonstrate broader applicability)