### PR TITLE
Use awaitility matchers for checking holdings messages MODINVSTOR-1001

### DIFF
--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -18,7 +18,7 @@ import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getHoldingsEvents;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLastHoldingEvent;
 import static org.folio.rest.support.messages.HoldingsEventMessageChecks.noHoldingsUpdatedMessagePublished;
-import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveAllEventForHolding;
+import static org.folio.rest.support.messages.HoldingsEventMessageChecks.allHoldingsDeletedMessagePublished;
 import static org.folio.rest.support.messages.HoldingsEventMessageChecks.holdingsDeletedMessagePublished;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertUpdateEvent;
 import static org.folio.rest.support.messages.HoldingsEventMessageChecks.holdingsUpdatedMessagePublished;
@@ -629,7 +629,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(allHoldings.size(), is(0));
 
-    assertRemoveAllEventForHolding();
+    allHoldingsDeletedMessagePublished();
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -17,7 +17,7 @@ import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getHoldingsEvents;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLastHoldingEvent;
-import static org.folio.rest.support.matchers.DomainEventAssertions.assertNoUpdateEventForHolding;
+import static org.folio.rest.support.messages.HoldingsEventMessageChecks.noHoldingsUpdatedMessagePublished;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveAllEventForHolding;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveEventForHolding;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertUpdateEvent;
@@ -2055,7 +2055,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(holdingsFromGet.getString("hrid"), is(hrid));
     // Make sure a create event published vs update event
     holdingsCreatedMessagePublished(holdingsFromGet);
-    assertNoUpdateEventForHolding(instanceId.toString(), holdingsId.toString());
+    noHoldingsUpdatedMessagePublished(instanceId.toString(), holdingsId.toString());
 
     log.info("Finished canUsePutToCreateAHoldingsWhenHRIDIsSupplied");
   }

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -21,7 +21,7 @@ import static org.folio.rest.support.matchers.DomainEventAssertions.assertNoUpda
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveAllEventForHolding;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveEventForHolding;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertUpdateEvent;
-import static org.folio.rest.support.matchers.DomainEventAssertions.assertUpdateEventForHolding;
+import static org.folio.rest.support.messages.HoldingsEventMessageChecks.holdingsUpdatedMessagePublished;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertUpdateEventForItem;
 import static org.folio.rest.support.matchers.PostgresErrorMessageMatchers.isMaximumSequenceValueError;
 import static org.folio.rest.support.messages.HoldingsEventMessageChecks.holdingsCreatedMessagePublished;
@@ -357,7 +357,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(tags.size(), is(1));
     assertThat(tags, hasItem(NEW_TEST_TAG));
-    assertUpdateEventForHolding(holdingResource.getJson(), holdingFromGet);
+    holdingsUpdatedMessagePublished(holdingResource.getJson(), holdingFromGet);
   }
 
   @Test
@@ -394,7 +394,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     JsonObject holdingFromGet = getResponse.getJson();
 
     assertThat(holdingFromGet.getString("instanceId"), is(newInstanceId.toString()));
-    assertUpdateEventForHolding(holdingResource.getJson(), holdingFromGet);
+    holdingsUpdatedMessagePublished(holdingResource.getJson(), holdingFromGet);
 
     JsonObject newItem = item.copy()
       .put("_version", 2);

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -19,7 +19,7 @@ import static org.folio.rest.support.kafka.FakeKafkaConsumer.getHoldingsEvents;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLastHoldingEvent;
 import static org.folio.rest.support.messages.HoldingsEventMessageChecks.noHoldingsUpdatedMessagePublished;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveAllEventForHolding;
-import static org.folio.rest.support.matchers.DomainEventAssertions.assertRemoveEventForHolding;
+import static org.folio.rest.support.messages.HoldingsEventMessageChecks.holdingsDeletedMessagePublished;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertUpdateEvent;
 import static org.folio.rest.support.messages.HoldingsEventMessageChecks.holdingsUpdatedMessagePublished;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertUpdateEventForItem;
@@ -418,7 +418,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     Response getResponse = holdingsClient.getById(holdingId);
 
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
-    assertRemoveEventForHolding(holdingResource.getJson());
+    holdingsDeletedMessagePublished(holdingResource.getJson());
   }
 
   @Test
@@ -669,9 +669,9 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertNotExists(h1);
     assertNotExists(h3);
     assertNotExists(h5);
