### PR TITLE
Rework fake kafka consumer MODINVSTOR-1001

### DIFF
--- a/src/test/java/org/folio/rest/api/AuthorityStorageTest.java
+++ b/src/test/java/org/folio/rest/api/AuthorityStorageTest.java
@@ -5,10 +5,6 @@ import static org.folio.rest.support.AdditionalHttpStatusCodes.UNPROCESSABLE_ENT
 import static org.folio.rest.support.HttpResponseMatchers.errorMessageContains;
 import static org.folio.rest.support.HttpResponseMatchers.statusCodeIs;
 import static org.folio.rest.support.http.InterfaceUrls.authoritiesStorageUrl;
-import static org.folio.rest.support.messages.AuthorityEventMessageChecks.allAuthoritiesDeletedMessagePublished;
-import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityCreatedMessagePublished;
-import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityDeletedMessagePublished;
-import static org.folio.rest.support.messages.AuthorityEventMessageChecks.authorityUpdatedMessagePublished;
 import static org.folio.utility.ModuleUtility.getClient;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -24,6 +20,7 @@ import java.util.concurrent.TimeoutException;
 import org.folio.rest.jaxrs.model.Authority;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
+import org.folio.rest.support.messages.AuthorityEventMessageChecks;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -34,6 +31,8 @@ import lombok.SneakyThrows;
 
 @RunWith(JUnitParamsRunner.class)
 public class AuthorityStorageTest extends TestBase {
+  private final AuthorityEventMessageChecks authorityMessageChecks
+    = new AuthorityEventMessageChecks(kafkaConsumer);
 
   @SneakyThrows
   @Before
@@ -64,7 +63,7 @@ public class AuthorityStorageTest extends TestBase {
     var response2 = authoritiesClient.getById(UUID.fromString(response.get(0).getString("id")));
     assertEquals("personalName0", response2.getJson().getString("personalName"));
 
-    authorityCreatedMessagePublished(response2.getJson());
+    authorityMessageChecks.createdMessagePublished(response2.getJson());
   }
 
   @Test
@@ -87,7 +86,7 @@ public class AuthorityStorageTest extends TestBase {
     response = authoritiesClient.getAll();
     assertEquals(0, response.size());
 
-    allAuthoritiesDeletedMessagePublished();
+    authorityMessageChecks.allAuthoritiesDeletedMessagePublished();
   }
 
   @Test
@@ -103,7 +102,7 @@ public class AuthorityStorageTest extends TestBase {
     var response2 = authoritiesClient.getAll();
     assertEquals(0, response2.size());
 
-    authorityDeletedMessagePublished(response.get(0));
+    authorityMessageChecks.deletedMessagePublished(response.get(0));
   }
 
   @Test
@@ -137,7 +136,7 @@ public class AuthorityStorageTest extends TestBase {
     var response2 = authoritiesClient.getById(UUID.fromString(response.get(0).getString("id")));
     assertEquals(object.getString("personalName"), response2.getJson().getString("personalName"));
 
-    authorityUpdatedMessagePublished(response.get(0), response2.getJson());
+    authorityMessageChecks.updatedMessagePublished(response.get(0), response2.getJson());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/DereferencedItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/DereferencedItemStorageTest.java
@@ -13,11 +13,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNull;
 
-import io.vertx.core.json.JsonObject;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
-import lombok.SneakyThrows;
+
 import org.folio.rest.jaxrs.model.DereferencedItem;
 import org.folio.rest.jaxrs.model.DereferencedItems;
 import org.folio.rest.support.Response;
@@ -26,6 +25,9 @@ import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import io.vertx.core.json.JsonObject;
+import lombok.SneakyThrows;
 
 public class DereferencedItemStorageTest extends TestBaseWithInventoryUtil {
   private static final UUID smallAngryPlanetId = UUID.randomUUID();
@@ -49,7 +51,7 @@ public class DereferencedItemStorageTest extends TestBaseWithInventoryUtil {
     postItem(smallAngryPlanet);
     postItem(nod);
     postItem(uprooted);
-    FakeKafkaConsumer.clearAllEvents();
+    FakeKafkaConsumer.discardAllMessages();
   }
 
   @AfterClass
@@ -63,7 +65,7 @@ public class DereferencedItemStorageTest extends TestBaseWithInventoryUtil {
   public void CanGetRecordByBarcode() {
     String queryString = "barcode==036000291452";
     String queryString2 = "barcode==657670342075";
-    
+
     DereferencedItems items = findByCql(queryString);
 
     assertThat(items.getTotalRecords(), is(1));
@@ -91,7 +93,7 @@ public class DereferencedItemStorageTest extends TestBaseWithInventoryUtil {
   @Test
   public void ReturnsEmptyCollectionWhenNoItemsFound() {
     String queryString = "barcode==647671342075";
-    
+
     DereferencedItems items = findByCql(queryString);
 
     assertThat(items.getTotalRecords(), is(0));
@@ -100,7 +102,7 @@ public class DereferencedItemStorageTest extends TestBaseWithInventoryUtil {
   @Test
   public void Returns400WhenCqlSearchInvalid() {
     String queryString = "barcode&647671342075";
-    
+
     Response response = attemptFindByCql(queryString);
 
     assertThat(response.getStatusCode(), is(400));
@@ -116,7 +118,7 @@ public class DereferencedItemStorageTest extends TestBaseWithInventoryUtil {
   @Test
   public void Returns404WhenNoItemFoundForId() {
     String Id = UUID.randomUUID().toString();
-    
+
     Response response = attemptFindById(Id);
 
     assertThat(response.getStatusCode(), is(404));
@@ -125,7 +127,7 @@ public class DereferencedItemStorageTest extends TestBaseWithInventoryUtil {
   @Test
   public void Returns400WhenInvalidUUID() {
     String Id = "w325b3dc4";
-    
+
     Response response = attemptFindById(Id);
 
     assertThat(response.getStatusCode(), is(400));
@@ -173,7 +175,7 @@ public class DereferencedItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   private static JsonObject createItemRequest(
-    UUID id, UUID holdingsRecordId, String barcode, 
+    UUID id, UUID holdingsRecordId, String barcode,
     String materialType, Boolean includeOptionalFields) {
 
     JsonObject itemToCreate = new JsonObject();

--- a/src/test/java/org/folio/rest/api/DereferencedItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/DereferencedItemStorageTest.java
@@ -21,7 +21,6 @@ import org.folio.rest.jaxrs.model.DereferencedItem;
 import org.folio.rest.jaxrs.model.DereferencedItems;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
-import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -51,7 +50,8 @@ public class DereferencedItemStorageTest extends TestBaseWithInventoryUtil {
     postItem(smallAngryPlanet);
     postItem(nod);
     postItem(uprooted);
-    FakeKafkaConsumer.discardAllMessages();
+
+    kafkaConsumer.discardAllMessages();
   }
 
   @AfterClass

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -15,7 +15,6 @@ import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageSyncUrl;
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
 import static org.folio.rest.support.matchers.PostgresErrorMessageMatchers.isMaximumSequenceValueError;
-import static org.folio.rest.support.messages.ItemEventMessageChecks.itemUpdatedMessagePublished;
 import static org.folio.utility.ModuleUtility.getClient;
 import static org.folio.utility.ModuleUtility.getVertx;
 import static org.folio.utility.RestUtility.TENANT_ID;
@@ -66,6 +65,7 @@ import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.builders.ItemRequestBuilder;
 import org.folio.rest.support.db.OptimisticLocking;
 import org.folio.rest.support.messages.HoldingsEventMessageChecks;
+import org.folio.rest.support.messages.ItemEventMessageChecks;
 import org.folio.rest.tools.utils.OptimisticLockingUtil;
 import org.junit.After;
 import org.junit.Before;
@@ -87,6 +87,9 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
   private final HoldingsEventMessageChecks holdingsMessageChecks
     = new HoldingsEventMessageChecks(kafkaConsumer);
+
+  private final ItemEventMessageChecks itemMessageChecks
+    = new ItemEventMessageChecks(kafkaConsumer);
 
   @SneakyThrows
   @Before
@@ -394,7 +397,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     JsonObject newItem = item.copy()
       .put("_version", 2);
 
-    itemUpdatedMessagePublished(item, newItem, instanceId.toString());
+    itemMessageChecks.updatedMessagePublished(item, newItem, instanceId.toString());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -14,13 +14,8 @@ import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageSyncUnsaf
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageSyncUrl;
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
-import static org.folio.rest.support.messages.ItemEventMessageChecks.itemUpdatedMessagePublished;
 import static org.folio.rest.support.matchers.PostgresErrorMessageMatchers.isMaximumSequenceValueError;
-import static org.folio.rest.support.messages.HoldingsEventMessageChecks.allHoldingsDeletedMessagePublished;
-import static org.folio.rest.support.messages.HoldingsEventMessageChecks.holdingsCreatedMessagePublished;
-import static org.folio.rest.support.messages.HoldingsEventMessageChecks.holdingsDeletedMessagePublished;
-import static org.folio.rest.support.messages.HoldingsEventMessageChecks.holdingsUpdatedMessagePublished;
-import static org.folio.rest.support.messages.HoldingsEventMessageChecks.noHoldingsUpdatedMessagePublished;
+import static org.folio.rest.support.messages.ItemEventMessageChecks.itemUpdatedMessagePublished;
 import static org.folio.utility.ModuleUtility.getClient;
 import static org.folio.utility.ModuleUtility.getVertx;
 import static org.folio.utility.RestUtility.TENANT_ID;
@@ -89,6 +84,9 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   private static final Logger log = LogManager.getLogger();
   private static final String TAG_VALUE = "test-tag";
   public static final String NEW_TEST_TAG = "new test tag";
+
+  private final HoldingsEventMessageChecks holdingsMessageChecks
+    = new HoldingsEventMessageChecks(kafkaConsumer);
 
   @SneakyThrows
   @Before
@@ -161,7 +159,8 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(tags.size(), is(1));
     assertThat(tags, hasItem(TAG_VALUE));
-    holdingsCreatedMessagePublished(holding);
+
+    holdingsMessageChecks.createdMessagePublished(holding);
   }
 
   @Test
@@ -352,7 +351,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(tags.size(), is(1));
     assertThat(tags, hasItem(NEW_TEST_TAG));
-    holdingsUpdatedMessagePublished(holdingResource.getJson(), holdingFromGet);
+    holdingsMessageChecks.updatedMessagePublished(holdingResource.getJson(), holdingFromGet);
   }
 
   @Test
@@ -389,10 +388,12 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     JsonObject holdingFromGet = getResponse.getJson();
 
     assertThat(holdingFromGet.getString("instanceId"), is(newInstanceId.toString()));
-    holdingsUpdatedMessagePublished(holdingResource.getJson(), holdingFromGet);
+
+    holdingsMessageChecks.updatedMessagePublished(holdingResource.getJson(), holdingFromGet);
 
     JsonObject newItem = item.copy()
       .put("_version", 2);
+
     itemUpdatedMessagePublished(item, newItem, instanceId.toString());
   }
 
@@ -413,16 +414,13 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     Response getResponse = holdingsClient.getById(holdingId);
 
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
-    holdingsDeletedMessagePublished(holdingResource.getJson());
+
+    holdingsMessageChecks.deletedMessagePublished(holdingResource.getJson());
   }
 
+  @SneakyThrows
   @Test
-  public void canGetAllHoldings()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
-
+  public void canGetAllHoldings() {
     UUID firstInstanceId = UUID.randomUUID();
     UUID secondInstanceId = UUID.randomUUID();
     UUID thirdInstanceId = UUID.randomUUID();
@@ -624,7 +622,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(allHoldings.size(), is(0));
 
-    allHoldingsDeletedMessagePublished();
+    holdingsMessageChecks.allHoldingsDeletedMessagePublished();
   }
 
   @SneakyThrows
@@ -664,26 +662,24 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertNotExists(h1);
     assertNotExists(h3);
     assertNotExists(h5);
-    holdingsDeletedMessagePublished(h1);
-    holdingsDeletedMessagePublished(h3);
-    holdingsDeletedMessagePublished(h5);
+
+    holdingsMessageChecks.deletedMessagePublished(h1);
+    holdingsMessageChecks.deletedMessagePublished(h3);
+    holdingsMessageChecks.deletedMessagePublished(h5);
   }
 
   @SneakyThrows
   @Test
   public void cannotDeleteHoldingsWithEmptyCql() {
-
     var response = getClient().delete(holdingsStorageUrl("?query="), TENANT_ID).get(10, SECONDS);
 
     assertThat(response.getStatusCode(), is(400));
     assertThat(response.getBody(), containsString("empty"));
   }
 
+  @SneakyThrows
   @Test
-  public void tenantIsRequiredForCreatingANewHolding()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
-
+  public void tenantIsRequiredForCreatingANewHolding() {
     UUID instanceId = UUID.randomUUID();
 
     instancesClient.create(smallAngryPlanet(instanceId));
@@ -2048,9 +2044,11 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     final JsonObject holdingsFromGet = getResponse.getJson();
 
     assertThat(holdingsFromGet.getString("hrid"), is(hrid));
+
     // Make sure a create event published vs update event
-    holdingsCreatedMessagePublished(holdingsFromGet);
-    noHoldingsUpdatedMessagePublished(instanceId.toString(), holdingsId.toString());
+    holdingsMessageChecks.createdMessagePublished(holdingsFromGet);
+    holdingsMessageChecks.noHoldingsUpdatedMessagePublished(
+      instanceId.toString(), holdingsId.toString());
 
     log.info("Finished canUsePutToCreateAHoldingsWhenHRIDIsSupplied");
   }
@@ -2335,7 +2333,8 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       final JsonObject holding = (JsonObject) hrObj;
 
       assertExists(holding);
-      holdingsCreatedMessagePublished(getById(holding.getString("id")).getJson());
+
+      holdingsMessageChecks.createdMessagePublished(getById(holding.getString("id")).getJson());
     }
   }
 
@@ -2394,11 +2393,11 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       .filter(id -> !id.equals(existingHrId))
       .map(this::getById)
       .map(Response::getJson)
-      .forEach(HoldingsEventMessageChecks::holdingsCreatedMessagePublished);
+      .forEach(holdingsMessageChecks::createdMessagePublished);
 
     var holdingsAfterUpdate = getById(existingHrId).getJson();
 
-    holdingsUpdatedMessagePublished(holdingsBeforeUpdate, holdingsAfterUpdate);
+    holdingsMessageChecks.updatedMessagePublished(holdingsBeforeUpdate, holdingsAfterUpdate);
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/InstanceDomainEventTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceDomainEventTest.java
@@ -4,9 +4,6 @@ import static org.folio.rest.api.InstanceStorageTest.smallAngryPlanet;
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
-import static org.folio.rest.support.messages.InstanceEventMessageChecks.noInstanceUpdatedMessagePublished;
-import static org.folio.rest.support.messages.InstanceEventMessageChecks.noInstanceDeletedMessagePublished;
-import static org.folio.rest.support.messages.InstanceEventMessageChecks.noInstanceMessagesPublished;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
@@ -14,6 +11,7 @@ import java.util.UUID;
 
 import org.folio.rest.support.Response;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
+import org.folio.rest.support.messages.InstanceEventMessageChecks;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -21,6 +19,8 @@ import io.vertx.core.json.JsonObject;
 import lombok.SneakyThrows;
 
 public class InstanceDomainEventTest extends TestBaseWithInventoryUtil {
+  private final InstanceEventMessageChecks instanceMessageChecks
+    = new InstanceEventMessageChecks(kafkaConsumer);
 
   @SneakyThrows
   @Before
@@ -45,7 +45,7 @@ public class InstanceDomainEventTest extends TestBaseWithInventoryUtil {
       updatedInstance);
 
     assertThat(updateInstance.getStatusCode(), is(400));
-    noInstanceUpdatedMessagePublished(instance.getId().toString());
+    instanceMessageChecks.noUpdatedMessagePublished(instance.getId().toString());
   }
 
   @Test
@@ -58,7 +58,7 @@ public class InstanceDomainEventTest extends TestBaseWithInventoryUtil {
     final var createResponse = instancesClient.attemptToCreate(instanceJson);
 
     assertThat(createResponse.getStatusCode(), is(400));
-    noInstanceMessagesPublished(instanceId.toString());
+    instanceMessageChecks.noMessagesPublished(instanceId.toString());
   }
 
   @Test
@@ -73,7 +73,8 @@ public class InstanceDomainEventTest extends TestBaseWithInventoryUtil {
     final Response removeResponse = instancesClient.attemptToDelete(instance.getId());
 
     assertThat(removeResponse.getStatusCode(), is(400));
-    noInstanceDeletedMessagePublished(instance.getId().toString());
+
+    instanceMessageChecks.noDeletedMessagePublished(instance.getId().toString());
   }
 
   @Test
@@ -90,5 +91,6 @@ public class InstanceDomainEventTest extends TestBaseWithInventoryUtil {
     final Response removeResponse = instancesClient.attemptDeleteAll();
 
     assertThat(removeResponse.getStatusCode(), is(400));
-    noInstanceDeletedMessagePublished(instance.getId().toString());
+
+    instanceMessageChecks.noDeletedMessagePublished(instance.getId().toString());
   }}

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -18,12 +18,6 @@ import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.natureOfContentTermsUrl;
 import static org.folio.rest.support.matchers.DateTimeMatchers.hasIsoFormat;
 import static org.folio.rest.support.matchers.DateTimeMatchers.withinSecondsBeforeNow;
-import static org.folio.rest.support.messages.InstanceEventMessageChecks.instanceCreatedMessagesPublished;
-import static org.folio.rest.support.messages.InstanceEventMessageChecks.noInstanceMessagesPublished;
-import static org.folio.rest.support.messages.InstanceEventMessageChecks.allInstancesDeletedMessagePublished;
-import static org.folio.rest.support.messages.InstanceEventMessageChecks.instancedUpdatedMessagePublished;
-import static org.folio.rest.support.messages.InstanceEventMessageChecks.instanceCreatedMessagePublished;
-import static org.folio.rest.support.messages.InstanceEventMessageChecks.instanceDeletedMessagePublished;
 import static org.folio.rest.support.matchers.PostgresErrorMessageMatchers.isMaximumSequenceValueError;
 import static org.folio.rest.support.matchers.PostgresErrorMessageMatchers.isUniqueViolation;
 import static org.folio.util.StringUtil.urlEncode;
@@ -93,6 +87,7 @@ import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.builders.ItemRequestBuilder;
 import org.folio.rest.support.db.OptimisticLocking;
+import org.folio.rest.support.messages.InstanceEventMessageChecks;
 import org.folio.rest.tools.utils.OptimisticLockingUtil;
 import org.folio.utility.LocationUtility;
 import org.junit.After;
@@ -118,7 +113,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   private static final String DISCOVERY_SUPPRESS = "discoverySuppress";
   private static final String STAFF_SUPPRESS = "staffSuppress";
 
-  private Set<String> natureOfContentIdsToRemoveAfterTest = new HashSet<>();
+  private final Set<String> natureOfContentIdsToRemoveAfterTest = new HashSet<>();
+
+  private final InstanceEventMessageChecks instanceMessageChecks
+    = new InstanceEventMessageChecks(kafkaConsumer);
 
   @SneakyThrows
   @Before
@@ -220,7 +218,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       instanceFromGet.getString(STATUS_UPDATED_DATE_PROPERTY), hasIsoFormat());
 
     assertThat(instanceFromGet.getBoolean(DISCOVERY_SUPPRESS), is(false));
-    instanceCreatedMessagePublished(instanceFromGet);
+
+    instanceMessageChecks.createdMessagePublished(instanceFromGet);
 
     var storedPublicationPeriod = instance.getJsonObject("publicationPeriod")
       .mapTo(PublicationPeriod.class);
@@ -433,8 +432,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(itemFromGet.getString(STATUS_UPDATED_DATE_PROPERTY),
       is(replacement.getString(STATUS_UPDATED_DATE_PROPERTY)));
     assertThat(itemFromGet.getBoolean(DISCOVERY_SUPPRESS), is(false));
-    instancedUpdatedMessagePublished(createdInstance.getJson(), updatedInstance.getJson());
     assertThat(itemFromGet.getJsonArray("administrativeNotes").contains(adminNote), is(true));
+
+    instanceMessageChecks.updatedMessagePublished(createdInstance.getJson(),
+      updatedInstance.getJson());
   }
 
   @Test
@@ -456,7 +457,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(deleteResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
 
     assertGetNotFound(url);
-    instanceDeletedMessagePublished(createdInstance.getJson());
+
+    instanceMessageChecks.deletedMessagePublished(createdInstance.getJson());
   }
 
   @SneakyThrows
@@ -490,9 +492,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertNotExists(instance3);
     assertNotExists(instance5);
     getMarcJsonNotFound(id5);
-    instanceDeletedMessagePublished(instance1);
-    instanceDeletedMessagePublished(instance3);
-    instanceDeletedMessagePublished(instance5);
+
+    instanceMessageChecks.deletedMessagePublished(instance1);
+    instanceMessageChecks.deletedMessagePublished(instance3);
+    instanceMessageChecks.deletedMessagePublished(instance5);
   }
 
   @SneakyThrows
@@ -1498,14 +1501,12 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(allInstances.size(), is(0));
     assertThat(responseBody.getInteger(TOTAL_RECORDS_KEY), is(0));
 
-    allInstancesDeletedMessagePublished();
+    instanceMessageChecks.allInstancesDeletedMessagePublished();
   }
 
+  @SneakyThrows
   @Test
-  public void tenantIsRequiredForCreatingNewInstance()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
-
+  public void tenantIsRequiredForCreatingNewInstance() {
     JsonObject instance = nod(UUID.randomUUID());
 
     CompletableFuture<Response> postCompleted = new CompletableFuture<>();
@@ -1518,13 +1519,12 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(response.getBody(), is("Unable to process request Tenant must be set"));
   }
 
+  @SneakyThrows
   @Test
-  public void tenantIsRequiredForGettingAnInstance()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
+  public void tenantIsRequiredForGettingAnInstance() {
 
     URL getInstanceUrl = instancesStorageUrl(String.format("/%s",
-      UUID.randomUUID().toString()));
+      UUID.randomUUID()));
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 
@@ -1536,11 +1536,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(response.getBody(), is("Unable to process request Tenant must be set"));
   }
 
