### PR TITLE
Apply awaitility matchers to authority messages MODINVSTOR-1001

### DIFF
--- a/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
@@ -9,17 +9,13 @@ import static org.folio.services.domainevent.DomainEvent.deleteAllEvent;
 import static org.folio.services.domainevent.DomainEvent.deleteEvent;
 import static org.folio.services.domainevent.DomainEvent.updateEvent;
 
-import io.vertx.core.Context;
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.streams.ReadStream;
-import io.vertx.kafka.client.producer.KafkaProducer;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.commons.lang3.tuple.Triple;
 import org.apache.logging.log4j.Logger;
@@ -29,8 +25,14 @@ import org.folio.kafka.SimpleKafkaProducerManager;
 import org.folio.kafka.services.KafkaEnvironmentProperties;
 import org.folio.kafka.services.KafkaProducerRecordBuilder;
 
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.streams.ReadStream;
+import io.vertx.kafka.client.producer.KafkaProducer;
+
 public class CommonDomainEventPublisher<T> {
-  public static final String NULL_INSTANCE_ID = "00000000-0000-0000-0000-000000000000";
+  public static final String NULL_ID = "00000000-0000-0000-0000-000000000000";
   private static final Logger log = getLogger(CommonDomainEventPublisher.class);
 
   private final Map<String, String> okapiHeaders;
@@ -101,7 +103,7 @@ public class CommonDomainEventPublisher<T> {
   }
 
   Future<Void> publishAllRecordsRemoved() {
-    return publish(NULL_INSTANCE_ID, deleteAllEvent(tenantId(okapiHeaders)));
+    return publish(NULL_ID, deleteAllEvent(tenantId(okapiHeaders)));
   }
 
   public <R> Future<Long> publishStream(ReadStream<R> readStream,

--- a/src/test/java/org/folio/rest/api/AuthorityStorageTest.java
+++ b/src/test/java/org/folio/rest/api/AuthorityStorageTest.java
@@ -3,9 +3,9 @@ package org.folio.rest.api;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.rest.support.http.InterfaceUrls.authoritiesStorageUrl;
 import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityCreatedMessagePublished;
-import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveAllEventForAuthority;
-import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityDeletedEventMessagePublished;
-import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityUpdatedEventPublished;
+import static org.folio.rest.support.messages.AuthorityEventMessageChecks.allAuthoritiesDeletedMessagePublished;
+import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityDeletedMessagePublished;
+import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityUpdatedMessagePublished;
 import static org.folio.utility.ModuleUtility.getClient;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.junit.Assert.assertEquals;
@@ -74,12 +74,16 @@ public class AuthorityStorageTest extends TestBase {
   public void deleteAll() {
     assertEquals(0, authoritiesClient.getAll().size());
     createAuthRecords(2);
+
     var response = authoritiesClient.getAll();
     assertEquals(2, response.size());
+
     authoritiesClient.deleteAll();
+
     response = authoritiesClient.getAll();
     assertEquals(0, response.size());
-    assertRemoveAllEventForAuthority();
+
+    allAuthoritiesDeletedMessagePublished();
   }
 
   @Test
@@ -95,7 +99,7 @@ public class AuthorityStorageTest extends TestBase {
     var response2 = authoritiesClient.getAll();
     assertEquals(0, response2.size());
 
-    authorityDeletedEventMessagePublished(response.get(0));
+    authorityDeletedMessagePublished(response.get(0));
   }
 
   @Test
@@ -126,12 +130,15 @@ public class AuthorityStorageTest extends TestBase {
 
     var response = authoritiesClient.getAll();
     assertEquals(1, response.size());
+
     JsonObject object = new JsonObject(response.get(0).encode());
     object.put("personalName", "changed");
     authoritiesClient.replace(UUID.fromString(object.getString("id")), object);
+
     var response2 = authoritiesClient.getById(UUID.fromString(response.get(0).getString("id")));
     assertEquals(object.getString("personalName"), response2.getJson().getString("personalName"));
-    authorityUpdatedEventPublished(response.get(0), response2.getJson());
+
+    authorityUpdatedMessagePublished(response.get(0), response2.getJson());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/AuthorityStorageTest.java
+++ b/src/test/java/org/folio/rest/api/AuthorityStorageTest.java
@@ -1,13 +1,17 @@
 package org.folio.rest.api;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.folio.rest.support.AdditionalHttpStatusCodes.UNPROCESSABLE_ENTITY;
+import static org.folio.rest.support.HttpResponseMatchers.errorMessageContains;
+import static org.folio.rest.support.HttpResponseMatchers.statusCodeIs;
 import static org.folio.rest.support.http.InterfaceUrls.authoritiesStorageUrl;
-import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityCreatedMessagePublished;
 import static org.folio.rest.support.messages.AuthorityEventMessageChecks.allAuthoritiesDeletedMessagePublished;
+import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityCreatedMessagePublished;
 import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityDeletedMessagePublished;
 import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityUpdatedMessagePublished;
 import static org.folio.utility.ModuleUtility.getClient;
 import static org.folio.utility.RestUtility.TENANT_ID;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 
 import java.net.HttpURLConnection;
@@ -178,13 +182,16 @@ public class AuthorityStorageTest extends TestBase {
     assertEquals("personalName0", response3.getJson().getString("personalName"));
   }
 
-  @Test(expected = AssertionError.class)
+  @Test()
   public void postWithWrongFields() {
     assertEquals(0, authoritiesClient.getAll().size());
 
-    authoritiesClient.create(new JsonObject()
+    final var response = authoritiesClient.attemptToCreate(new JsonObject()
       .put("personalName", "personalName")
       .put("wrong", "test"));
+
+    assertThat(response, statusCodeIs(UNPROCESSABLE_ENTITY));
+    assertThat(response, errorMessageContains("Unrecognized field \"wrong\""));
   }
 
   private void createAuthRecords(int quantity) {
@@ -206,5 +213,4 @@ public class AuthorityStorageTest extends TestBase {
       throw new RuntimeException(e);
     }
   }
-
 }

--- a/src/test/java/org/folio/rest/api/AuthorityStorageTest.java
+++ b/src/test/java/org/folio/rest/api/AuthorityStorageTest.java
@@ -124,13 +124,8 @@ public class AuthorityStorageTest extends TestBase {
   @Test
   public void putById() {
     assertEquals(0, authoritiesClient.getAll().size());
-    createAuthRecords(1);
 
-    // Clear Kafka events after create to reduce chances of
-    // CREATE messages appearing after UPDATE later on.
-    // This should be removed once the messaging problem is
-    // properly resolved.
-    removeAllEvents();
+    createAuthRecords(1);
 
     var response = authoritiesClient.getAll();
     assertEquals(1, response.size());

--- a/src/test/java/org/folio/rest/api/AuthorityStorageTest.java
+++ b/src/test/java/org/folio/rest/api/AuthorityStorageTest.java
@@ -4,8 +4,8 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.rest.support.http.InterfaceUrls.authoritiesStorageUrl;
 import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityCreatedMessagePublished;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveAllEventForAuthority;
-import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveEventForAuthority;
-import static org.folio.rest.support.matchers.DomainEventAssertions.assertUpdateEventForAuthority;
+import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityDeletedEventMessagePublished;
+import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityUpdatedEventPublished;
 import static org.folio.utility.ModuleUtility.getClient;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.junit.Assert.assertEquals;
@@ -86,12 +86,16 @@ public class AuthorityStorageTest extends TestBase {
   public void deleteById() {
     assertEquals(0, authoritiesClient.getAll().size());
     createAuthRecords(1);
+
     var response = authoritiesClient.getAll();
     assertEquals(1, response.size());
+
     authoritiesClient.delete(UUID.fromString(response.get(0).getString("id")));
+
     var response2 = authoritiesClient.getAll();
     assertEquals(0, response2.size());
-    assertRemoveEventForAuthority(response.get(0));
+
+    authorityDeletedEventMessagePublished(response.get(0));
   }
 
   @Test
@@ -127,7 +131,7 @@ public class AuthorityStorageTest extends TestBase {
     authoritiesClient.replace(UUID.fromString(object.getString("id")), object);
     var response2 = authoritiesClient.getById(UUID.fromString(response.get(0).getString("id")));
     assertEquals(object.getString("personalName"), response2.getJson().getString("personalName"));
-    assertUpdateEventForAuthority(response.get(0), response2.getJson());
+    authorityUpdatedEventPublished(response.get(0), response2.getJson());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/AuthorityStorageTest.java
+++ b/src/test/java/org/folio/rest/api/AuthorityStorageTest.java
@@ -2,7 +2,7 @@ package org.folio.rest.api;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.rest.support.http.InterfaceUrls.authoritiesStorageUrl;
-import static org.folio.rest.support.matchers.DomainEventAssertions.assertCreateEventForAuthority;
+import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityCreatedMessagePublished;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveAllEventForAuthority;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveEventForAuthority;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertUpdateEventForAuthority;
@@ -10,21 +10,23 @@ import static org.folio.utility.ModuleUtility.getClient;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.junit.Assert.assertEquals;
 
-import io.vertx.core.json.JsonObject;
 import java.net.HttpURLConnection;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import junitparams.JUnitParamsRunner;
-import lombok.SneakyThrows;
+
 import org.folio.rest.jaxrs.model.Authority;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import io.vertx.core.json.JsonObject;
+import junitparams.JUnitParamsRunner;
+import lombok.SneakyThrows;
 
 @RunWith(JUnitParamsRunner.class)
 public class AuthorityStorageTest extends TestBase {
@@ -51,11 +53,14 @@ public class AuthorityStorageTest extends TestBase {
   public void getById() {
     assertEquals(0, authoritiesClient.getAll().size());
     createAuthRecords(1);
+
     var response = authoritiesClient.getAll();
     assertEquals(1, response.size());
+
     var response2 = authoritiesClient.getById(UUID.fromString(response.get(0).getString("id")));
     assertEquals("personalName0", response2.getJson().getString("personalName"));
-    assertCreateEventForAuthority(response2.getJson());
+
+    authorityCreatedMessagePublished(response2.getJson());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -20,7 +20,7 @@ import static org.folio.rest.support.matchers.DateTimeMatchers.hasIsoFormat;
 import static org.folio.rest.support.matchers.DateTimeMatchers.withinSecondsBeforeNow;
 import static org.folio.rest.support.messages.InstanceEventMessageChecks.instanceCreatedMessagesPublished;
 import static org.folio.rest.support.messages.InstanceEventMessageChecks.noInstanceMessagesPublished;
-import static org.folio.rest.support.messages.InstanceEventMessageChecks.deleteAllEventForInstancesPublished;
+import static org.folio.rest.support.messages.InstanceEventMessageChecks.allInstancesDeletedMessagePublished;
 import static org.folio.rest.support.messages.InstanceEventMessageChecks.instancedUpdatedMessagePublished;
 import static org.folio.rest.support.messages.InstanceEventMessageChecks.instanceCreatedMessagePublished;
 import static org.folio.rest.support.messages.InstanceEventMessageChecks.instanceDeletedMessagePublished;
@@ -93,7 +93,6 @@ import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.builders.ItemRequestBuilder;
 import org.folio.rest.support.db.OptimisticLocking;
-import org.folio.rest.support.messages.InstanceEventMessageChecks;
 import org.folio.rest.tools.utils.OptimisticLockingUtil;
 import org.folio.utility.LocationUtility;
 import org.junit.After;
@@ -1499,7 +1498,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(allInstances.size(), is(0));
     assertThat(responseBody.getInteger(TOTAL_RECORDS_KEY), is(0));
 
-    deleteAllEventForInstancesPublished();
+    allInstancesDeletedMessagePublished();
   }
 
   @Test

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -142,10 +142,9 @@ public final class FakeKafkaConsumer {
     return authorityEvents.size();
   }
 
-  public static Collection<EventMessage> getInstanceMessages() {
-    return instanceEvents.values()
+  public static Collection<EventMessage> getMessagesForAuthority(String authorityId) {
+    return authorityEvents.getOrDefault(authorityId, emptyList())
       .stream()
-      .flatMap(List::stream)
       .map(EventMessage::fromConsumerRecord)
       .collect(Collectors.toList());
   }

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -128,10 +128,6 @@ public final class FakeKafkaConsumer {
     boundWith.clear();
   }
 
-  public static int getAllPublishedInstanceIdsCount() {
-    return instanceEvents.size();
-  }
-
   public static Collection<JsonObject> getAllPublishedBoundWithEvents() {
     List<JsonObject> list = new ArrayList<>();
     boundWith.values().forEach(collection -> collection.forEach(record -> list.add(record.value())));
@@ -149,6 +145,10 @@ public final class FakeKafkaConsumer {
       .collect(Collectors.toList());
   }
 
+  public static int getAllPublishedInstanceIdsCount() {
+    return instanceEvents.size();
+  }
+
   public static Collection<EventMessage> getMessagesForInstance(String instanceId) {
     return instanceEvents.getOrDefault(instanceId, emptyList())
       .stream()
@@ -161,12 +161,6 @@ public final class FakeKafkaConsumer {
       .map(FakeKafkaConsumer::getMessagesForInstance)
       .flatMap(Collection::stream)
       .collect(Collectors.toList());
-  }
-
-  public static Collection<KafkaConsumerRecord<String, JsonObject> > getAuthorityEvents(
-    String authorityId) {
-
-    return authorityEvents.getOrDefault(authorityId, emptyList());
   }
 
   public static Collection<KafkaConsumerRecord<String, JsonObject> > getItemEvents(
@@ -208,18 +202,6 @@ public final class FakeKafkaConsumer {
 
   private static Comparator<KafkaConsumerRecord<String, JsonObject>> timestampComparator() {
     return Comparator.comparing(KafkaConsumerRecord::timestamp);
-  }
-
-  public static KafkaConsumerRecord<String, JsonObject> getLastAuthorityEvent(
-    String id) {
-
-    return getLastEvent(getAuthorityEvents(id));
-  }
-
-  public static KafkaConsumerRecord<String, JsonObject>  getFirstAuthorityEvent(
-    String authorityId) {
-
-    return getFirstEvent(getAuthorityEvents(authorityId));
   }
 
   public static KafkaConsumerRecord<String, JsonObject>  getLastItemEvent(

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -8,15 +8,13 @@ import static org.folio.okapi.common.XOkapiHeaders.URL;
 import static org.folio.rest.api.TestBase.holdingsClient;
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
 import static org.folio.rest.support.JsonObjectMatchers.equalsIgnoringMetadata;
-import static org.folio.rest.support.kafka.FakeKafkaConsumer.getAuthorityEvents;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getFirstHoldingEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getFirstItemEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getHoldingsEvents;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getItemEvents;
-import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLastAuthorityEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLastHoldingEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLastItemEvent;
-import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_INSTANCE_ID;
+import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_ID;
 import static org.folio.utility.ModuleUtility.vertxUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.is;
@@ -131,13 +129,6 @@ public final class DomainEventAssertions {
     assertThat(updateMessage.getString("type"), not(is("UPDATE")));
   }
 
-  public static void assertRemoveAllEventForAuthority() {
-    awaitAtMost()
-      .until(() -> getAuthorityEvents(NULL_INSTANCE_ID).size(), greaterThan(0));
-
-    assertRemoveAllEvent(getLastAuthorityEvent(NULL_INSTANCE_ID));
-  }
-
   public static void assertCreateEventForItem(JsonObject item) {
     final String itemId = item.getString("id");
     final String instanceIdForItem = getInstanceIdForItem(item);
@@ -164,9 +155,9 @@ public final class DomainEventAssertions {
 
   public static void assertRemoveAllEventForItem() {
     awaitAtMost()
-      .until(() -> getItemEvents(NULL_INSTANCE_ID, null).size(), greaterThan(0));
+      .until(() -> getItemEvents(NULL_ID, null).size(), greaterThan(0));
 
-    assertRemoveAllEvent(getLastItemEvent(NULL_INSTANCE_ID, null));
+    assertRemoveAllEvent(getLastItemEvent(NULL_ID, null));
   }
 
   public static void assertUpdateEventForItem(JsonObject oldItem, JsonObject newItem) {
@@ -214,9 +205,9 @@ public final class DomainEventAssertions {
 
   public static void assertRemoveAllEventForHolding() {
     awaitAtMost()
-      .until(() -> getHoldingsEvents(NULL_INSTANCE_ID, null).size(), greaterThan(0));
+      .until(() -> getHoldingsEvents(NULL_ID, null).size(), greaterThan(0));
 
-    assertRemoveAllEvent(getLastHoldingEvent(NULL_INSTANCE_ID, null));
+    assertRemoveAllEvent(getLastHoldingEvent(NULL_ID, null));
   }
 
   public static void assertUpdateEventForHolding(JsonObject oldHr, JsonObject newHr) {

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -131,23 +131,11 @@ public final class DomainEventAssertions {
     assertThat(updateMessage.getString("type"), not(is("UPDATE")));
   }
 
-  public static void assertRemoveEventForAuthority(JsonObject authority) {
-    final String id = authority.getString("id");
-
-    awaitAtMost().until(() -> hasRemoveEvent(getAuthorityEvents(id), authority));
-  }
-
   public static void assertRemoveAllEventForAuthority() {
     awaitAtMost()
       .until(() -> getAuthorityEvents(NULL_INSTANCE_ID).size(), greaterThan(0));
 
     assertRemoveAllEvent(getLastAuthorityEvent(NULL_INSTANCE_ID));
-  }
-
-  public static void assertUpdateEventForAuthority(JsonObject oldAuthority, JsonObject newAuthority) {
-    final String id = oldAuthority.getString("id");
-
-    awaitAtMost().until(() -> hasUpdateEvent(getAuthorityEvents(id), oldAuthority, newAuthority));
   }
 
   public static void assertCreateEventForItem(JsonObject item) {

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -9,7 +9,6 @@ import static org.folio.rest.api.TestBase.holdingsClient;
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
 import static org.folio.rest.support.JsonObjectMatchers.equalsIgnoringMetadata;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getAuthorityEvents;
-import static org.folio.rest.support.kafka.FakeKafkaConsumer.getFirstAuthorityEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getFirstHoldingEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getFirstItemEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getHoldingsEvents;
@@ -130,15 +129,6 @@ public final class DomainEventAssertions {
 
     final JsonObject updateMessage  = getLastHoldingEvent(instanceId, hrId).value();
     assertThat(updateMessage.getString("type"), not(is("UPDATE")));
-  }
-
-  public static void assertCreateEventForAuthority(JsonObject authority) {
-    final String id = authority.getString("id");
-
-    awaitAtMost()
-      .until(() -> getAuthorityEvents(id).size(), greaterThan(0));
-
-    assertCreateEvent(getFirstAuthorityEvent(id), authority);
   }
 
   public static void assertRemoveEventForAuthority(JsonObject authority) {

--- a/src/test/java/org/folio/rest/support/messages/AuthorityEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/AuthorityEventMessageChecks.java
@@ -1,10 +1,11 @@
 package org.folio.rest.support.messages;
 
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
+import static org.folio.rest.support.kafka.FakeKafkaConsumer.getMessagesForAuthority;
+import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_ID;
 import static org.folio.utility.ModuleUtility.vertxUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 
-import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.folio.rest.support.messages.matchers.EventMessageMatchers;
 
 import io.vertx.core.json.JsonObject;
@@ -18,24 +19,29 @@ public class AuthorityEventMessageChecks {
   public static void authorityCreatedMessagePublished(JsonObject authority) {
     final String authorityId = getId(authority);
 
-    awaitAtMost().until(() -> FakeKafkaConsumer.getMessagesForAuthority(authorityId),
+    awaitAtMost().until(() -> getMessagesForAuthority(authorityId),
       eventMessageMatchers.hasCreateEventMessageFor(authority));
   }
 
-  public static void authorityDeletedEventMessagePublished(JsonObject authority) {
-    final String authorityId = authority.getString("id");
-
-    awaitAtMost().until(() -> FakeKafkaConsumer.getMessagesForAuthority(authorityId),
-      eventMessageMatchers.hasDeleteEventMessageFor(authority));
-  }
-
-  public static void authorityUpdatedEventPublished(JsonObject oldAuthority,
+  public static void authorityUpdatedMessagePublished(JsonObject oldAuthority,
     JsonObject newAuthority) {
 
     final String authorityId = getId(oldAuthority);
 
-    awaitAtMost().until(() -> FakeKafkaConsumer.getMessagesForAuthority(authorityId),
+    awaitAtMost().until(() -> getMessagesForAuthority(authorityId),
       eventMessageMatchers.hasUpdateEventMessageFor(oldAuthority, newAuthority));
+  }
+
+  public static void authorityDeletedMessagePublished(JsonObject authority) {
+    final String authorityId = getId(authority);
+
+    awaitAtMost().until(() -> getMessagesForAuthority(authorityId),
+      eventMessageMatchers.hasDeleteEventMessageFor(authority));
+  }
+
+  public static void allAuthoritiesDeletedMessagePublished() {
+    awaitAtMost().until(() -> getMessagesForAuthority(NULL_ID),
+      eventMessageMatchers.hasDeleteAllEventMessage());
   }
 
   private static String getId(JsonObject json) {

--- a/src/test/java/org/folio/rest/support/messages/AuthorityEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/AuthorityEventMessageChecks.java
@@ -1,0 +1,28 @@
+package org.folio.rest.support.messages;
+
+import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
+import static org.folio.utility.ModuleUtility.vertxUrl;
+import static org.folio.utility.RestUtility.TENANT_ID;
+
+import org.folio.rest.support.kafka.FakeKafkaConsumer;
+import org.folio.rest.support.messages.matchers.EventMessageMatchers;
+
+import io.vertx.core.json.JsonObject;
+
+public class AuthorityEventMessageChecks {
+  private static final EventMessageMatchers eventMessageMatchers
+    = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
+
+  private AuthorityEventMessageChecks() { }
+
+  public static void authorityCreatedMessagePublished(JsonObject authority) {
+    final String authorityId = getId(authority);
+
+    awaitAtMost().until(() -> FakeKafkaConsumer.getMessagesForAuthority(authorityId),
+      eventMessageMatchers.hasCreateEventMessageFor(authority));
+  }
+
+  private static String getId(JsonObject json) {
+    return json.getString("id");
+  }
+}

--- a/src/test/java/org/folio/rest/support/messages/AuthorityEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/AuthorityEventMessageChecks.java
@@ -22,6 +22,22 @@ public class AuthorityEventMessageChecks {
       eventMessageMatchers.hasCreateEventMessageFor(authority));
   }
 
+  public static void authorityDeletedEventMessagePublished(JsonObject authority) {
+    final String authorityId = authority.getString("id");
+
+    awaitAtMost().until(() -> FakeKafkaConsumer.getMessagesForAuthority(authorityId),
+      eventMessageMatchers.hasDeleteEventMessageFor(authority));
+  }
+
+  public static void authorityUpdatedEventPublished(JsonObject oldAuthority,
+    JsonObject newAuthority) {
+
+    final String authorityId = getId(oldAuthority);
+
+    awaitAtMost().until(() -> FakeKafkaConsumer.getMessagesForAuthority(authorityId),
+      eventMessageMatchers.hasUpdateEventMessageFor(oldAuthority, newAuthority));
+  }
+
   private static String getId(JsonObject json) {
     return json.getString("id");
   }

--- a/src/test/java/org/folio/rest/support/messages/InstanceEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/InstanceEventMessageChecks.java
@@ -4,7 +4,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
 import static org.folio.rest.support.AwaitConfiguration.awaitDuring;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getMessagesForInstance;
-import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_INSTANCE_ID;
+import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_ID;
 import static org.folio.utility.ModuleUtility.vertxUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.is;
@@ -80,9 +80,9 @@ public class InstanceEventMessageChecks {
         eventMessageMatchers.hasNoDeleteEventMessage());
   }
 
-  public static void deleteAllEventForInstancesPublished() {
+  public static void allInstancesDeletedMessagePublished() {
     awaitAtMost()
-      .until(() -> getMessagesForInstance(NULL_INSTANCE_ID),
+      .until(() -> getMessagesForInstance(NULL_ID),
         eventMessageMatchers.hasDeleteAllEventMessage());
   }
 


### PR DESCRIPTION
A follow on from #862 and #863

In order to remove the need for catching assertion exceptions and improve the stability of checking for published messages, replace the current use of assertions during awaitility with matcher composition.

The use of a `hasItem` matcher for checking the collection of received messages means that the test will pass when any of the messages matches the expectations, irrespective of ordering. This relies on the matching being sufficiently specific to not produce false matches.

The previous changes has moved all of the instance messages to this new approach. This change moves the authority message checks to the new approach.

### Approach Taken
* move (and rename) methods for authority messages to separate class
* use matcher with awaitility for each check
* remove additional `removeAllEvents` call in editing authority test 
* replace expected assertion error when attempting to create an invalid authority with explicit assertions
* remove unused methods for fetching first and last authority messages