### PR TITLE
Use awaitility matchers for bound with messages MODINVSTOR-1001

### DIFF
--- a/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
+++ b/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
@@ -1,9 +1,7 @@
 package org.folio.rest.api;
 
-import static org.awaitility.Awaitility.await;
 import static org.folio.rest.support.messages.BoundWithEventMessageChecks.boundWithCreatedMessagePublished;
 import static org.folio.rest.support.messages.BoundWithEventMessageChecks.boundWithUpdatedMessagePublished;
-import static org.folio.rest.support.messages.BoundWithEventMessageChecks.hasPublishedBoundWithHoldingsRecordIds;
 import static org.folio.utility.ModuleUtility.getClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -11,7 +9,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.net.HttpURLConnection;
 import java.util.List;
 import java.util.UUID;
-import java.util.concurrent.TimeUnit;
 
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.Response;
@@ -81,10 +78,6 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
     boundWithCreatedMessagePublished(firstPart.getJson(), mainInstance.getId().toString());
     boundWithCreatedMessagePublished(secondPart.getJson(), anotherInstance.getId().toString());
     boundWithCreatedMessagePublished(thirdPart.getJson(), aThirdInstance.getId().toString());
-
-    await().atMost(10, TimeUnit.SECONDS)
-      .until(() -> hasPublishedBoundWithHoldingsRecordIds(
-          mainHoldingsRecord.getId(), anotherHoldingsRecord.getId(), aThirdHoldingsRecord.getId()));
   }
 
   @Test
@@ -145,10 +138,6 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
     // until this is investigated further, that check is removed
     boundWithUpdatedMessagePublished(partTwoCreated.getJson(), partTwoUpdated.getJson(),
       instance2.getId().toString(), instance3.getId().toString());
-
-    await().atMost(10, TimeUnit.SECONDS)
-      .until(() -> hasPublishedBoundWithHoldingsRecordIds(
-          holdingsRecord1.getId(), holdingsRecord2.getId(), holdingsRecord3.getId()));
   }
 
   private JsonObject createBoundWithPartJson(UUID holdingsRecordId, UUID itemId) {

--- a/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
+++ b/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
@@ -15,7 +15,6 @@ import org.folio.rest.support.Response;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.builders.ItemRequestBuilder;
 import org.folio.rest.support.http.ResourceClient;
-import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
@@ -48,7 +47,6 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void canCreateAndRetrieveBoundWithParts() {
-    FakeKafkaConsumer.clearAllEvents();
     IndividualResource mainInstance = createInstance("Main Instance");
     IndividualResource mainHoldingsRecord = createHoldingsRecord(mainInstance.getId());
     IndividualResource item = createItem(mainHoldingsRecord.getId());
@@ -96,7 +94,6 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void canChangeOnePartOfABoundWith() {
-    FakeKafkaConsumer.clearAllEvents();
     IndividualResource instance1 = createInstance("Instance 1");
     IndividualResource holdingsRecord1 = createHoldingsRecord(instance1.getId());
     IndividualResource instance2 = createInstance("Instance 2");

--- a/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
+++ b/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
@@ -1,19 +1,16 @@
 package org.folio.rest.api;
 
 import static org.awaitility.Awaitility.await;
+import static org.folio.rest.support.messages.BoundWithEventMessageChecks.hasPublishedBoundWithHoldingsRecordIds;
 import static org.folio.utility.ModuleUtility.getClient;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import java.net.HttpURLConnection;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
-import junitparams.JUnitParamsRunner;
-import lombok.SneakyThrows;
+
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
@@ -24,6 +21,11 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import junitparams.JUnitParamsRunner;
+import lombok.SneakyThrows;
 
 @RunWith(JUnitParamsRunner.class)
 public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
@@ -151,14 +153,5 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
         .forHolding(holdingsRecordId)
         .withMaterialType(bookMaterialTypeId)
         .withPermanentLoanType(canCirculateLoanTypeId));
-  }
-
-  private boolean hasPublishedBoundWithHoldingsRecordIds(UUID id1, UUID id2, UUID id3) {
-    List<String> holdingsRecordIds = List.of(id1.toString(), id2.toString(), id3.toString());
-    List<String> publishedHoldingsRecordIds = FakeKafkaConsumer.getAllPublishedBoundWithEvents().stream()
-        .filter(json -> json.containsKey("new"))
-        .map(json -> json.getJsonObject("new").getString("holdingsRecordId"))
-        .collect(Collectors.toList());
-    return publishedHoldingsRecordIds.containsAll(holdingsRecordIds);
   }
 }

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -130,12 +130,6 @@ public final class FakeKafkaConsumer {
     boundWithEvents.clear();
   }
 
