### PR TITLE
MODINVSTOR-988 Add ns as an identifying code for LCNAF Source file

### DIFF
--- a/reference-data/authority-source-files/LCNAF.json
+++ b/reference-data/authority-source-files/LCNAF.json
@@ -5,7 +5,8 @@
     "n",
     "nb",
     "nr",
-    "no"
+    "no",
+    "ns"
   ],
   "type": "Names",
   "baseUrl": "id.loc.gov/authorities/names/",

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1078,6 +1078,11 @@
     },
     {
       "run": "after",
+      "snippetPath": "updateLCNAFAuthoritySourceFile.sql",
+      "fromModuleVersion": "25.0.3"
+    },
+    {
+      "run": "after",
       "snippetPath": "setDefaultMetadataForHrIdSettings.sql",
       "fromModuleVersion": "25.1.0"
     }

--- a/src/main/resources/templates/db_scripts/updateLCNAFAuthoritySourceFile.sql
+++ b/src/main/resources/templates/db_scripts/updateLCNAFAuthoritySourceFile.sql
@@ -1,0 +1,16 @@
+UPDATE ${myuniversity}_${mymodule}.authority_source_file
+SET jsonb = '{
+               "id": "af045f2f-e851-4613-984c-4bc13430454a",
+               "name": "LC Name Authority file (LCNAF)",
+               "codes": [
+                 "n",
+                 "nb",
+                 "nr",
+                 "no",
+                 "ns"
+               ],
+               "type": "Names",
+               "baseUrl": "id.loc.gov/authorities/names/",
+               "source": "folio"
+             }'
+WHERE id = 'af045f2f-e851-4613-984c-4bc13430454a';


### PR DESCRIPTION
## Purpose
Add ns as an identifying code for LCNAF Authority Source file

## Approach
* Update reference data
* Add migration script