+  @SneakyThrows
   @Test
-  public void tenantIsRequiredForGettingAllInstances()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
-
+  public void tenantIsRequiredForGettingAllInstances() {
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 
     getClient().get(instancesStorageUrl(""), null, ResponseHandler.any(getCompleted));
@@ -1551,9 +1549,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(response.getBody(), is("Unable to process request Tenant must be set"));
   }
 
+  @SneakyThrows
   @Test
-  public void testCrossTableQueries() throws Exception {
-
+  public void testCrossTableQueries() {
     String url = instancesStorageUrl("") + "?query=";
 
     //////// create instance objects /////////////////////////////
@@ -1725,7 +1723,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertNotSuppressedFromDiscovery(instances);
 
-    instanceCreatedMessagesPublished(toList(instances));
+    instanceMessageChecks.createdMessagesPublished(toList(instances));
   }
 
   @Test
@@ -1767,9 +1765,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertNotSuppressedFromDiscovery(instances);
 
-    instanceCreatedMessagesPublished(toList(instances));
-    noInstanceMessagesPublished(firstErrorInstance.getString("id"));
-    noInstanceMessagesPublished(secondErrorInstance.getString("id"));
+    instanceMessageChecks.createdMessagesPublished(toList(instances));
+    instanceMessageChecks.noMessagesPublished(firstErrorInstance.getString("id"));
+    instanceMessageChecks.noMessagesPublished(secondErrorInstance.getString("id"));
   }
 
   @Test
@@ -1946,7 +1944,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       .map(Response::getJson)
       .collect(Collectors.toList());
 
-    instanceCreatedMessagesPublished(createdInstances);
+    instanceMessageChecks.createdMessagesPublished(createdInstances);
   }
 
   @Test
@@ -2036,9 +2034,13 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     JsonObject updatedInstance = getResponse.getJson();
     assertThat(updatedInstance.getString("title"), is("Long Way to a Small Angry Planet"));
 
-    instancedUpdatedMessagePublished(existingInstance.getJson(), updatedInstance);
-    instanceCreatedMessagePublished(getById(firstInstanceToCreate.getString("id")).getJson());
-    instanceCreatedMessagePublished(getById(secondInstanceToCreate.getString("id")).getJson());
+    instanceMessageChecks.updatedMessagePublished(existingInstance.getJson(), updatedInstance);
+
+    instanceMessageChecks.createdMessagePublished(
+      getById(firstInstanceToCreate.getString("id")).getJson());
+
+    instanceMessageChecks.createdMessagePublished(
+      getById(secondInstanceToCreate.getString("id")).getJson());
   }
 
   @Test
@@ -2688,7 +2690,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       getById(instance.getId()).getJson().copy().put(DISCOVERY_SUPPRESS, true));
 
     assertSuppressedFromDiscovery(instance.getId().toString());
-    instancedUpdatedMessagePublished(instance.getJson(), updateInstance.getJson());
+
+    instanceMessageChecks.updatedMessagePublished(instance.getJson(), updateInstance.getJson());
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
@@ -7,7 +7,6 @@ import static org.folio.rest.support.matchers.ItemMatchers.hasCallNumber;
 import static org.folio.rest.support.matchers.ItemMatchers.hasPrefix;
 import static org.folio.rest.support.matchers.ItemMatchers.hasSuffix;
 import static org.folio.rest.support.matchers.ItemMatchers.hasTypeId;
-import static org.folio.rest.support.messages.ItemEventMessageChecks.itemUpdatedMessagePublished;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -23,6 +22,7 @@ import org.folio.rest.api.testdata.ItemEffectiveCallNumberComponentsTestData.Cal
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
+import org.folio.rest.support.messages.ItemEventMessageChecks;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -39,6 +39,9 @@ public class ItemEffectiveCallNumberComponentsTest extends TestBaseWithInventory
   public static final String HOLDINGS_CALL_NUMBER_TYPE_SECOND = UUID.randomUUID().toString();
   public static final String ITEM_LEVEL_CALL_NUMBER_TYPE = UUID.randomUUID().toString();
   public static final String ITEM_LEVEL_CALL_NUMBER_TYPE_SECOND = UUID.randomUUID().toString();