-  public static Collection<JsonObject> getAllPublishedBoundWithEvents() {
-    List<JsonObject> list = new ArrayList<>();
-    boundWithEvents.values().forEach(collection -> collection.forEach(record -> list.add(record.value())));
-    return list;
-  }
-
   public static int getAllPublishedAuthoritiesCount() {
     return authorityEvents.size();
   }

--- a/src/test/java/org/folio/rest/support/messages/BoundWithEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/BoundWithEventMessageChecks.java
@@ -6,10 +6,6 @@ import static org.folio.utility.ModuleUtility.vertxUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.allOf;
 
-import java.util.List;
-import java.util.UUID;
-import java.util.stream.Collectors;
-
 import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.folio.rest.support.messages.matchers.EventMessageMatchers;
 import org.hamcrest.CoreMatchers;
@@ -23,17 +19,6 @@ public class BoundWithEventMessageChecks {
     = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
 
   private BoundWithEventMessageChecks() { }
-
-  public static boolean hasPublishedBoundWithHoldingsRecordIds(UUID id1,
-    UUID id2, UUID id3) {
-    List<String> holdingsRecordIds = List.of(id1.toString(), id2.toString(),
-      id3.toString());
-    List<String> publishedHoldingsRecordIds = FakeKafkaConsumer.getAllPublishedBoundWithEvents().stream()
-      .filter(json -> json.containsKey("new"))
-      .map(json -> json.getJsonObject("new").getString("holdingsRecordId"))
-      .collect(Collectors.toList());
-    return publishedHoldingsRecordIds.containsAll(holdingsRecordIds);
-  }
 
   public static void boundWithCreatedMessagePublished(JsonObject boundWith,
     String instanceId) {

--- a/src/test/java/org/folio/rest/support/messages/BoundWithEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/BoundWithEventMessageChecks.java
@@ -1,12 +1,24 @@
 package org.folio.rest.support.messages;
 
+import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
+import static org.folio.utility.ModuleUtility.vertxUrl;
+import static org.folio.utility.RestUtility.TENANT_ID;
+
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
 import org.folio.rest.support.kafka.FakeKafkaConsumer;
+import org.folio.rest.support.messages.matchers.EventMessageMatchers;
+
+import io.vertx.core.json.JsonObject;
 
 public class BoundWithEventMessageChecks {
+  private static final EventMessageMatchers eventMessageMatchers
+    = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
+
+  private BoundWithEventMessageChecks() { }
+
   public static boolean hasPublishedBoundWithHoldingsRecordIds(UUID id1,
     UUID id2, UUID id3) {
     List<String> holdingsRecordIds = List.of(id1.toString(), id2.toString(),
@@ -16,5 +28,22 @@ public class BoundWithEventMessageChecks {
       .map(json -> json.getJsonObject("new").getString("holdingsRecordId"))
       .collect(Collectors.toList());
     return publishedHoldingsRecordIds.containsAll(holdingsRecordIds);
+  }
+
+  public static void boundWithCreatedMessagePublished(JsonObject boundWith,
+    String instanceId) {
+
+    // Bound With messages are published with the instance ID as the key
+    // and that property is not part of the record, so must be provided separately
+    awaitAtMost().until(() -> FakeKafkaConsumer.getMessagesForBoundWith(instanceId),
+      eventMessageMatchers.hasCreateEventMessageFor(
+        addInstanceIdToBoundWith(boundWith, instanceId)));
+  }
+
+  private static JsonObject addInstanceIdToBoundWith(JsonObject boundWith, String instanceId) {
+    // Event for bound with has an extra 'instanceId' property for
+    // old/new object, the property does not exist in schema,
+    // so we have to add it manually
+    return boundWith.copy().put("instanceId", instanceId);
   }
 }

--- a/src/test/java/org/folio/rest/support/messages/BoundWithEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/BoundWithEventMessageChecks.java
@@ -1,0 +1,20 @@
+package org.folio.rest.support.messages;
+
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import org.folio.rest.support.kafka.FakeKafkaConsumer;
+
+public class BoundWithEventMessageChecks {
+  public static boolean hasPublishedBoundWithHoldingsRecordIds(UUID id1,
+    UUID id2, UUID id3) {
+    List<String> holdingsRecordIds = List.of(id1.toString(), id2.toString(),
+      id3.toString());
+    List<String> publishedHoldingsRecordIds = FakeKafkaConsumer.getAllPublishedBoundWithEvents().stream()
+      .filter(json -> json.containsKey("new"))
+      .map(json -> json.getJsonObject("new").getString("holdingsRecordId"))
+      .collect(Collectors.toList());
+    return publishedHoldingsRecordIds.containsAll(holdingsRecordIds);
+  }
+}

--- a/src/test/java/org/folio/rest/support/messages/ItemEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/ItemEventMessageChecks.java
@@ -71,7 +71,7 @@ public class ItemEventMessageChecks {
   }
 
   private static JsonObject addInstanceIdForItem(JsonObject item, String instanceId) {
-    // Domain event for item has an extra 'instanceId' property for
+    // Event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
     // so we have to add it manually
     return item.copy().put("instanceId", instanceId);

--- a/src/test/java/org/folio/rest/support/messages/ItemEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/ItemEventMessageChecks.java
@@ -26,7 +26,7 @@ public class ItemEventMessageChecks {
 
     awaitAtMost().until(() -> getMessagesForItem(instanceId, itemId),
       eventMessageMatchers.hasCreateEventMessageFor(
-        addInstanceIdForItem(item, instanceId)));
+        addInstanceIdToItem(item, instanceId)));
   }
 
   public static void itemUpdatedMessagePublished(JsonObject oldItem, JsonObject newItem) {
@@ -43,8 +43,8 @@ public class ItemEventMessageChecks {
 
     awaitAtMost().until(() -> getMessagesForItem(newInstanceId, itemId),
       eventMessageMatchers.hasUpdateEventMessageFor(
-        addInstanceIdForItem(oldItem, oldInstanceId),
-        addInstanceIdForItem(newItem, newInstanceId)));
+        addInstanceIdToItem(oldItem, oldInstanceId),
+        addInstanceIdToItem(newItem, newInstanceId)));
   }
 
   public static void itemDeletedMessagePublished(JsonObject item) {
@@ -53,7 +53,7 @@ public class ItemEventMessageChecks {
 
     awaitAtMost().until(() -> getMessagesForItem(instanceId, itemId),
       eventMessageMatchers.hasDeleteEventMessageFor(
-        addInstanceIdForItem(item, instanceId)));
+        addInstanceIdToItem(item, instanceId)));
   }
 
   public static void allItemsDeletedMessagePublished() {
@@ -70,7 +70,7 @@ public class ItemEventMessageChecks {
     return item.getString("holdingsRecordId");
   }
 
-  private static JsonObject addInstanceIdForItem(JsonObject item, String instanceId) {
+  private static JsonObject addInstanceIdToItem(JsonObject item, String instanceId) {
     // Event for item has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
     // so we have to add it manually

--- a/src/test/java/org/folio/rest/support/messages/matchers/EventMessageMatchers.java
+++ b/src/test/java/org/folio/rest/support/messages/matchers/EventMessageMatchers.java
@@ -86,7 +86,7 @@ public class EventMessageMatchers {
   }
 
   @NotNull
-  private Matcher<EventMessage> isUpdateEvent() {
+  public Matcher<EventMessage> isUpdateEvent() {
     return hasType("UPDATE");
   }
 
@@ -106,12 +106,12 @@ public class EventMessageMatchers {
   }
 
   @NotNull
-  private Matcher<EventMessage> isForTenant() {
+  public Matcher<EventMessage> isForTenant() {
     return hasProperty("tenant", is(expectedTenantId));
   }
 
   @NotNull
-  private Matcher<EventMessage> hasHeaders() {
+  public Matcher<EventMessage> hasHeaders() {
     return hasProperty("headers", allOf(
       hasTenantHeader(),
       hasUrlHeader()));
@@ -145,7 +145,8 @@ public class EventMessageMatchers {
   }
 
   @NotNull
-  private Matcher<EventMessage> hasNewRepresentation(JsonObject expectedRepresentation) {
+  public Matcher<EventMessage> hasNewRepresentation(
+    JsonObject expectedRepresentation) {
     return hasNewRepresentationThat(equalsIgnoringMetadata(expectedRepresentation));
   }
 


### PR DESCRIPTION
A follow on from #862 , #863, #865, #867 and #869

In order to remove the need for catching assertion exceptions and improve the stability of checking for published messages, replace the current use of assertions during awaitility with matcher composition.

The use of a `hasItem` matcher for checking the collection of received messages means that the test will pass when any of the messages matches the expectations, irrespective of ordering. This relies on the matching being sufficiently specific to not produce false matches.

The previous changes has moved all of the instance, authority, holdings and item messages to this new approach. This change moves bound with message checks to the new approach.

The check for update messages deliberately DOES NOT check the `old` representation of the record. This is due to a potential bug with which representation is included in this part of the message. Until that is resolved, that check fails.

### Approach Taken
* move existing methods for bound with messages to separate class
* introduce new checks for create and update messages, similar to other record types
* remove existing checks (that check specific portions of the messages)