-    assertRemoveEventForHolding(h1);
-    assertRemoveEventForHolding(h3);
-    assertRemoveEventForHolding(h5);
+    holdingsDeletedMessagePublished(h1);
+    holdingsDeletedMessagePublished(h3);
+    holdingsDeletedMessagePublished(h5);
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
@@ -1,6 +1,6 @@
 package org.folio.rest.api;
 
-import static org.folio.rest.support.matchers.DomainEventAssertions.assertUpdateEventForHolding;
+import static org.folio.rest.support.messages.HoldingsEventMessageChecks.holdingsUpdatedMessagePublished;
 import static org.folio.rest.support.matchers.DomainEventAssertions.assertUpdateEventForItem;
 import static org.folio.utility.ModuleUtility.getClient;
 import static org.folio.utility.ModuleUtility.getVertx;
@@ -204,7 +204,7 @@ public class ItemEffectiveLocationTest extends TestBaseWithInventoryUtil {
     assertThat(associatedItem.getString(EFFECTIVE_LOCATION_ID_KEY),
       is(effectiveLocation(holdingEndLoc, itemLoc)));
     assertUpdateEventForItem(createdItem, associatedItem);
-    assertUpdateEventForHolding(createdHolding,
+    holdingsUpdatedMessagePublished(createdHolding,
       holdingsClient.getById(holdingsRecordId).getJson());
   }
 

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -178,9 +178,7 @@ public final class FakeKafkaConsumer {
     return getEmptyDefault(itemEvents, instanceAndIdKey(instanceId, itemId));
   }
 
-  private static List<KafkaConsumerRecord<String, JsonObject>> getEmptyDefault(
-    Map<String, List<KafkaConsumerRecord<String, JsonObject>>> map, String key) {
-
+  private static <T> List<T> getEmptyDefault(Map<String, List<T>> map, String key) {
     return map.getOrDefault(key, emptyList());
   }
 

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -166,16 +166,10 @@ public final class FakeKafkaConsumer {
   public static Collection<EventMessage> getMessagesForHoldings(
     String instanceId, String holdingsId) {
 
-    return getHoldingsEvents(instanceId, holdingsId)
+    return holdingsEvents.getOrDefault(instanceAndIdKey(instanceId, holdingsId), emptyList())
       .stream()
       .map(EventMessage::fromConsumerRecord)
       .collect(Collectors.toList());
-  }
-
-  public static Collection<KafkaConsumerRecord<String, JsonObject> > getHoldingsEvents(
-    String instanceId, String hrId) {
-
-    return holdingsEvents.getOrDefault(instanceAndIdKey(instanceId, hrId), emptyList());
   }
 
   public static Collection<KafkaConsumerRecord<String, JsonObject> > getItemEvents(
@@ -223,12 +217,6 @@ public final class FakeKafkaConsumer {
     String instanceId, String itemId) {
 
     return getFirstEvent(getItemEvents(instanceId, itemId));
-  }
-
-  public static KafkaConsumerRecord<String, JsonObject>  getLastHoldingEvent(
-    String instanceId, String hrId) {
-
-    return getLastEvent(getHoldingsEvents(instanceId, hrId));
   }
 
   private static String instanceAndIdKey(String instanceId, String itemId) {

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -139,7 +139,7 @@ public final class FakeKafkaConsumer {
   }
 
   public static Collection<EventMessage> getMessagesForAuthority(String authorityId) {
-    return authorityEvents.getOrDefault(authorityId, emptyList())
+    return getEmptyDefault(authorityEvents, authorityId)
       .stream()
       .map(EventMessage::fromConsumerRecord)
       .collect(Collectors.toList());
@@ -150,7 +150,7 @@ public final class FakeKafkaConsumer {
   }
 
   public static Collection<EventMessage> getMessagesForInstance(String instanceId) {
-    return instanceEvents.getOrDefault(instanceId, emptyList())
+    return getEmptyDefault(instanceEvents, instanceId)
       .stream()
       .map(EventMessage::fromConsumerRecord)
       .collect(Collectors.toList());
@@ -166,7 +166,7 @@ public final class FakeKafkaConsumer {
   public static Collection<EventMessage> getMessagesForHoldings(
     String instanceId, String holdingsId) {
 
-    return holdingsEvents.getOrDefault(instanceAndIdKey(instanceId, holdingsId), emptyList())
+    return getEmptyDefault(holdingsEvents, instanceAndIdKey(instanceId, holdingsId))
       .stream()
       .map(EventMessage::fromConsumerRecord)
       .collect(Collectors.toList());
@@ -175,7 +175,13 @@ public final class FakeKafkaConsumer {
   public static Collection<KafkaConsumerRecord<String, JsonObject> > getItemEvents(
     String instanceId, String itemId) {
 
-    return itemEvents.getOrDefault(instanceAndIdKey(instanceId, itemId), emptyList());
+    return getEmptyDefault(itemEvents, instanceAndIdKey(instanceId, itemId));
+  }
+
+  private static List<KafkaConsumerRecord<String, JsonObject>> getEmptyDefault(
+    Map<String, List<KafkaConsumerRecord<String, JsonObject>>> map, String key) {
+
+    return map.getOrDefault(key, emptyList());
   }
 
   private static KafkaConsumerRecord<String, JsonObject>  getLastEvent(

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -163,16 +163,25 @@ public final class FakeKafkaConsumer {
       .collect(Collectors.toList());
   }
 
-  public static Collection<KafkaConsumerRecord<String, JsonObject> > getItemEvents(
-    String instanceId, String itemId) {
+  public static Collection<EventMessage> getMessagesForHoldings(
+    String instanceId, String holdingsId) {
 
-    return itemEvents.getOrDefault(instanceAndIdKey(instanceId, itemId), emptyList());
+    return getHoldingsEvents(instanceId, holdingsId)
+      .stream()
+      .map(EventMessage::fromConsumerRecord)
+      .collect(Collectors.toList());
   }
 
   public static Collection<KafkaConsumerRecord<String, JsonObject> > getHoldingsEvents(
     String instanceId, String hrId) {
 
     return holdingsEvents.getOrDefault(instanceAndIdKey(instanceId, hrId), emptyList());
+  }
+
+  public static Collection<KafkaConsumerRecord<String, JsonObject> > getItemEvents(
+    String instanceId, String itemId) {
+
+    return itemEvents.getOrDefault(instanceAndIdKey(instanceId, itemId), emptyList());
   }
 
   private static KafkaConsumerRecord<String, JsonObject>  getLastEvent(
@@ -220,12 +229,6 @@ public final class FakeKafkaConsumer {
     String instanceId, String hrId) {
 
     return getLastEvent(getHoldingsEvents(instanceId, hrId));
-  }
-
-  public static KafkaConsumerRecord<String, JsonObject> getFirstHoldingEvent(
-    String instanceId, String hrId) {
-
-    return getFirstEvent(getHoldingsEvents(instanceId, hrId));
   }
 
   private static String instanceAndIdKey(String instanceId, String itemId) {

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -9,9 +9,7 @@ import static org.folio.rest.api.TestBase.holdingsClient;
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
 import static org.folio.rest.support.JsonObjectMatchers.equalsIgnoringMetadata;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getFirstItemEvent;
-import static org.folio.rest.support.kafka.FakeKafkaConsumer.getHoldingsEvents;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getItemEvents;
-import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLastHoldingEvent;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getLastItemEvent;
 import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_ID;
 import static org.folio.utility.ModuleUtility.vertxUrl;
@@ -170,12 +168,5 @@ public final class DomainEventAssertions {
 
   private static JsonObject addInstanceIdForItem(JsonObject item, String instanceId) {
     return item.copy().put("instanceId", instanceId);
-  }
-
-  public static void assertRemoveAllEventForHolding() {
-    awaitAtMost()
-      .until(() -> getHoldingsEvents(NULL_ID, null).size(), greaterThan(0));
-
-    assertRemoveAllEvent(getLastHoldingEvent(NULL_ID, null));
   }
 }

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -172,13 +172,6 @@ public final class DomainEventAssertions {
     return item.copy().put("instanceId", instanceId);
   }
 
-  public static void assertRemoveEventForHolding(JsonObject hr) {
-    final String id = hr.getString("id");
-    final String instanceId = hr.getString("instanceId");
-
-    awaitAtMost().until(() -> hasRemoveEvent(getHoldingsEvents(instanceId, id), hr));
-  }
-
   public static void assertRemoveAllEventForHolding() {
     awaitAtMost()
       .until(() -> getHoldingsEvents(NULL_ID, null).size(), greaterThan(0));

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -17,10 +17,8 @@ import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_ID;
 import static org.folio.utility.ModuleUtility.vertxUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
@@ -172,14 +170,6 @@ public final class DomainEventAssertions {
 
   private static JsonObject addInstanceIdForItem(JsonObject item, String instanceId) {
     return item.copy().put("instanceId", instanceId);
-  }
-
-  public static void assertNoUpdateEventForHolding(String instanceId, String hrId) {
-    awaitAtMost()
-      .until(() -> getHoldingsEvents(instanceId, hrId), is(not(empty())));
-
-    final JsonObject updateMessage  = getLastHoldingEvent(instanceId, hrId).value();
-    assertThat(updateMessage.getString("type"), not(is("UPDATE")));
   }
 
   public static void assertRemoveEventForHolding(JsonObject hr) {

--- a/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
+++ b/src/test/java/org/folio/rest/support/matchers/DomainEventAssertions.java
@@ -94,23 +94,6 @@ public final class DomainEventAssertions {
     assertHeaders(updateEvent.headers());
   }
 
-  public static boolean hasUpdateEvent(Collection<KafkaConsumerRecord<String, JsonObject>> events,
-      JsonObject oldRecord, JsonObject newRecord) {
-
-    if (events == null) {
-      return false;
-    }
-    for (var event : events) {
-      try {
-        assertUpdateEvent(event, oldRecord, newRecord);
-        return true;
-      } catch (AssertionError e) {
-        // ignore
-      }
-    }
-    return false;
-  }
-
   private static void assertHeaders(List<KafkaHeader> headers) {
     final MultiMap caseInsensitiveMap = caseInsensitiveMultiMap()
       .addAll(kafkaHeadersToMap(headers));
@@ -189,13 +172,6 @@ public final class DomainEventAssertions {
 
   private static JsonObject addInstanceIdForItem(JsonObject item, String instanceId) {
     return item.copy().put("instanceId", instanceId);
-  }
-
-  public static void assertUpdateEventForHolding(JsonObject oldHr, JsonObject newHr) {
-    final String id = newHr.getString("id");
-    final String newInstanceId = newHr.getString("instanceId");
-
-    awaitAtMost().until(() -> hasUpdateEvent(getHoldingsEvents(newInstanceId, id), oldHr, newHr));
   }
 
   public static void assertNoUpdateEventForHolding(String instanceId, String hrId) {

--- a/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
@@ -4,6 +4,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
 import static org.folio.rest.support.AwaitConfiguration.awaitDuring;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getMessagesForHoldings;
+import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_ID;
 import static org.folio.utility.ModuleUtility.vertxUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 
@@ -48,7 +49,13 @@ public class HoldingsEventMessageChecks {
     awaitAtMost().until(() -> getMessagesForHoldings(instanceId, holdingsId),
       eventMessageMatchers.hasDeleteEventMessageFor(holdings));
   }
-  
+
+  public static void allHoldingsDeletedMessagePublished() {
+    awaitAtMost()
+      .until(() -> getMessagesForHoldings(NULL_ID, null),
+        eventMessageMatchers.hasDeleteAllEventMessage());
+  }
+
   private static String getId(JsonObject holdings) {
     return holdings.getString("id");
   }

--- a/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
@@ -1,6 +1,8 @@
 package org.folio.rest.support.messages;
 
+import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
+import static org.folio.rest.support.AwaitConfiguration.awaitDuring;
 import static org.folio.rest.support.kafka.FakeKafkaConsumer.getMessagesForHoldings;
 import static org.folio.utility.ModuleUtility.vertxUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
@@ -29,6 +31,14 @@ public class HoldingsEventMessageChecks {
 
     awaitAtMost().until(() -> getMessagesForHoldings(instanceId, holdingsId),
       eventMessageMatchers.hasUpdateEventMessageFor(oldHoldings, newHoldings));
+  }
+
+  public static void noHoldingsUpdatedMessagePublished(String instanceId,
+    String holdingsId) {
+
+    awaitDuring(1, SECONDS)
+      .until(() -> getMessagesForHoldings(instanceId, holdingsId),
+        eventMessageMatchers.hasNoUpdateEventMessage());
   }
 
   private static String getId(JsonObject holdings) {

--- a/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
@@ -15,13 +15,27 @@ public class HoldingsEventMessageChecks {
 
   public static void holdingsCreatedMessagePublished(JsonObject holdings) {
     final var holdingsId = getId(holdings);
-    final var instanceId = holdings.getString("instanceId");
+    final var instanceId = getInstanceId(holdings);
 
     awaitAtMost().until(() -> getMessagesForHoldings(instanceId, holdingsId),
       eventMessageMatchers.hasCreateEventMessageFor(holdings));
   }
 
-  private static String getId(JsonObject json) {
-    return json.getString("id");
+  public static void holdingsUpdatedMessagePublished(JsonObject oldHoldings,
+    JsonObject newHoldings) {
+
+    final var holdingsId = getId(newHoldings);
+    final var instanceId = getInstanceId(newHoldings);
+
+    awaitAtMost().until(() -> getMessagesForHoldings(instanceId, holdingsId),
+      eventMessageMatchers.hasUpdateEventMessageFor(oldHoldings, newHoldings));
+  }
+
+  private static String getId(JsonObject holdings) {
+    return holdings.getString("id");
+  }
+
+  private static String getInstanceId(JsonObject holdings) {
+    return holdings.getString("instanceId");
   }
 }

--- a/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
@@ -16,6 +16,8 @@ public class HoldingsEventMessageChecks {
   private static final EventMessageMatchers eventMessageMatchers
     = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
 
+  private HoldingsEventMessageChecks() { }
+
   public static void holdingsCreatedMessagePublished(JsonObject holdings) {
     final var holdingsId = getId(holdings);
     final var instanceId = getInstanceId(holdings);

--- a/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
@@ -41,6 +41,14 @@ public class HoldingsEventMessageChecks {
         eventMessageMatchers.hasNoUpdateEventMessage());
   }
 
+  public static void holdingsDeletedMessagePublished(JsonObject holdings) {
+    final var holdingsId = getId(holdings);
+    final var instanceId = getInstanceId(holdings);
+
+    awaitAtMost().until(() -> getMessagesForHoldings(instanceId, holdingsId),
+      eventMessageMatchers.hasDeleteEventMessageFor(holdings));
+  }
+  
   private static String getId(JsonObject holdings) {
     return holdings.getString("id");
   }

--- a/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
@@ -1,0 +1,27 @@
+package org.folio.rest.support.messages;
+
+import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
+import static org.folio.rest.support.kafka.FakeKafkaConsumer.getMessagesForHoldings;
+import static org.folio.utility.ModuleUtility.vertxUrl;
+import static org.folio.utility.RestUtility.TENANT_ID;
+
+import org.folio.rest.support.messages.matchers.EventMessageMatchers;
+
+import io.vertx.core.json.JsonObject;
+
+public class HoldingsEventMessageChecks {
+  private static final EventMessageMatchers eventMessageMatchers
+    = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
+
+  public static void holdingsCreatedMessagePublished(JsonObject holdings) {
+    final var holdingsId = getId(holdings);
+    final var instanceId = holdings.getString("instanceId");
+
+    awaitAtMost().until(() -> getMessagesForHoldings(instanceId, holdingsId),
+      eventMessageMatchers.hasCreateEventMessageFor(holdings));
+  }
+
+  private static String getId(JsonObject json) {
+    return json.getString("id");
+  }
+}

--- a/src/test/java/org/folio/rest/support/messages/matchers/EventMessageMatchers.java
+++ b/src/test/java/org/folio/rest/support/messages/matchers/EventMessageMatchers.java
@@ -8,10 +8,8 @@ import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.hasSize;
 
 import java.net.URL;
-import java.util.Collection;
 import java.util.Map;
 
 import org.folio.okapi.common.XOkapiHeaders;
@@ -38,13 +36,6 @@ public class EventMessageMatchers {
       hasHeaders(),
       hasNewRepresentation(representation),
       hasNoOldRepresentation()));
-  }
-
-  @NotNull
-  public Matcher<Collection<?>> hasCreateEventMessagesFor(
-    Collection<JsonObject> representations) {
-
-    return hasSize(representations.size());
   }
 
   @NotNull


### PR DESCRIPTION
A follow on from #862 , #863 and #865

In order to remove the need for catching assertion exceptions and improve the stability of checking for published messages, replace the current use of assertions during awaitility with matcher composition.

The use of a `hasItem` matcher for checking the collection of received messages means that the test will pass when any of the messages matches the expectations, irrespective of ordering. This relies on the matching being sufficiently specific to not produce false matches.

The previous changes has moved all of the instance and authority messages to this new approach. This change moves holdings message checks to the new approach.

### Approach Taken
* move (and rename) methods for holdings messages to separate class
* use matcher with awaitility for each check
* remove unused methods for fetching first and last holdings messages
* extract a method for getting an empty list by default from a map of lists