+
+  private final ItemEventMessageChecks itemMessageChecks
+    = new ItemEventMessageChecks(kafkaConsumer);
 
   @BeforeClass
   public static void createCallNumberTypes() {
@@ -246,13 +249,13 @@ public class ItemEffectiveCallNumberComponentsTest extends TestBaseWithInventory
 
     var itemAfterHoldingsUpdate = getById(createdItem.getJson());
 
-    itemUpdatedMessagePublished(createdItem.getJson(), itemAfterHoldingsUpdate);
+    itemMessageChecks.updatedMessagePublished(createdItem.getJson(), itemAfterHoldingsUpdate);
 
     if (!Objects.equals(itemInitValue, itemTargetValue)) {
       itemsClient.replace(createdItem.getId(), itemAfterHoldingsUpdate.copy()
         .put(itemPropertyName, itemTargetValue));
 
-      itemUpdatedMessagePublished(itemAfterHoldingsUpdate,
+      itemMessageChecks.updatedMessagePublished(itemAfterHoldingsUpdate,
         itemsClient.getById(createdItem.getId()).getJson());
     }
 

--- a/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
@@ -1,6 +1,5 @@
 package org.folio.rest.api;
 
-import static org.folio.rest.support.messages.ItemEventMessageChecks.itemUpdatedMessagePublished;
 import static org.folio.utility.ModuleUtility.getClient;
 import static org.folio.utility.ModuleUtility.getVertx;
 import static org.folio.utility.RestUtility.TENANT_ID;
@@ -25,6 +24,7 @@ import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.http.InterfaceUrls;
 import org.folio.rest.support.messages.HoldingsEventMessageChecks;
+import org.folio.rest.support.messages.ItemEventMessageChecks;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -48,6 +48,9 @@ public class ItemEffectiveLocationTest extends TestBaseWithInventoryUtil {
 
   private final HoldingsEventMessageChecks holdingsMessageChecks
     = new HoldingsEventMessageChecks(kafkaConsumer);
+
+  private final ItemEventMessageChecks itemMessageChecks
+    = new ItemEventMessageChecks(kafkaConsumer);
 
   @SneakyThrows
   @Before
@@ -209,7 +212,7 @@ public class ItemEffectiveLocationTest extends TestBaseWithInventoryUtil {
     assertThat(associatedItem.getString(EFFECTIVE_LOCATION_ID_KEY),
       is(effectiveLocation(holdingEndLoc, itemLoc)));
 
-    itemUpdatedMessagePublished(createdItem, associatedItem);
+    itemMessageChecks.updatedMessagePublished(createdItem, associatedItem);
 
     holdingsMessageChecks.updatedMessagePublished(createdHolding,
       holdingsClient.getById(holdingsRecordId).getJson());

--- a/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
@@ -1,6 +1,5 @@
 package org.folio.rest.api;
 
-import static org.folio.rest.support.messages.HoldingsEventMessageChecks.holdingsUpdatedMessagePublished;
 import static org.folio.rest.support.messages.ItemEventMessageChecks.itemUpdatedMessagePublished;
 import static org.folio.utility.ModuleUtility.getClient;
 import static org.folio.utility.ModuleUtility.getVertx;
@@ -25,6 +24,7 @@ import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.http.InterfaceUrls;
+import org.folio.rest.support.messages.HoldingsEventMessageChecks;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
@@ -45,6 +45,9 @@ import lombok.SneakyThrows;
 @RunWith(JUnitParamsRunner.class)
 public class ItemEffectiveLocationTest extends TestBaseWithInventoryUtil {
   private static final UUID instanceId = UUID.randomUUID();
+
+  private final HoldingsEventMessageChecks holdingsMessageChecks
+    = new HoldingsEventMessageChecks(kafkaConsumer);
 
   @SneakyThrows
   @Before
@@ -208,7 +211,7 @@ public class ItemEffectiveLocationTest extends TestBaseWithInventoryUtil {
 
     itemUpdatedMessagePublished(createdItem, associatedItem);
 
-    holdingsUpdatedMessagePublished(createdHolding,
+    holdingsMessageChecks.updatedMessagePublished(createdHolding,
       holdingsClient.getById(holdingsRecordId).getJson());
   }
 

--- a/src/test/java/org/folio/rest/api/IterationJobRunnerTest.java
+++ b/src/test/java/org/folio/rest/api/IterationJobRunnerTest.java
@@ -1,7 +1,6 @@
 package org.folio.rest.api;
 
 import static io.vertx.core.Future.succeededFuture;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.folio.okapi.common.XOkapiHeaders.TENANT;
 import static org.folio.rest.jaxrs.model.IterationJob.JobStatus.CANCELLED;
@@ -19,11 +18,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import io.vertx.core.Context;
 import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
-import lombok.SneakyThrows;
+
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.folio.persist.InstanceRepository;
 import org.folio.persist.IterationJobRepository;
@@ -31,12 +29,15 @@ import org.folio.rest.jaxrs.model.IterationJob;
 import org.folio.rest.jaxrs.model.IterationJobParams;
 import org.folio.rest.persist.PostgresClientFuturized;
 import org.folio.rest.support.fixtures.InstanceIterationFixture;
-import org.folio.rest.support.kafka.FakeKafkaConsumer;
+import org.folio.rest.support.messages.InstanceEventMessageChecks;
 import org.folio.rest.support.sql.TestRowStream;
 import org.folio.services.iteration.IterationJobRunner;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import io.vertx.core.Context;
+import lombok.SneakyThrows;
 
 public class IterationJobRunnerTest extends TestBaseWithInventoryUtil {
 
@@ -51,8 +52,11 @@ public class IterationJobRunnerTest extends TestBaseWithInventoryUtil {
   private InstanceRepository instanceRepository;
   private IterationJobRunner jobRunner;
 
+  private final InstanceEventMessageChecks instanceMessageChecks
+    = new InstanceEventMessageChecks(kafkaConsumer);;
+
   @BeforeClass
-  public static void beforeClass() throws Exception {
+  public static void beforeClass() {
     TestBase.beforeAll();
 
     instanceIteration = new InstanceIterationFixture(getClient());
@@ -94,8 +98,8 @@ public class IterationJobRunnerTest extends TestBaseWithInventoryUtil {
     assertThat(job.getSubmittedDate(), notNullValue());
 
     // Should be a single iteration message for each instance ID generated in the row stream
-    await().atMost(15, SECONDS)
-      .until(FakeKafkaConsumer::getAllPublishedInstanceIdsCount, greaterThanOrEqualTo(numberOfRecords));
+    instanceMessageChecks.countOfAllPublishedInstancesIs(
+      greaterThanOrEqualTo(numberOfRecords));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
+++ b/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
@@ -1,7 +1,6 @@
 package org.folio.rest.api;
 
 import static io.vertx.core.Future.succeededFuture;
-import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.awaitility.Awaitility.await;
 import static org.folio.InventoryKafkaTopic.AUTHORITY;
 import static org.folio.InventoryKafkaTopic.INSTANCE;
@@ -33,6 +32,7 @@ import org.folio.rest.jaxrs.model.ReindexJob;
 import org.folio.rest.persist.PostgresClientFuturized;
 import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.folio.rest.support.messages.AuthorityEventMessageChecks;
+import org.folio.rest.support.messages.InstanceEventMessageChecks;
 import org.folio.rest.support.sql.TestRowStream;
 import org.folio.services.domainevent.CommonDomainEventPublisher;
 import org.folio.services.reindex.ReindexJobRunner;
@@ -52,6 +52,8 @@ public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
 
   private final AuthorityEventMessageChecks authorityMessageChecks
     = new AuthorityEventMessageChecks(kafkaConsumer);
+  private final InstanceEventMessageChecks instanceMessageChecks
+    = new InstanceEventMessageChecks(kafkaConsumer);
 
   @Test
   public void canReindexInstances() {
@@ -83,8 +85,8 @@ public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
     // Should be a single reindex message for each instance ID generated in the row stream
     // The numbers should match exactly, but intermittently, the published id count is
     // greater than the number of records-no one has been able to figure out why.
-    await().atMost(10, SECONDS)
-      .until(FakeKafkaConsumer::getAllPublishedInstanceIdsCount, greaterThanOrEqualTo(numberOfRecords));
+    instanceMessageChecks.countOfAllPublishedInstancesIs(
+      greaterThanOrEqualTo(numberOfRecords));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
+++ b/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
@@ -30,7 +30,6 @@ import org.folio.rest.jaxrs.model.Authority;
 import org.folio.rest.jaxrs.model.Instance;
 import org.folio.rest.jaxrs.model.ReindexJob;
 import org.folio.rest.persist.PostgresClientFuturized;
-import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.folio.rest.support.messages.AuthorityEventMessageChecks;
 import org.folio.rest.support.messages.InstanceEventMessageChecks;
 import org.folio.rest.support.sql.TestRowStream;
@@ -69,7 +68,7 @@ public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
       .toCompletableFuture());
 
     // Make sure no events are left over from test preparation
-    FakeKafkaConsumer.discardAllMessages();
+    kafkaConsumer.discardAllMessages();
 
     jobRunner(postgresClientFuturized).startReindex(reindexJob, ReindexResourceName.INSTANCE);
 
@@ -103,7 +102,7 @@ public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
       .toCompletableFuture());
 
     // Make sure no events are left over from test preparation
-    FakeKafkaConsumer.discardAllMessages();
+    kafkaConsumer.discardAllMessages();
 
     jobRunner(postgresClientFuturized).startReindex(reindexJob, ReindexResourceName.AUTHORITY);
 

--- a/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
+++ b/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
@@ -21,10 +21,10 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
-import io.vertx.core.Context;
 import java.util.Date;
 import java.util.Map;
 import java.util.UUID;
+
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.folio.persist.ReindexJobRepository;
 import org.folio.rest.jaxrs.model.Authority;
@@ -37,6 +37,8 @@ import org.folio.services.domainevent.CommonDomainEventPublisher;
 import org.folio.services.reindex.ReindexJobRunner;
 import org.folio.services.reindex.ReindexResourceName;
 import org.junit.Test;
+
+import io.vertx.core.Context;
 
 public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
   private final ReindexJobRepository repository = getRepository();
@@ -61,7 +63,7 @@ public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
       .toCompletableFuture());
 
     // Make sure no events are left over from test preparation
-    FakeKafkaConsumer.clearAllEvents();
+    FakeKafkaConsumer.discardAllMessages();
 
     jobRunner(postgresClientFuturized).startReindex(reindexJob, ReindexResourceName.INSTANCE);
 
@@ -95,7 +97,7 @@ public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
       .toCompletableFuture());
 
     // Make sure no events are left over from test preparation
-    FakeKafkaConsumer.clearAllEvents();
+    FakeKafkaConsumer.discardAllMessages();
 
     jobRunner(postgresClientFuturized).startReindex(reindexJob, ReindexResourceName.AUTHORITY);
 

--- a/src/test/java/org/folio/rest/api/SampleDataTest.java
+++ b/src/test/java/org/folio/rest/api/SampleDataTest.java
@@ -17,18 +17,20 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import java.net.URL;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
-import junit.framework.AssertionFailedError;
-import lombok.SneakyThrows;
+
 import org.folio.rest.support.Response;
 import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import junit.framework.AssertionFailedError;
+import lombok.SneakyThrows;
 
 public class SampleDataTest extends TestBase {
 
@@ -44,7 +46,7 @@ public class SampleDataTest extends TestBase {
 
     removeTenant(TENANT_ID);
     prepareTenant(TENANT_ID, null, "mod-inventory-storage-1.0.0", true);
-    FakeKafkaConsumer.clearAllEvents();
+    FakeKafkaConsumer.discardAllMessages();
   }
 
   private void assertCount(URL url, String arrayName, int expectedCount) {

--- a/src/test/java/org/folio/rest/api/SampleDataTest.java
+++ b/src/test/java/org/folio/rest/api/SampleDataTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 
 import org.folio.rest.support.Response;
-import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
@@ -46,7 +45,8 @@ public class SampleDataTest extends TestBase {
 
     removeTenant(TENANT_ID);
     prepareTenant(TENANT_ID, null, "mod-inventory-storage-1.0.0", true);
-    FakeKafkaConsumer.discardAllMessages();
+
+    kafkaConsumer.discardAllMessages();
   }
 
   private void assertCount(URL url, String arrayName, int expectedCount) {

--- a/src/test/java/org/folio/rest/api/TestBase.java
+++ b/src/test/java/org/folio/rest/api/TestBase.java
@@ -17,8 +17,6 @@ import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import io.vertx.core.Future;
-import io.vertx.core.json.JsonObject;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.UUID;
@@ -26,7 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import lombok.SneakyThrows;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.support.Response;
@@ -40,6 +38,10 @@ import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import lombok.SneakyThrows;
 
 /**
  * When not run from StorageTestSuite then this class invokes StorageTestSuite.before() and
@@ -114,8 +116,6 @@ public abstract class TestBase {
   @SneakyThrows
   @Before
   public void removeAllEvents() {
-    kafkaConsumer.resetTimestamp();
-
     FakeKafkaConsumer.clearAllEvents();
   }
 

--- a/src/test/java/org/folio/rest/api/TestBase.java
+++ b/src/test/java/org/folio/rest/api/TestBase.java
@@ -71,7 +71,7 @@ public abstract class TestBase {
   static ResourceClient inventoryViewClient;
   static ResourceClient statisticalCodeClient;
   static StatisticalCodeFixture statisticalCodeFixture;
-  static FakeKafkaConsumer kafkaConsumer;
+  static final FakeKafkaConsumer kafkaConsumer = new FakeKafkaConsumer();
   static InstanceReindexFixture instanceReindex;
   static AuthorityReindexFixture authorityReindex;
   static AsyncMigrationFixture asyncMigration;
@@ -96,15 +96,16 @@ public abstract class TestBase {
     statisticalCodeClient = ResourceClient.forStatisticalCodes(getClient());
     instancesStorageBatchInstancesClient = ResourceClient
       .forInstancesStorageBatchInstances(getClient());
-    instanceTypesClient = ResourceClient
-      .forInstanceTypes(getClient());
+    instanceTypesClient = ResourceClient.forInstanceTypes(getClient());
     illPoliciesClient = ResourceClient.forIllPolicies(getClient());
     statisticalCodeFixture = new StatisticalCodeFixture(getClient());
-    kafkaConsumer = new FakeKafkaConsumer().consume(getVertx());
     instanceReindex = new InstanceReindexFixture(getClient());
     authorityReindex = new AuthorityReindexFixture(getClient());
     asyncMigration = new AsyncMigrationFixture(getClient());
-    FakeKafkaConsumer.discardAllMessages();
+
+    kafkaConsumer.discardAllMessages();
+    kafkaConsumer.consume(getVertx());
+
     logger.info("finishing @BeforeClass testBaseBeforeClass()");
   }
 
@@ -116,7 +117,7 @@ public abstract class TestBase {
   @SneakyThrows
   @Before
   public void removeAllEvents() {
-    FakeKafkaConsumer.discardAllMessages();
+    kafkaConsumer.discardAllMessages();
   }
 
   /**

--- a/src/test/java/org/folio/rest/api/TestBase.java
+++ b/src/test/java/org/folio/rest/api/TestBase.java
@@ -104,7 +104,7 @@ public abstract class TestBase {
     instanceReindex = new InstanceReindexFixture(getClient());
     authorityReindex = new AuthorityReindexFixture(getClient());
     asyncMigration = new AsyncMigrationFixture(getClient());
-    FakeKafkaConsumer.clearAllEvents();
+    FakeKafkaConsumer.discardAllMessages();
     logger.info("finishing @BeforeClass testBaseBeforeClass()");
   }
 
@@ -116,7 +116,7 @@ public abstract class TestBase {
   @SneakyThrows
   @Before
   public void removeAllEvents() {
-    FakeKafkaConsumer.clearAllEvents();
+    FakeKafkaConsumer.discardAllMessages();
   }
 
   /**

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -24,7 +24,6 @@ import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.builders.ItemRequestBuilder;
 import org.folio.rest.support.client.LoanTypesClient;
 import org.folio.rest.support.client.MaterialTypesClient;
-import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.folio.utility.LocationUtility;
 import org.junit.BeforeClass;
 
@@ -90,7 +89,8 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     setupMaterialTypes();
     setupLoanTypes();
     setupLocations();
-    FakeKafkaConsumer.discardAllMessages();
+
+    kafkaConsumer.discardAllMessages();
 
     logger.info("finishing @BeforeClass testBaseWithInvUtilBeforeClass()");
   }

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -9,13 +9,11 @@ import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.UnaryOperator;
-import lombok.SneakyThrows;
+
 import org.folio.HttpStatus;
 import org.folio.rest.jaxrs.model.InstanceType;
 import org.folio.rest.jaxrs.model.Item;
@@ -29,6 +27,10 @@ import org.folio.rest.support.client.MaterialTypesClient;
 import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.folio.utility.LocationUtility;
 import org.junit.BeforeClass;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import lombok.SneakyThrows;
 
 /**
  *
@@ -88,7 +90,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     setupMaterialTypes();
     setupLoanTypes();
     setupLocations();
-    FakeKafkaConsumer.clearAllEvents();
+    FakeKafkaConsumer.discardAllMessages();
 
     logger.info("finishing @BeforeClass testBaseWithInvUtilBeforeClass()");
   }

--- a/src/test/java/org/folio/rest/support/kafka/AggregateMessageCollector.java
+++ b/src/test/java/org/folio/rest/support/kafka/AggregateMessageCollector.java
@@ -1,0 +1,26 @@
+package org.folio.rest.support.kafka;
+
+import java.util.List;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import lombok.NonNull;
+
+public class AggregateMessageCollector implements MessageCollector {
+  @NonNull
+  private final List<MessageCollector> messageCollectors;
+
+  public AggregateMessageCollector(MessageCollector... messageCollectors) {
+    this(List.of(messageCollectors));
+  }
+
+  public AggregateMessageCollector(@NonNull List<MessageCollector> messageCollectors) {
+    this.messageCollectors = messageCollectors;
+  }
+
+  @Override
+  public void acceptMessage(KafkaConsumerRecord<String, JsonObject> message) {
+    messageCollectors.forEach(
+      messageCollector -> messageCollector.acceptMessage(message));
+  }
+}

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -92,7 +92,7 @@ public final class FakeKafkaConsumer {
     return itemTopicConsumer.receivedMessagesByKey(instanceAndIdKey(instanceId, itemId));
   }
 
-  public static Collection<EventMessage> getMessagesForBoundWith(String instanceId) {
+  public Collection<EventMessage> getMessagesForBoundWith(String instanceId) {
     return boundWithTopicConsumer.receivedMessagesByKey(instanceId);
   }
 

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -1,25 +1,14 @@
 package org.folio.rest.support.kafka;
 
-import static java.util.Collections.emptyList;
-
-import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.apache.kafka.common.serialization.StringDeserializer;
-import org.folio.kafka.services.KafkaEnvironmentProperties;
 import org.folio.rest.support.messages.EventMessage;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
-import io.vertx.kafka.client.consumer.KafkaConsumer;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
-import io.vertx.kafka.client.serialization.JsonObjectDeserializer;
 
 public final class FakeKafkaConsumer {
   // These definitions are deliberately separate to the production definitions
@@ -73,7 +62,7 @@ public final class FakeKafkaConsumer {
   }
 
   public static Collection<EventMessage> getMessagesForAuthority(String authorityId) {
-    return authorityTopicConsumer.receivedMessages(authorityId);
+    return authorityTopicConsumer.receivedMessagesByKey(authorityId);
   }
 
   public static int getAllPublishedInstanceIdsCount() {
@@ -81,7 +70,7 @@ public final class FakeKafkaConsumer {
   }
 
   public static Collection<EventMessage> getMessagesForInstance(String instanceId) {
-    return instanceTopicConsumer.receivedMessages(instanceId);
+    return instanceTopicConsumer.receivedMessagesByKey(instanceId);
   }
 
   public static Collection<EventMessage> getMessagesForInstances(List<String> instanceIds) {
@@ -94,17 +83,17 @@ public final class FakeKafkaConsumer {
   public static Collection<EventMessage> getMessagesForHoldings(
     String instanceId, String holdingsId) {
 
-    return holdingsTopicConsumer.receivedMessages(instanceAndIdKey(instanceId, holdingsId));
+    return holdingsTopicConsumer.receivedMessagesByKey(instanceAndIdKey(instanceId, holdingsId));
   }
 
   public static Collection<EventMessage> getMessagesForItem(
     String instanceId, String itemId) {
 
-    return itemTopicConsumer.receivedMessages(instanceAndIdKey(instanceId, itemId));
+    return itemTopicConsumer.receivedMessagesByKey(instanceAndIdKey(instanceId, itemId));
   }
 
   public static Collection<EventMessage> getMessagesForBoundWith(String instanceId) {
-    return boundWithTopicConsumer.receivedMessages(instanceId);
+    return boundWithTopicConsumer.receivedMessagesByKey(instanceId);
   }
 
   private static String instanceAndIdKey(String instanceId, String itemId) {
@@ -119,64 +108,5 @@ public final class FakeKafkaConsumer {
     final var id = oldOrNew != null ? oldOrNew.getString("id") : null;
 
     return instanceAndIdKey(message.key(), id);
-  }
-
-  public static class MessageCollectingTopicConsumer {
-    private final String topicName;
-    private final Map<String, List<EventMessage>> collectedMessages;
-    private final Function<KafkaConsumerRecord<String, JsonObject>, String> keyMap;
-    private KafkaConsumer<String, JsonObject> consumer;
-
-    public MessageCollectingTopicConsumer(String topicName,
-      Function<KafkaConsumerRecord<String, JsonObject>, String> keyMap) {
-
-      this.topicName = topicName;
-      this.collectedMessages = new ConcurrentHashMap<>();
-      this.keyMap = keyMap;
-    }
-
-    private void subscribe(Vertx vertx) {
-      consumer = KafkaConsumer.create(vertx, consumerProperties());
-
-      consumer.handler(this::acceptMessage);
-      consumer.subscribe(topicName);
-    }
-
-    public void unsubscribe() {
-      if (consumer != null) {
-        consumer.unsubscribe();
-      }
-    }
-
-    private void acceptMessage(KafkaConsumerRecord<String, JsonObject> message) {
-      final var collectedMessages = this.collectedMessages.computeIfAbsent(
-        this.keyMap.apply(message), v -> new ArrayList<>());
-
-      collectedMessages.add(EventMessage.fromConsumerRecord(message));
-    }
-
-    private Collection<EventMessage> receivedMessages(String key) {
-      return collectedMessages.getOrDefault(key, emptyList());
-    }
-
-    private int countOfReceivedKeys() {
-      return collectedMessages.size();
-    }
-
-    private void discardCollectedMessages() {
-      collectedMessages.clear();
-    }
-
-    private static Map<String, String> consumerProperties() {
-      Map<String, String> config = new HashMap<>();
-      config.put("bootstrap.servers", KafkaEnvironmentProperties.host() + ":" + KafkaEnvironmentProperties.port());
-      config.put("key.deserializer", StringDeserializer.class.getName());
-      config.put("value.deserializer", JsonObjectDeserializer.class.getName());
-      config.put("group.id", "folio_test");
-      config.put("auto.offset.reset", "earliest");
-      config.put("enable.auto.commit", "false");
-
-      return config;
-    }
   }
 }

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -87,12 +87,12 @@ public final class FakeKafkaConsumer {
     consumer.unsubscribe();
   }
 
-  public static void clearAllEvents() {
-    itemEvents.clear();
-    instanceEvents.clear();
-    holdingsEvents.clear();
-    authorityEvents.clear();
-    boundWithEvents.clear();
+  public static void discardAllMessages() {
+    itemTopicConsumer.discardCollectedMessages();
+    instanceTopicConsumer.discardCollectedMessages();
+    holdingsTopicConsumer.discardCollectedMessages();
+    authorityTopicConsumer.discardCollectedMessages();
+    boundWithTopicConsumer.discardCollectedMessages();
   }
 
   public static int getAllPublishedAuthoritiesCount() {
@@ -184,6 +184,10 @@ public final class FakeKafkaConsumer {
 
     private Collection<EventMessage> getMessagesByKey(String key) {
       return collectedMessages.getOrDefault(key, emptyList());
+    }
+
+    private void discardCollectedMessages() {
+      collectedMessages.clear();
     }
   }
 }

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -20,16 +20,21 @@ public final class FakeKafkaConsumer {
   final static String AUTHORITY_TOPIC_NAME = "folio.test_tenant.inventory.authority";
   final static String BOUND_WITH_TOPIC_NAME = "folio.test_tenant.inventory.bound-with";
 
-  private final VertxMessageCollectingTopicConsumer instanceTopicConsumer = new VertxMessageCollectingTopicConsumer(
-    INSTANCE_TOPIC_NAME, KafkaConsumerRecord::key);
-  private final VertxMessageCollectingTopicConsumer holdingsTopicConsumer = new VertxMessageCollectingTopicConsumer(
-    HOLDINGS_TOPIC_NAME, FakeKafkaConsumer::instanceAndIdKey);
-  private final VertxMessageCollectingTopicConsumer itemTopicConsumer = new VertxMessageCollectingTopicConsumer(
-    ITEM_TOPIC_NAME, FakeKafkaConsumer::instanceAndIdKey);
-  private final VertxMessageCollectingTopicConsumer authorityTopicConsumer = new VertxMessageCollectingTopicConsumer(
-    AUTHORITY_TOPIC_NAME, KafkaConsumerRecord::key);
-  private final VertxMessageCollectingTopicConsumer boundWithTopicConsumer = new VertxMessageCollectingTopicConsumer(
-    BOUND_WITH_TOPIC_NAME, KafkaConsumerRecord::key);
+  private final VertxMessageCollectingTopicConsumer instanceTopicConsumer
+    = new VertxMessageCollectingTopicConsumer(INSTANCE_TOPIC_NAME,
+      new GroupedMessageCollector(KafkaConsumerRecord::key));
+  private final VertxMessageCollectingTopicConsumer holdingsTopicConsumer
+    = new VertxMessageCollectingTopicConsumer(HOLDINGS_TOPIC_NAME,
+      new GroupedMessageCollector(FakeKafkaConsumer::instanceAndIdKey));
+  private final VertxMessageCollectingTopicConsumer itemTopicConsumer
+    = new VertxMessageCollectingTopicConsumer(ITEM_TOPIC_NAME,
+      new GroupedMessageCollector(FakeKafkaConsumer::instanceAndIdKey));
+  private final VertxMessageCollectingTopicConsumer authorityTopicConsumer
+    = new VertxMessageCollectingTopicConsumer(AUTHORITY_TOPIC_NAME,
+      new GroupedMessageCollector(KafkaConsumerRecord::key));
+  private final VertxMessageCollectingTopicConsumer boundWithTopicConsumer
+    = new VertxMessageCollectingTopicConsumer(BOUND_WITH_TOPIC_NAME,
+      new GroupedMessageCollector(KafkaConsumerRecord::key));
 
   public void consume(Vertx vertx) {
     instanceTopicConsumer.subscribe(vertx);

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -23,8 +23,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.serialization.JsonObjectDeserializer;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
 
 public final class FakeKafkaConsumer {
   // These definitions are deliberately separate to the production definitions
@@ -36,21 +34,16 @@ public final class FakeKafkaConsumer {
   final static String AUTHORITY_TOPIC_NAME = "folio.test_tenant.inventory.authority";
   final static String BOUND_WITH_TOPIC_NAME = "folio.test_tenant.inventory.bound-with";
 
-  private final static Map<String, List<EventMessage>> instanceEvents = new ConcurrentHashMap<>();
-  private final static TopicConsumer instanceTopicConsumer = new TopicConsumer(INSTANCE_TOPIC_NAME,
-    instanceEvents, KafkaConsumerRecord::key);
-  private final static Map<String, List<EventMessage>> holdingsEvents = new ConcurrentHashMap<>();
-  private final static TopicConsumer holdingsTopicConsumer = new TopicConsumer(HOLDINGS_TOPIC_NAME,
-    holdingsEvents, FakeKafkaConsumer::instanceAndIdKey);
-  private final static Map<String, List<EventMessage>> itemEvents = new ConcurrentHashMap<>();
-  private final static TopicConsumer itemTopicConsumer = new TopicConsumer(ITEM_TOPIC_NAME,
-    itemEvents, FakeKafkaConsumer::instanceAndIdKey);
-  private final static Map<String, List<EventMessage>> authorityEvents = new ConcurrentHashMap<>();
-  private final static TopicConsumer authorityTopicConsumer = new TopicConsumer(AUTHORITY_TOPIC_NAME,
-    authorityEvents, KafkaConsumerRecord::key);
-  private final static Map<String, List<EventMessage>> boundWithEvents = new ConcurrentHashMap<>();
-  private final static TopicConsumer boundWithTopicConsumer = new TopicConsumer(BOUND_WITH_TOPIC_NAME,
-    boundWithEvents, KafkaConsumerRecord::key);
+  private final static TopicConsumer instanceTopicConsumer = new TopicConsumer(
+    INSTANCE_TOPIC_NAME, KafkaConsumerRecord::key);
+  private final static TopicConsumer holdingsTopicConsumer = new TopicConsumer(
+    HOLDINGS_TOPIC_NAME, FakeKafkaConsumer::instanceAndIdKey);
+  private final static TopicConsumer itemTopicConsumer = new TopicConsumer(
+    ITEM_TOPIC_NAME, FakeKafkaConsumer::instanceAndIdKey);
+  private final static TopicConsumer authorityTopicConsumer = new TopicConsumer(
+    AUTHORITY_TOPIC_NAME, KafkaConsumerRecord::key);
+  private final static TopicConsumer boundWithTopicConsumer = new TopicConsumer(
+    BOUND_WITH_TOPIC_NAME, KafkaConsumerRecord::key);
 
   // Provide a strong reference to reduce the chances of deallocation before
   // all clients are properly unsubscribed.
@@ -164,12 +157,18 @@ public final class FakeKafkaConsumer {
     return config;
   }
 
-  @AllArgsConstructor
   public static class TopicConsumer {
-    @Getter
     private final String topicName;
     private final Map<String, List<EventMessage>> collectedMessages;
     private final Function<KafkaConsumerRecord<String, JsonObject>, String> keyMap;
+
+    public TopicConsumer(String topicName,
+      Function<KafkaConsumerRecord<String, JsonObject>, String> keyMap) {
+
+      this.topicName = topicName;
+      this.collectedMessages = new ConcurrentHashMap<>();
+      this.keyMap = keyMap;
+    }
 
     private void acceptMessage(KafkaConsumerRecord<String, JsonObject> message) {
       final var collectedMessages = this.collectedMessages.computeIfAbsent(
@@ -192,6 +191,10 @@ public final class FakeKafkaConsumer {
 
     private void discardCollectedMessages() {
       collectedMessages.clear();
+    }
+
+    private String getTopicName() {
+      return topicName;
     }
   }
 }

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -28,24 +28,29 @@ public final class FakeKafkaConsumer {
 
   private final VertxMessageCollectingTopicConsumer instanceTopicConsumer
     = new VertxMessageCollectingTopicConsumer(INSTANCE_TOPIC_NAME,
-      new GroupedMessageCollector(KafkaConsumerRecord::key,
-        collectedInstanceMessages));
+      new TopicFilterIngMessageCollector(INSTANCE_TOPIC_NAME,
+        new GroupedMessageCollector(KafkaConsumerRecord::key,
+          collectedInstanceMessages)));
   private final VertxMessageCollectingTopicConsumer holdingsTopicConsumer
     = new VertxMessageCollectingTopicConsumer(HOLDINGS_TOPIC_NAME,
-      new GroupedMessageCollector(FakeKafkaConsumer::instanceAndIdKey,
-        collectedHoldingsMessages));
+      new TopicFilterIngMessageCollector(HOLDINGS_TOPIC_NAME,
+        new GroupedMessageCollector(FakeKafkaConsumer::instanceAndIdKey,
+          collectedHoldingsMessages)));
   private final VertxMessageCollectingTopicConsumer itemTopicConsumer
     = new VertxMessageCollectingTopicConsumer(ITEM_TOPIC_NAME,
-      new GroupedMessageCollector(FakeKafkaConsumer::instanceAndIdKey,
-        collectedItemMessages));
+      new TopicFilterIngMessageCollector(ITEM_TOPIC_NAME,
+        new GroupedMessageCollector(FakeKafkaConsumer::instanceAndIdKey,
+        collectedItemMessages)));
   private final VertxMessageCollectingTopicConsumer authorityTopicConsumer
     = new VertxMessageCollectingTopicConsumer(AUTHORITY_TOPIC_NAME,
-      new GroupedMessageCollector(KafkaConsumerRecord::key,
-        collectedAuthorityMessages));
+     new TopicFilterIngMessageCollector(AUTHORITY_TOPIC_NAME,
+       new GroupedMessageCollector(KafkaConsumerRecord::key,
+         collectedAuthorityMessages)));
   private final VertxMessageCollectingTopicConsumer boundWithTopicConsumer
     = new VertxMessageCollectingTopicConsumer(BOUND_WITH_TOPIC_NAME,
-      new GroupedMessageCollector(KafkaConsumerRecord::key,
-        collectedBoundWithMessages));
+      new TopicFilterIngMessageCollector(BOUND_WITH_TOPIC_NAME,
+        new GroupedMessageCollector(KafkaConsumerRecord::key,
+          collectedBoundWithMessages)));
 
   public void consume(Vertx vertx) {
     instanceTopicConsumer.subscribe(vertx);

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -2,6 +2,7 @@ package org.folio.rest.support.kafka;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.folio.rest.support.messages.EventMessage;
@@ -27,27 +28,27 @@ public final class FakeKafkaConsumer {
   private final GroupedCollectedMessages collectedBoundWithMessages = new GroupedCollectedMessages();
 
   private final VertxMessageCollectingTopicConsumer instanceTopicConsumer
-    = new VertxMessageCollectingTopicConsumer(INSTANCE_TOPIC_NAME,
+    = new VertxMessageCollectingTopicConsumer(Set.of(INSTANCE_TOPIC_NAME),
       new TopicFilterIngMessageCollector(INSTANCE_TOPIC_NAME,
         new GroupedMessageCollector(KafkaConsumerRecord::key,
           collectedInstanceMessages)));
   private final VertxMessageCollectingTopicConsumer holdingsTopicConsumer
-    = new VertxMessageCollectingTopicConsumer(HOLDINGS_TOPIC_NAME,
+    = new VertxMessageCollectingTopicConsumer(Set.of(HOLDINGS_TOPIC_NAME),
       new TopicFilterIngMessageCollector(HOLDINGS_TOPIC_NAME,
         new GroupedMessageCollector(FakeKafkaConsumer::instanceAndIdKey,
           collectedHoldingsMessages)));
   private final VertxMessageCollectingTopicConsumer itemTopicConsumer
-    = new VertxMessageCollectingTopicConsumer(ITEM_TOPIC_NAME,
+    = new VertxMessageCollectingTopicConsumer(Set.of(ITEM_TOPIC_NAME),
       new TopicFilterIngMessageCollector(ITEM_TOPIC_NAME,
         new GroupedMessageCollector(FakeKafkaConsumer::instanceAndIdKey,
-        collectedItemMessages)));
+          collectedItemMessages)));
   private final VertxMessageCollectingTopicConsumer authorityTopicConsumer
-    = new VertxMessageCollectingTopicConsumer(AUTHORITY_TOPIC_NAME,
-     new TopicFilterIngMessageCollector(AUTHORITY_TOPIC_NAME,
-       new GroupedMessageCollector(KafkaConsumerRecord::key,
-         collectedAuthorityMessages)));
+    = new VertxMessageCollectingTopicConsumer(Set.of(AUTHORITY_TOPIC_NAME),
+      new TopicFilterIngMessageCollector(AUTHORITY_TOPIC_NAME,
+        new GroupedMessageCollector(KafkaConsumerRecord::key,
+          collectedAuthorityMessages)));
   private final VertxMessageCollectingTopicConsumer boundWithTopicConsumer
-    = new VertxMessageCollectingTopicConsumer(BOUND_WITH_TOPIC_NAME,
+    = new VertxMessageCollectingTopicConsumer(Set.of(BOUND_WITH_TOPIC_NAME),
       new TopicFilterIngMessageCollector(BOUND_WITH_TOPIC_NAME,
         new GroupedMessageCollector(KafkaConsumerRecord::key,
           collectedBoundWithMessages)));

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -20,15 +20,15 @@ public final class FakeKafkaConsumer {
   final static String AUTHORITY_TOPIC_NAME = "folio.test_tenant.inventory.authority";
   final static String BOUND_WITH_TOPIC_NAME = "folio.test_tenant.inventory.bound-with";
 
-  private final MessageCollectingTopicConsumer instanceTopicConsumer = new MessageCollectingTopicConsumer(
+  private final VertxMessageCollectingTopicConsumer instanceTopicConsumer = new VertxMessageCollectingTopicConsumer(
     INSTANCE_TOPIC_NAME, KafkaConsumerRecord::key);
-  private final MessageCollectingTopicConsumer holdingsTopicConsumer = new MessageCollectingTopicConsumer(
+  private final VertxMessageCollectingTopicConsumer holdingsTopicConsumer = new VertxMessageCollectingTopicConsumer(
     HOLDINGS_TOPIC_NAME, FakeKafkaConsumer::instanceAndIdKey);
-  private final MessageCollectingTopicConsumer itemTopicConsumer = new MessageCollectingTopicConsumer(
+  private final VertxMessageCollectingTopicConsumer itemTopicConsumer = new VertxMessageCollectingTopicConsumer(
     ITEM_TOPIC_NAME, FakeKafkaConsumer::instanceAndIdKey);
-  private final MessageCollectingTopicConsumer authorityTopicConsumer = new MessageCollectingTopicConsumer(
+  private final VertxMessageCollectingTopicConsumer authorityTopicConsumer = new VertxMessageCollectingTopicConsumer(
     AUTHORITY_TOPIC_NAME, KafkaConsumerRecord::key);
-  private final MessageCollectingTopicConsumer boundWithTopicConsumer = new MessageCollectingTopicConsumer(
+  private final VertxMessageCollectingTopicConsumer boundWithTopicConsumer = new VertxMessageCollectingTopicConsumer(
     BOUND_WITH_TOPIC_NAME, KafkaConsumerRecord::key);
 
   public void consume(Vertx vertx) {

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -57,11 +57,11 @@ public final class FakeKafkaConsumer {
     boundWithTopicConsumer.discardCollectedMessages();
   }
 
-  public static int getAllPublishedAuthoritiesCount() {
+  public int getAllPublishedAuthoritiesCount() {
     return authorityTopicConsumer.countOfReceivedKeys();
   }
 
-  public static Collection<EventMessage> getMessagesForAuthority(String authorityId) {
+  public Collection<EventMessage> getMessagesForAuthority(String authorityId) {
     return authorityTopicConsumer.receivedMessagesByKey(authorityId);
   }
 

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -84,9 +84,7 @@ public final class FakeKafkaConsumer {
     return holdingsTopicConsumer.receivedMessagesByKey(instanceAndIdKey(instanceId, holdingsId));
   }
 
-  public static Collection<EventMessage> getMessagesForItem(
-    String instanceId, String itemId) {
-
+  public Collection<EventMessage> getMessagesForItem(String instanceId, String itemId) {
     return itemTopicConsumer.receivedMessagesByKey(instanceAndIdKey(instanceId, itemId));
   }
 

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -65,17 +65,17 @@ public final class FakeKafkaConsumer {
     return authorityTopicConsumer.receivedMessagesByKey(authorityId);
   }
 
-  public static int getAllPublishedInstanceIdsCount() {
+  public int getAllPublishedInstanceIdsCount() {
     return instanceTopicConsumer.countOfReceivedKeys();
   }
 
-  public static Collection<EventMessage> getMessagesForInstance(String instanceId) {
+  public Collection<EventMessage> getMessagesForInstance(String instanceId) {
     return instanceTopicConsumer.receivedMessagesByKey(instanceId);
   }
 
-  public static Collection<EventMessage> getMessagesForInstances(List<String> instanceIds) {
+  public Collection<EventMessage> getMessagesForInstances(List<String> instanceIds) {
     return instanceIds.stream()
-      .map(FakeKafkaConsumer::getMessagesForInstance)
+      .map(this::getMessagesForInstance)
       .flatMap(Collection::stream)
       .collect(Collectors.toList());
   }

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -20,25 +20,23 @@ public final class FakeKafkaConsumer {
   final static String AUTHORITY_TOPIC_NAME = "folio.test_tenant.inventory.authority";
   final static String BOUND_WITH_TOPIC_NAME = "folio.test_tenant.inventory.bound-with";
 
-  private final static MessageCollectingTopicConsumer instanceTopicConsumer = new MessageCollectingTopicConsumer(
+  private final MessageCollectingTopicConsumer instanceTopicConsumer = new MessageCollectingTopicConsumer(
     INSTANCE_TOPIC_NAME, KafkaConsumerRecord::key);
-  private final static MessageCollectingTopicConsumer holdingsTopicConsumer = new MessageCollectingTopicConsumer(
+  private final MessageCollectingTopicConsumer holdingsTopicConsumer = new MessageCollectingTopicConsumer(
     HOLDINGS_TOPIC_NAME, FakeKafkaConsumer::instanceAndIdKey);
-  private final static MessageCollectingTopicConsumer itemTopicConsumer = new MessageCollectingTopicConsumer(
+  private final MessageCollectingTopicConsumer itemTopicConsumer = new MessageCollectingTopicConsumer(
     ITEM_TOPIC_NAME, FakeKafkaConsumer::instanceAndIdKey);
-  private final static MessageCollectingTopicConsumer authorityTopicConsumer = new MessageCollectingTopicConsumer(
+  private final MessageCollectingTopicConsumer authorityTopicConsumer = new MessageCollectingTopicConsumer(
     AUTHORITY_TOPIC_NAME, KafkaConsumerRecord::key);
-  private final static MessageCollectingTopicConsumer boundWithTopicConsumer = new MessageCollectingTopicConsumer(
+  private final MessageCollectingTopicConsumer boundWithTopicConsumer = new MessageCollectingTopicConsumer(
     BOUND_WITH_TOPIC_NAME, KafkaConsumerRecord::key);
 
-  public FakeKafkaConsumer consume(Vertx vertx) {
+  public void consume(Vertx vertx) {
     instanceTopicConsumer.subscribe(vertx);
     holdingsTopicConsumer.subscribe(vertx);
     itemTopicConsumer.subscribe(vertx);
     authorityTopicConsumer.subscribe(vertx);
     boundWithTopicConsumer.subscribe(vertx);
-
-    return this;
   }
 
   public void unsubscribe() {
@@ -49,7 +47,7 @@ public final class FakeKafkaConsumer {
     boundWithTopicConsumer.unsubscribe();
   }
 
-  public static void discardAllMessages() {
+  public void discardAllMessages() {
     itemTopicConsumer.discardCollectedMessages();
     instanceTopicConsumer.discardCollectedMessages();
     holdingsTopicConsumer.discardCollectedMessages();

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -100,7 +100,7 @@ public final class FakeKafkaConsumer {
   }
 
   public static Collection<EventMessage> getMessagesForAuthority(String authorityId) {
-    return getEmptyDefault(authorityEvents, authorityId);
+    return authorityTopicConsumer.getMessagesByKey(authorityId);
   }
 
   public static int getAllPublishedInstanceIdsCount() {
@@ -108,7 +108,7 @@ public final class FakeKafkaConsumer {
   }
 
   public static Collection<EventMessage> getMessagesForInstance(String instanceId) {
-    return getEmptyDefault(instanceEvents, instanceId);
+    return instanceTopicConsumer.getMessagesByKey(instanceId);
   }
 
   public static Collection<EventMessage> getMessagesForInstances(List<String> instanceIds) {
@@ -121,21 +121,17 @@ public final class FakeKafkaConsumer {
   public static Collection<EventMessage> getMessagesForHoldings(
     String instanceId, String holdingsId) {
 
-    return getEmptyDefault(holdingsEvents, instanceAndIdKey(instanceId, holdingsId));
+    return holdingsTopicConsumer.getMessagesByKey(instanceAndIdKey(instanceId, holdingsId));
   }
 
   public static Collection<EventMessage> getMessagesForItem(
     String instanceId, String itemId) {
 
-    return getEmptyDefault(itemEvents, instanceAndIdKey(instanceId, itemId));
+    return itemTopicConsumer.getMessagesByKey(instanceAndIdKey(instanceId, itemId));
   }
 
   public static Collection<EventMessage> getMessagesForBoundWith(String instanceId) {
-    return getEmptyDefault(boundWithEvents, instanceId);
-  }
-
-  private static <T> List<T> getEmptyDefault(Map<String, List<T>> map, String key) {
-    return map.getOrDefault(key, emptyList());
+    return boundWithTopicConsumer.getMessagesByKey(instanceId);
   }
 
   private static String instanceAndIdKey(String instanceId, String itemId) {
@@ -184,6 +180,10 @@ public final class FakeKafkaConsumer {
 
     private boolean accepts(KafkaConsumerRecord<String, JsonObject> message) {
       return Objects.equals(message.topic(), topicName);
+    }
+
+    private Collection<EventMessage> getMessagesByKey(String key) {
+      return collectedMessages.getOrDefault(key, emptyList());
     }
   }
 }

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -80,9 +80,7 @@ public final class FakeKafkaConsumer {
       .collect(Collectors.toList());
   }
 
-  public static Collection<EventMessage> getMessagesForHoldings(
-    String instanceId, String holdingsId) {
-
+  public Collection<EventMessage> getMessagesForHoldings(String instanceId, String holdingsId) {
     return holdingsTopicConsumer.receivedMessagesByKey(instanceAndIdKey(instanceId, holdingsId));
   }
 

--- a/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -96,19 +96,19 @@ public final class FakeKafkaConsumer {
   }
 
   public static int getAllPublishedAuthoritiesCount() {
-    return authorityEvents.size();
+    return authorityTopicConsumer.countOfReceivedKeys();
   }
 
   public static Collection<EventMessage> getMessagesForAuthority(String authorityId) {
-    return authorityTopicConsumer.getMessagesByKey(authorityId);
+    return authorityTopicConsumer.receivedMessages(authorityId);
   }
 
   public static int getAllPublishedInstanceIdsCount() {
-    return instanceEvents.size();
+    return instanceTopicConsumer.countOfReceivedKeys();
   }
 
   public static Collection<EventMessage> getMessagesForInstance(String instanceId) {
-    return instanceTopicConsumer.getMessagesByKey(instanceId);
+    return instanceTopicConsumer.receivedMessages(instanceId);
   }
 
   public static Collection<EventMessage> getMessagesForInstances(List<String> instanceIds) {
@@ -121,17 +121,17 @@ public final class FakeKafkaConsumer {
   public static Collection<EventMessage> getMessagesForHoldings(
     String instanceId, String holdingsId) {
 
-    return holdingsTopicConsumer.getMessagesByKey(instanceAndIdKey(instanceId, holdingsId));
+    return holdingsTopicConsumer.receivedMessages(instanceAndIdKey(instanceId, holdingsId));
   }
 
   public static Collection<EventMessage> getMessagesForItem(
     String instanceId, String itemId) {
 
-    return itemTopicConsumer.getMessagesByKey(instanceAndIdKey(instanceId, itemId));
+    return itemTopicConsumer.receivedMessages(instanceAndIdKey(instanceId, itemId));
   }
 
   public static Collection<EventMessage> getMessagesForBoundWith(String instanceId) {
-    return boundWithTopicConsumer.getMessagesByKey(instanceId);
+    return boundWithTopicConsumer.receivedMessages(instanceId);
   }
 
   private static String instanceAndIdKey(String instanceId, String itemId) {
@@ -182,8 +182,12 @@ public final class FakeKafkaConsumer {
       return Objects.equals(message.topic(), topicName);
     }
 
-    private Collection<EventMessage> getMessagesByKey(String key) {
+    private Collection<EventMessage> receivedMessages(String key) {
       return collectedMessages.getOrDefault(key, emptyList());
+    }
+
+    private int countOfReceivedKeys() {
+      return collectedMessages.size();
     }
 
     private void discardCollectedMessages() {

--- a/src/test/java/org/folio/rest/support/kafka/GroupedCollectedMessages.java
+++ b/src/test/java/org/folio/rest/support/kafka/GroupedCollectedMessages.java
@@ -1,0 +1,37 @@
+package org.folio.rest.support.kafka;
+
+import static java.util.Collections.emptyList;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.folio.rest.support.messages.EventMessage;
+
+public class GroupedCollectedMessages {
+  private final Map<String, List<EventMessage>> collectedMessages;
+
+  public GroupedCollectedMessages() {
+    collectedMessages = new HashMap<>();
+  }
+
+  void add(String key, EventMessage eventMessage) {
+    final var keyBucket = collectedMessages.computeIfAbsent(key,
+      v -> new ArrayList<>());
+
+    keyBucket.add(eventMessage);
+  }
+
+  List<EventMessage> messagesByGroupKey(String key) {
+    return collectedMessages.getOrDefault(key, emptyList());
+  }
+
+  int groupCount() {
+    return collectedMessages.size();
+  }
+
+  void empty() {
+    collectedMessages.clear();
+  }
+}

--- a/src/test/java/org/folio/rest/support/kafka/GroupedMessageCollector.java
+++ b/src/test/java/org/folio/rest/support/kafka/GroupedMessageCollector.java
@@ -1,11 +1,6 @@
 package org.folio.rest.support.kafka;
 
-import static java.util.Collections.emptyList;
-
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.function.Function;
 
 import org.folio.rest.support.messages.EventMessage;
@@ -15,31 +10,30 @@ import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 
 class GroupedMessageCollector {
   private final Function<KafkaConsumerRecord<String, JsonObject>, String> groupKeyMap;
-  private final Map<String, List<EventMessage>> collectedMessages;
+  private final GroupedCollectedMessages groupedCollectedMessages = new GroupedCollectedMessages();
 
   GroupedMessageCollector(
     Function<KafkaConsumerRecord<String, JsonObject>, String> groupKeyMap) {
 
     this.groupKeyMap = groupKeyMap;
-    collectedMessages = new HashMap<>();
   }
 
   void acceptMessage(KafkaConsumerRecord<String, JsonObject> message) {
-    final var keyBucket = collectedMessages.computeIfAbsent(
-      groupKeyMap.apply(message), v -> new ArrayList<>());
+    final var key = groupKeyMap.apply(message);
+    final var eventMessage = EventMessage.fromConsumerRecord(message);
 
-    keyBucket.add(EventMessage.fromConsumerRecord(message));
+    groupedCollectedMessages.add(key, eventMessage);
   }
 
   List<EventMessage> messagesByGroupKey(String key) {
-    return collectedMessages.getOrDefault(key, emptyList());
+    return groupedCollectedMessages.messagesByGroupKey(key);
   }
 
   int groupCount() {
-    return collectedMessages.size();
+    return groupedCollectedMessages.groupCount();
   }
 
   void empty() {
-    collectedMessages.clear();
+    groupedCollectedMessages.empty();
   }
 }

--- a/src/test/java/org/folio/rest/support/kafka/GroupedMessageCollector.java
+++ b/src/test/java/org/folio/rest/support/kafka/GroupedMessageCollector.java
@@ -1,6 +1,5 @@
 package org.folio.rest.support.kafka;
 
-import java.util.List;
 import java.util.function.Function;
 
 import org.folio.rest.support.messages.EventMessage;
@@ -10,30 +9,20 @@ import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 
 class GroupedMessageCollector {
   private final Function<KafkaConsumerRecord<String, JsonObject>, String> groupKeyMap;
-  private final GroupedCollectedMessages groupedCollectedMessages = new GroupedCollectedMessages();
+  private final GroupedCollectedMessages destination;
 
   GroupedMessageCollector(
-    Function<KafkaConsumerRecord<String, JsonObject>, String> groupKeyMap) {
+    Function<KafkaConsumerRecord<String, JsonObject>, String> groupKeyMap,
+    GroupedCollectedMessages destination) {
 
     this.groupKeyMap = groupKeyMap;
+    this.destination = destination;
   }
 
   void acceptMessage(KafkaConsumerRecord<String, JsonObject> message) {
     final var key = groupKeyMap.apply(message);
     final var eventMessage = EventMessage.fromConsumerRecord(message);
 
-    groupedCollectedMessages.add(key, eventMessage);
-  }
-
-  List<EventMessage> messagesByGroupKey(String key) {
-    return groupedCollectedMessages.messagesByGroupKey(key);
-  }
-
-  int groupCount() {
-    return groupedCollectedMessages.groupCount();
-  }
-
-  void empty() {
-    groupedCollectedMessages.empty();
+    destination.add(key, eventMessage);
   }
 }

--- a/src/test/java/org/folio/rest/support/kafka/GroupedMessageCollector.java
+++ b/src/test/java/org/folio/rest/support/kafka/GroupedMessageCollector.java
@@ -7,7 +7,7 @@ import org.folio.rest.support.messages.EventMessage;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 
-class GroupedMessageCollector {
+class GroupedMessageCollector implements MessageCollector {
   private final Function<KafkaConsumerRecord<String, JsonObject>, String> groupKeyMap;
   private final GroupedCollectedMessages destination;
 
@@ -19,7 +19,8 @@ class GroupedMessageCollector {
     this.destination = destination;
   }
 
-  void acceptMessage(KafkaConsumerRecord<String, JsonObject> message) {
+  @Override
+  public void acceptMessage(KafkaConsumerRecord<String, JsonObject> message) {
     final var key = groupKeyMap.apply(message);
     final var eventMessage = EventMessage.fromConsumerRecord(message);
 

--- a/src/test/java/org/folio/rest/support/kafka/GroupedMessageCollector.java
+++ b/src/test/java/org/folio/rest/support/kafka/GroupedMessageCollector.java
@@ -1,0 +1,45 @@
+package org.folio.rest.support.kafka;
+
+import static java.util.Collections.emptyList;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+import org.folio.rest.support.messages.EventMessage;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+
+class GroupedMessageCollector {
+  private final Function<KafkaConsumerRecord<String, JsonObject>, String> groupKeyMap;
+  private final Map<String, List<EventMessage>> collectedMessages;
+
+  GroupedMessageCollector(
+    Function<KafkaConsumerRecord<String, JsonObject>, String> groupKeyMap) {
+
+    this.groupKeyMap = groupKeyMap;
+    collectedMessages = new HashMap<>();
+  }
+
+  void acceptMessage(KafkaConsumerRecord<String, JsonObject> message) {
+    final var keyBucket = collectedMessages.computeIfAbsent(
+      groupKeyMap.apply(message), v -> new ArrayList<>());
+
+    keyBucket.add(EventMessage.fromConsumerRecord(message));
+  }
+
+  List<EventMessage> messagesByGroupKey(String key) {
+    return collectedMessages.getOrDefault(key, emptyList());
+  }
+
+  int groupCount() {
+    return collectedMessages.size();
+  }
+
+  void empty() {
+    collectedMessages.clear();
+  }
+}

--- a/src/test/java/org/folio/rest/support/kafka/MessageCollectingTopicConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/MessageCollectingTopicConsumer.java
@@ -1,0 +1,80 @@
+package org.folio.rest.support.kafka;
+
+import static java.util.Collections.emptyList;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.folio.kafka.services.KafkaEnvironmentProperties;
+import org.folio.rest.support.messages.EventMessage;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumer;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+import io.vertx.kafka.client.serialization.JsonObjectDeserializer;
+
+public class MessageCollectingTopicConsumer {
+  private final String topicName;
+  private final Map<String, List<EventMessage>> collectedMessages;
+  private final Function<KafkaConsumerRecord<String, JsonObject>, String> keyMap;
+  private KafkaConsumer<String, JsonObject> consumer;
+
+  public MessageCollectingTopicConsumer(String topicName,
+    Function<KafkaConsumerRecord<String, JsonObject>, String> keyMap) {
+
+    this.topicName = topicName;
+    this.collectedMessages = new ConcurrentHashMap<>();
+    this.keyMap = keyMap;
+  }
+
+  void subscribe(Vertx vertx) {
+    consumer = KafkaConsumer.create(vertx, consumerProperties());
+
+    consumer.handler(this::acceptMessage);
+    consumer.subscribe(topicName);
+  }
+
+  private void acceptMessage(KafkaConsumerRecord<String, JsonObject> message) {
+    final var collectedMessages = this.collectedMessages.computeIfAbsent(
+      this.keyMap.apply(message), v -> new ArrayList<>());
+
+    collectedMessages.add(EventMessage.fromConsumerRecord(message));
+  }
+  void unsubscribe() {
+    if (consumer != null) {
+      consumer.unsubscribe();
+    }
+  }
+
+  Collection<EventMessage> receivedMessagesByKey(String key) {
+    return collectedMessages.getOrDefault(key, emptyList());
+  }
+
+  int countOfReceivedKeys() {
+    return collectedMessages.size();
+  }
+
+  void discardCollectedMessages() {
+    collectedMessages.clear();
+  }
+
+  private static Map<String, String> consumerProperties() {
+    Map<String, String> config = new HashMap<>();
+    config.put("bootstrap.servers",
+      KafkaEnvironmentProperties.host() + ":" + KafkaEnvironmentProperties.port());
+    config.put("key.deserializer", StringDeserializer.class.getName());
+    config.put("value.deserializer", JsonObjectDeserializer.class.getName());
+    config.put("group.id", "folio_test");
+    config.put("auto.offset.reset", "earliest");
+    config.put("enable.auto.commit", "false");
+
+    return config;
+  }
+}

--- a/src/test/java/org/folio/rest/support/kafka/MessageCollector.java
+++ b/src/test/java/org/folio/rest/support/kafka/MessageCollector.java
@@ -1,0 +1,8 @@
+package org.folio.rest.support.kafka;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+
+public interface MessageCollector {
+  void acceptMessage(KafkaConsumerRecord<String, JsonObject> message);
+}

--- a/src/test/java/org/folio/rest/support/kafka/TopicFilterIngMessageCollector.java
+++ b/src/test/java/org/folio/rest/support/kafka/TopicFilterIngMessageCollector.java
@@ -1,0 +1,27 @@
+package org.folio.rest.support.kafka;
+
+import java.util.Objects;
+
+import io.vertx.core.json.JsonObject;
+import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
+
+class TopicFilterIngMessageCollector implements MessageCollector {
+  private final String topicName;
+  private final MessageCollector wrappedMessageCollector;
+
+  TopicFilterIngMessageCollector(String topicName,
+    MessageCollector wrappedMessageCollector) {
+
+    this.topicName = topicName;
+    this.wrappedMessageCollector = wrappedMessageCollector;
+  }
+
+  @Override
+  public void acceptMessage(KafkaConsumerRecord<String, JsonObject> message) {
+    if (!Objects.equals(message.topic(), topicName)) {
+      return;
+    }
+
+    wrappedMessageCollector.acceptMessage(message);
+  }
+}

--- a/src/test/java/org/folio/rest/support/kafka/VertxMessageCollectingTopicConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/VertxMessageCollectingTopicConsumer.java
@@ -1,12 +1,10 @@
 package org.folio.rest.support.kafka;
 
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.folio.kafka.services.KafkaEnvironmentProperties;
-import org.folio.rest.support.messages.EventMessage;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -36,18 +34,6 @@ public class VertxMessageCollectingTopicConsumer {
     if (consumer != null) {
       consumer.unsubscribe();
     }
-  }
-
-  Collection<EventMessage> receivedMessagesByKey(String key) {
-    return messageCollector.messagesByGroupKey(key);
-  }
-
-  int countOfReceivedKeys() {
-    return messageCollector.groupCount();
-  }
-
-  void discardCollectedMessages() {
-    messageCollector.empty();
   }
 
   private static Map<String, String> consumerProperties() {

--- a/src/test/java/org/folio/rest/support/kafka/VertxMessageCollectingTopicConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/VertxMessageCollectingTopicConsumer.java
@@ -13,11 +13,11 @@ import io.vertx.kafka.client.serialization.JsonObjectDeserializer;
 
 public class VertxMessageCollectingTopicConsumer {
   private final String topicName;
-  private final GroupedMessageCollector messageCollector;
+  private final MessageCollector messageCollector;
   private KafkaConsumer<String, JsonObject> consumer;
 
   public VertxMessageCollectingTopicConsumer(String topicName,
-    GroupedMessageCollector messageCollector) {
+    MessageCollector messageCollector) {
 
     this.topicName = topicName;
     this.messageCollector = messageCollector;

--- a/src/test/java/org/folio/rest/support/kafka/VertxMessageCollectingTopicConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/VertxMessageCollectingTopicConsumer.java
@@ -2,6 +2,7 @@ package org.folio.rest.support.kafka;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.folio.kafka.services.KafkaEnvironmentProperties;
@@ -12,14 +13,14 @@ import io.vertx.kafka.client.consumer.KafkaConsumer;
 import io.vertx.kafka.client.serialization.JsonObjectDeserializer;
 
 public class VertxMessageCollectingTopicConsumer {
-  private final String topicName;
+  private final Set<String> topicNames;
   private final MessageCollector messageCollector;
   private KafkaConsumer<String, JsonObject> consumer;
 
-  public VertxMessageCollectingTopicConsumer(String topicName,
+  public VertxMessageCollectingTopicConsumer(Set<String> topicNames,
     MessageCollector messageCollector) {
 
-    this.topicName = topicName;
+    this.topicNames = topicNames;
     this.messageCollector = messageCollector;
   }
 
@@ -27,7 +28,7 @@ public class VertxMessageCollectingTopicConsumer {
     consumer = KafkaConsumer.create(vertx, consumerProperties());
 
     consumer.handler(messageCollector::acceptMessage);
-    consumer.subscribe(topicName);
+    consumer.subscribe(topicNames);
   }
 
   void unsubscribe() {

--- a/src/test/java/org/folio/rest/support/kafka/VertxMessageCollectingTopicConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/VertxMessageCollectingTopicConsumer.java
@@ -3,7 +3,6 @@ package org.folio.rest.support.kafka;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.function.Function;
 
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.folio.kafka.services.KafkaEnvironmentProperties;
@@ -12,7 +11,6 @@ import org.folio.rest.support.messages.EventMessage;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
 import io.vertx.kafka.client.consumer.KafkaConsumer;
-import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.serialization.JsonObjectDeserializer;
 
 public class VertxMessageCollectingTopicConsumer {
@@ -21,10 +19,10 @@ public class VertxMessageCollectingTopicConsumer {
   private KafkaConsumer<String, JsonObject> consumer;
 
   public VertxMessageCollectingTopicConsumer(String topicName,
-    Function<KafkaConsumerRecord<String, JsonObject>, String> keyMap) {
+    GroupedMessageCollector messageCollector) {
 
     this.topicName = topicName;
-    this.messageCollector = new GroupedMessageCollector(keyMap);
+    this.messageCollector = messageCollector;
   }
 
   void subscribe(Vertx vertx) {

--- a/src/test/java/org/folio/rest/support/kafka/VertxMessageCollectingTopicConsumer.java
+++ b/src/test/java/org/folio/rest/support/kafka/VertxMessageCollectingTopicConsumer.java
@@ -20,13 +20,13 @@ import io.vertx.kafka.client.consumer.KafkaConsumer;
 import io.vertx.kafka.client.consumer.KafkaConsumerRecord;
 import io.vertx.kafka.client.serialization.JsonObjectDeserializer;
 
-public class MessageCollectingTopicConsumer {
+public class VertxMessageCollectingTopicConsumer {
   private final String topicName;
   private final Map<String, List<EventMessage>> collectedMessages;
   private final Function<KafkaConsumerRecord<String, JsonObject>, String> keyMap;
   private KafkaConsumer<String, JsonObject> consumer;
 
-  public MessageCollectingTopicConsumer(String topicName,
+  public VertxMessageCollectingTopicConsumer(String topicName,
     Function<KafkaConsumerRecord<String, JsonObject>, String> keyMap) {
 
     this.topicName = topicName;

--- a/src/test/java/org/folio/rest/support/messages/BoundWithEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/BoundWithEventMessageChecks.java
@@ -1,11 +1,14 @@
 package org.folio.rest.support.messages;
 
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
-import static org.folio.rest.support.kafka.FakeKafkaConsumer.getMessagesForBoundWith;
 import static org.folio.utility.ModuleUtility.vertxUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.allOf;
 
+import java.util.UUID;
+
+import org.folio.rest.support.IndividualResource;
+import org.folio.rest.support.Response;
 import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.folio.rest.support.messages.matchers.EventMessageMatchers;
 import org.hamcrest.CoreMatchers;
@@ -15,30 +18,43 @@ import org.jetbrains.annotations.NotNull;
 import io.vertx.core.json.JsonObject;
 
 public class BoundWithEventMessageChecks {
-  private static final EventMessageMatchers eventMessageMatchers
+  private final EventMessageMatchers eventMessageMatchers
     = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
+  private final FakeKafkaConsumer kafkaConsumer;
 
-  private BoundWithEventMessageChecks() { }
+  public BoundWithEventMessageChecks(FakeKafkaConsumer kafkaConsumer) {
+    this.kafkaConsumer = kafkaConsumer;
+  }
 
-  public static void boundWithCreatedMessagePublished(JsonObject boundWith,
-    String instanceId) {
+  public void createdMessagePublished(IndividualResource boundW, UUID instanceId) {
+    createdMessagePublished(boundW.getJson(), instanceId.toString());
+  }
+
+  public void createdMessagePublished(JsonObject boundWith, String instanceId) {
 
     // Bound With messages are published with the instance ID as the key
     // and that property is not part of the record, so must be provided separately
-    awaitAtMost().until(() -> FakeKafkaConsumer.getMessagesForBoundWith(instanceId),
+    awaitAtMost().until(() -> kafkaConsumer.getMessagesForBoundWith(instanceId),
       eventMessageMatchers.hasCreateEventMessageFor(
         addInstanceIdToBoundWith(boundWith, instanceId)));
   }
 
-  public static void boundWithUpdatedMessagePublished(JsonObject oldBoundWith,
+  public void updatedMessagePublished(IndividualResource oldBoundWith,
+    Response newBoundWith, UUID oldInstanceId, UUID newInstanceId) {
+
+    updatedMessagePublished(oldBoundWith.getJson(), newBoundWith.getJson(),
+      oldInstanceId.toString(), newInstanceId.toString());
+  }
+
+  public void updatedMessagePublished(JsonObject oldBoundWith,
     JsonObject newBoundWith, String oldInstanceId, String newInstanceId) {
 
-    awaitAtMost().until(() -> getMessagesForBoundWith(newInstanceId),
+    awaitAtMost().until(() -> kafkaConsumer.getMessagesForBoundWith(newInstanceId),
       hasBoundWithUpdateMessageFor(oldBoundWith, newBoundWith, oldInstanceId, newInstanceId));
   }
 
   @NotNull
-  private static Matcher<Iterable<? super EventMessage>> hasBoundWithUpdateMessageFor(
+  private Matcher<Iterable<? super EventMessage>> hasBoundWithUpdateMessageFor(
     JsonObject oldBoundWith, JsonObject newBoundWith, String oldInstanceId,
     String newInstanceId) {
 
@@ -56,7 +72,7 @@ public class BoundWithEventMessageChecks {
       // eventMessageMatchers.hasOldRepresentation(oldRepresentation)));
   }
 
-  private static JsonObject addInstanceIdToBoundWith(JsonObject boundWith, String instanceId) {
+  private JsonObject addInstanceIdToBoundWith(JsonObject boundWith, String instanceId) {
     // Event for bound with has an extra 'instanceId' property for
     // old/new object, the property does not exist in schema,
     // so we have to add it manually

--- a/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
@@ -3,58 +3,62 @@ package org.folio.rest.support.messages;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
 import static org.folio.rest.support.AwaitConfiguration.awaitDuring;
-import static org.folio.rest.support.kafka.FakeKafkaConsumer.getMessagesForHoldings;
 import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_ID;
 import static org.folio.utility.ModuleUtility.vertxUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 
+import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.folio.rest.support.messages.matchers.EventMessageMatchers;
 
 import io.vertx.core.json.JsonObject;
 
 public class HoldingsEventMessageChecks {
-  private static final EventMessageMatchers eventMessageMatchers
+  private final EventMessageMatchers eventMessageMatchers
     = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
 
-  private HoldingsEventMessageChecks() { }
+  private final FakeKafkaConsumer kafkaConsumer;
 
-  public static void holdingsCreatedMessagePublished(JsonObject holdings) {
+  public HoldingsEventMessageChecks(FakeKafkaConsumer kafkaConsumer) {
+    this.kafkaConsumer = kafkaConsumer;
+  }
+
+  public void createdMessagePublished(JsonObject holdings) {
     final var holdingsId = getId(holdings);
     final var instanceId = getInstanceId(holdings);
 
-    awaitAtMost().until(() -> getMessagesForHoldings(instanceId, holdingsId),
+    awaitAtMost().until(() -> kafkaConsumer.getMessagesForHoldings(instanceId, holdingsId),
       eventMessageMatchers.hasCreateEventMessageFor(holdings));
   }
 
-  public static void holdingsUpdatedMessagePublished(JsonObject oldHoldings,
+  public void updatedMessagePublished(JsonObject oldHoldings,
     JsonObject newHoldings) {
 
     final var holdingsId = getId(newHoldings);
     final var instanceId = getInstanceId(newHoldings);
 
-    awaitAtMost().until(() -> getMessagesForHoldings(instanceId, holdingsId),
+    awaitAtMost().until(() -> kafkaConsumer.getMessagesForHoldings(instanceId, holdingsId),
       eventMessageMatchers.hasUpdateEventMessageFor(oldHoldings, newHoldings));
   }
 
-  public static void noHoldingsUpdatedMessagePublished(String instanceId,
+  public void noHoldingsUpdatedMessagePublished(String instanceId,
     String holdingsId) {
 
     awaitDuring(1, SECONDS)
-      .until(() -> getMessagesForHoldings(instanceId, holdingsId),
+      .until(() -> kafkaConsumer.getMessagesForHoldings(instanceId, holdingsId),
         eventMessageMatchers.hasNoUpdateEventMessage());
   }
 
-  public static void holdingsDeletedMessagePublished(JsonObject holdings) {
+  public void deletedMessagePublished(JsonObject holdings) {
     final var holdingsId = getId(holdings);
     final var instanceId = getInstanceId(holdings);
 
-    awaitAtMost().until(() -> getMessagesForHoldings(instanceId, holdingsId),
+    awaitAtMost().until(() -> kafkaConsumer.getMessagesForHoldings(instanceId, holdingsId),
       eventMessageMatchers.hasDeleteEventMessageFor(holdings));
   }
 
-  public static void allHoldingsDeletedMessagePublished() {
+  public void allHoldingsDeletedMessagePublished() {
     awaitAtMost()
-      .until(() -> getMessagesForHoldings(NULL_ID, null),
+      .until(() -> kafkaConsumer.getMessagesForHoldings(NULL_ID, null),
         eventMessageMatchers.hasDeleteAllEventMessage());
   }
 

--- a/src/test/java/org/folio/rest/support/messages/InstanceEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/InstanceEventMessageChecks.java
@@ -1,9 +1,9 @@
 package org.folio.rest.support.messages;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.awaitility.Awaitility.await;
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
 import static org.folio.rest.support.AwaitConfiguration.awaitDuring;
-import static org.folio.rest.support.kafka.FakeKafkaConsumer.getMessagesForInstance;
 import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_ID;
 import static org.folio.utility.ModuleUtility.vertxUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
@@ -17,73 +17,82 @@ import java.util.stream.Collectors;
 
 import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.folio.rest.support.messages.matchers.EventMessageMatchers;
+import org.hamcrest.Matcher;
 
 import io.vertx.core.json.JsonObject;
 
 public class InstanceEventMessageChecks {
   private static final EventMessageMatchers eventMessageMatchers
     = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
+  private final FakeKafkaConsumer kafkaConsumer;
 
-  private InstanceEventMessageChecks() { }
-
-  public static void noInstanceMessagesPublished(String instanceId) {
-    awaitDuring(1, SECONDS)
-      .until(() -> getMessagesForInstance(instanceId), is(empty()));
+  public InstanceEventMessageChecks(FakeKafkaConsumer kafkaConsumer) {
+    this.kafkaConsumer = kafkaConsumer;
   }
 
-  public static void instanceCreatedMessagePublished(JsonObject instance) {
+  public void noMessagesPublished(String instanceId) {
+    awaitDuring(1, SECONDS)
+      .until(() -> kafkaConsumer.getMessagesForInstance(instanceId), is(empty()));
+  }
+
+  public void createdMessagePublished(JsonObject instance) {
     final String instanceId = getId(instance);
 
-    awaitAtMost().until(() -> getMessagesForInstance(instanceId),
+    awaitAtMost().until(() -> kafkaConsumer.getMessagesForInstance(instanceId),
       eventMessageMatchers.hasCreateEventMessageFor(instance));
   }
 
-  public static void instanceCreatedMessagesPublished(List<JsonObject> instances) {
+  public void createdMessagesPublished(List<JsonObject> instances) {
     final var instanceIds = instances.stream()
       .map(InstanceEventMessageChecks::getId)
       .collect(Collectors.toList());
 
     // This is a compromise because checking a large number of messages in
     // one go seems to cause instability in the Jenkins builds
-    awaitAtMost().until(() -> FakeKafkaConsumer.getMessagesForInstances(instanceIds),
+    awaitAtMost().until(() -> kafkaConsumer.getMessagesForInstances(instanceIds),
       hasSize(instances.size()));
 
     instances.forEach(instance -> {
-      assertThat(FakeKafkaConsumer.getMessagesForInstances(instanceIds),
+      assertThat(kafkaConsumer.getMessagesForInstances(instanceIds),
         eventMessageMatchers.hasCreateEventMessageFor(instance));
     });
   }
 
-  public static void instancedUpdatedMessagePublished(JsonObject oldInstance, JsonObject newInstance) {
+  public void updatedMessagePublished(JsonObject oldInstance, JsonObject newInstance) {
     final String instanceId = getId(oldInstance);
 
-    awaitAtMost().until(() -> getMessagesForInstance(instanceId),
+    awaitAtMost().until(() -> kafkaConsumer.getMessagesForInstance(instanceId),
       eventMessageMatchers.hasUpdateEventMessageFor(oldInstance, newInstance));
   }
 
-  public static void noInstanceUpdatedMessagePublished(String instanceId) {
+  public void noUpdatedMessagePublished(String instanceId) {
     awaitDuring(1, SECONDS)
-      .until(() -> getMessagesForInstance(instanceId),
+      .until(() -> kafkaConsumer.getMessagesForInstance(instanceId),
         eventMessageMatchers.hasNoUpdateEventMessage());
   }
 
-  public static void instanceDeletedMessagePublished(JsonObject instance) {
+  public void deletedMessagePublished(JsonObject instance) {
     final String instanceId = getId(instance);
 
-    awaitAtMost().until(() -> getMessagesForInstance(instanceId),
+    awaitAtMost().until(() -> kafkaConsumer.getMessagesForInstance(instanceId),
       eventMessageMatchers.hasDeleteEventMessageFor(instance));
   }
 
-  public static void noInstanceDeletedMessagePublished(String instanceId) {
+  public void noDeletedMessagePublished(String instanceId) {
     awaitDuring(1, SECONDS)
-      .until(() -> getMessagesForInstance(instanceId),
+      .until(() -> kafkaConsumer.getMessagesForInstance(instanceId),
         eventMessageMatchers.hasNoDeleteEventMessage());
   }
 
-  public static void allInstancesDeletedMessagePublished() {
+  public void allInstancesDeletedMessagePublished() {
     awaitAtMost()
-      .until(() -> getMessagesForInstance(NULL_ID),
+      .until(() -> kafkaConsumer.getMessagesForInstance(NULL_ID),
         eventMessageMatchers.hasDeleteAllEventMessage());
+  }
+
+  public void countOfAllPublishedInstancesIs(Matcher<Integer> matcher) {
+    await().atMost(15, SECONDS)
+      .until(kafkaConsumer::getAllPublishedInstanceIdsCount, matcher);
   }
 
   private static String getId(JsonObject json) {

--- a/src/test/java/org/folio/rest/support/messages/ItemEventMessageChecks.java
+++ b/src/test/java/org/folio/rest/support/messages/ItemEventMessageChecks.java
@@ -3,13 +3,13 @@ package org.folio.rest.support.messages;
 import static java.util.UUID.fromString;
 import static org.folio.rest.api.TestBase.holdingsClient;
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
-import static org.folio.rest.support.kafka.FakeKafkaConsumer.getMessagesForItem;
 import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_ID;
 import static org.folio.utility.ModuleUtility.vertxUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 
 import java.util.UUID;
 
+import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.folio.rest.support.messages.matchers.EventMessageMatchers;
 
 import io.vertx.core.json.JsonObject;
@@ -18,47 +18,51 @@ public class ItemEventMessageChecks {
   private static final EventMessageMatchers eventMessageMatchers
     = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
 
-  private ItemEventMessageChecks() { }
+  private final FakeKafkaConsumer kafkaConsumer;
 
-  public static void itemCreatedMessagePublished(JsonObject item) {
+  public ItemEventMessageChecks(FakeKafkaConsumer kafkaConsumer) {
+    this.kafkaConsumer = kafkaConsumer;
+  }
+
+  public void createdMessagePublished(JsonObject item) {
     final var itemId = getId(item);
     final var instanceId = getInstanceIdForItem(item);
 
-    awaitAtMost().until(() -> getMessagesForItem(instanceId, itemId),
+    awaitAtMost().until(() -> kafkaConsumer.getMessagesForItem(instanceId, itemId),
       eventMessageMatchers.hasCreateEventMessageFor(
         addInstanceIdToItem(item, instanceId)));
   }
 
-  public static void itemUpdatedMessagePublished(JsonObject oldItem, JsonObject newItem) {
+  public void updatedMessagePublished(JsonObject oldItem, JsonObject newItem) {
     final var oldInstanceId = getInstanceIdForItem(oldItem);
 
-    itemUpdatedMessagePublished(oldItem, newItem, oldInstanceId);
+    updatedMessagePublished(oldItem, newItem, oldInstanceId);
   }
 
-  public static void itemUpdatedMessagePublished(JsonObject oldItem,
+  public void updatedMessagePublished(JsonObject oldItem,
     JsonObject newItem, String oldInstanceId) {
 
     final var itemId = getId(newItem);
     final var newInstanceId = getInstanceIdForItem(newItem);
 
-    awaitAtMost().until(() -> getMessagesForItem(newInstanceId, itemId),
+    awaitAtMost().until(() -> kafkaConsumer.getMessagesForItem(newInstanceId, itemId),
       eventMessageMatchers.hasUpdateEventMessageFor(
         addInstanceIdToItem(oldItem, oldInstanceId),
         addInstanceIdToItem(newItem, newInstanceId)));
   }
 
-  public static void itemDeletedMessagePublished(JsonObject item) {
+  public void deletedMessagePublished(JsonObject item) {
     final var itemId = getId(item);
     final var instanceId = getInstanceIdForItem(item);
 
-    awaitAtMost().until(() -> getMessagesForItem(instanceId, itemId),
+    awaitAtMost().until(() -> kafkaConsumer.getMessagesForItem(instanceId, itemId),
       eventMessageMatchers.hasDeleteEventMessageFor(
         addInstanceIdToItem(item, instanceId)));
   }
 
-  public static void allItemsDeletedMessagePublished() {
+  public void allItemsDeletedMessagePublished() {
     awaitAtMost()
-      .until(() -> getMessagesForItem(NULL_ID, null),
+      .until(() -> kafkaConsumer.getMessagesForItem(NULL_ID, null),
         eventMessageMatchers.hasDeleteAllEventMessage());
   }
 


### PR DESCRIPTION
A follow on from #862, #863, #865, #867, #869 and #870

Now that most of the assertions around the receiving of Kafka messages has been moved to Awaitility methods that use Hamcrest matchers, the fake Kafka consumer can be reworked and, hopefully, simplified as much of the logic has been moved.

Initially, these changes included using a separate consumer for each topic, however that seems to have had a significant impact on build times and so was changed back to a single consumer.

### Approach Taken
* convert received messages from kafka consumer records before retaining them for assertions
* remove the checks for messages that occur out of timestamp order because ordering is no longer relied on in assertions
* Extract topic consumer to a separate class
* Extract message collecting into set of separate classes (topic filtering and grouping)
* Make the checks / assertions classes non-static
* Access collected messages in non-static way