### PR TITLE
Remove rest of assertion error catching MODINVSTOR-1001

### DIFF
--- a/src/test/java/org/folio/rest/api/DereferencedItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/DereferencedItemStorageTest.java
@@ -50,8 +50,6 @@ public class DereferencedItemStorageTest extends TestBaseWithInventoryUtil {
     postItem(smallAngryPlanet);
     postItem(nod);
     postItem(uprooted);
-
-    kafkaConsumer.discardAllMessages();
   }
 
   @AfterClass

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -1181,17 +1181,13 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     };
 
     for (String s : strings) {
-      try {
-        // full text search ignores punctuation
-        matchInstanceTitles(searchForInstances("title=\"" + s + "Uprooted\""), "Uprooted");
-        // == will return 0 results
-        matchInstanceTitles(searchForInstances("title==\"" + s + "Uprooted\""));
-        // identifier search will always return 0 results
-        matchInstanceTitles(searchForInstances("identifiers=\"" + s + "\""));
-        matchInstanceTitles(searchForInstances("identifiers==\"" + s + "\""));
-      } catch (Exception e) {
-        throw new AssertionError(s, e);
-      }
+      // full text search ignores punctuation
+      matchInstanceTitles(searchForInstances("title=\"" + s + "Uprooted\""), "Uprooted");
+      // == will return 0 results
+      matchInstanceTitles(searchForInstances("title==\"" + s + "Uprooted\""));
+      // identifier search will always return 0 results
+      matchInstanceTitles(searchForInstances("identifiers=\"" + s + "\""));
+      matchInstanceTitles(searchForInstances("identifiers==\"" + s + "\""));
     }
   }
 

--- a/src/test/java/org/folio/rest/api/InventoryViewTest.java
+++ b/src/test/java/org/folio/rest/api/InventoryViewTest.java
@@ -1,8 +1,8 @@
 package org.folio.rest.api;
 
-import static org.folio.rest.api.ItemStorageTest.nodWithNoBarcode;
 import static java.util.UUID.randomUUID;
 import static java.util.stream.Collectors.toList;
+import static org.folio.rest.api.ItemStorageTest.nodWithNoBarcode;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
@@ -12,6 +12,7 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
 import org.folio.rest.jaxrs.model.HoldingsItem;
 import org.folio.rest.jaxrs.model.HoldingsRecords2;
 import org.folio.rest.jaxrs.model.InventoryViewInstance;
@@ -133,10 +134,14 @@ public class InventoryViewTest extends TestBaseWithInventoryUtil {
   }
 
   private InventoryViewInstance getInstanceById(List<IndividualResource> instances, UUID id) {
-    return instances.stream()
+    final var instance = instances.stream()
       .map(r -> r.getJson().mapTo(InventoryViewInstance.class))
       .filter(r -> r.getInstanceId().equals(id.toString()))
       .findFirst()
-      .orElseThrow(() -> new AssertionError("No instance"));
+      .orElse(null);
+
+    assertThat("Instance not found", instance, is(notNullValue()));
+
+    return instance;
   }
 }

--- a/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
+++ b/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
@@ -67,9 +67,6 @@ public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
     get(repository.save(reindexJob.getId(), reindexJob).toCompletionStage()
       .toCompletableFuture());
 
-    // Make sure no events are left over from test preparation
-    kafkaConsumer.discardAllMessages();
-
     jobRunner(postgresClientFuturized).startReindex(reindexJob, ReindexResourceName.INSTANCE);
 
     await().until(() -> instanceReindex.getReindexJob(reindexJob.getId())
@@ -100,9 +97,6 @@ public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
 
     get(repository.save(reindexJob.getId(), reindexJob).toCompletionStage()
       .toCompletableFuture());
-
-    // Make sure no events are left over from test preparation
-    kafkaConsumer.discardAllMessages();
 
     jobRunner(postgresClientFuturized).startReindex(reindexJob, ReindexResourceName.AUTHORITY);
 

--- a/src/test/java/org/folio/rest/api/SampleDataTest.java
+++ b/src/test/java/org/folio/rest/api/SampleDataTest.java
@@ -40,7 +40,7 @@ public class SampleDataTest extends TestBase {
   public static void beforeAll() {
     TestBase.beforeAll();
 
-    removeTenant(TENANT_ID);
+    removeTenant(TENANT_ID);  
     prepareTenant(TENANT_ID, null, "mod-inventory-storage-1.0.0", true);
   }
 

--- a/src/test/java/org/folio/rest/api/SampleDataTest.java
+++ b/src/test/java/org/folio/rest/api/SampleDataTest.java
@@ -21,6 +21,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import java.net.URL;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Predicate;
 
 import org.folio.rest.support.Response;
 import org.junit.BeforeClass;
@@ -147,13 +148,14 @@ public class SampleDataTest extends TestBase {
       body.getJsonArray("instanceRelationships"));
 
     return instanceRelationships.stream()
-      .filter(instanceRelationship -> hasId(instanceRelationship, id))
+      .filter(hasId(id))
       .findFirst()
       .orElse(null);
   }
 
-  private static boolean hasId(JsonObject instanceRelationship, String id) {
-    return Objects.equals(instanceRelationship.getString("id"), id);
+  private static Predicate<JsonObject> hasId(String id) {
+    return (JsonObject instanceRelationship) ->
+      Objects.equals(instanceRelationship.getString("id"), id);
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/rest/api/SampleDataTest.java
+++ b/src/test/java/org/folio/rest/api/SampleDataTest.java
@@ -40,7 +40,7 @@ public class SampleDataTest extends TestBase {
   public static void beforeAll() {
     TestBase.beforeAll();
 
-    removeTenant(TENANT_ID);  
+    removeTenant(TENANT_ID);
     prepareTenant(TENANT_ID, null, "mod-inventory-storage-1.0.0", true);
   }
 

--- a/src/test/java/org/folio/rest/api/SampleDataTest.java
+++ b/src/test/java/org/folio/rest/api/SampleDataTest.java
@@ -45,8 +45,6 @@ public class SampleDataTest extends TestBase {
 
     removeTenant(TENANT_ID);
     prepareTenant(TENANT_ID, null, "mod-inventory-storage-1.0.0", true);
-
-    kafkaConsumer.discardAllMessages();
   }
 
   private void assertCount(URL url, String arrayName, int expectedCount) {

--- a/src/test/java/org/folio/rest/api/SampleDataTest.java
+++ b/src/test/java/org/folio/rest/api/SampleDataTest.java
@@ -19,6 +19,7 @@ import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import java.net.URL;
+import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import org.folio.rest.support.Response;
@@ -146,9 +147,13 @@ public class SampleDataTest extends TestBase {
       body.getJsonArray("instanceRelationships"));
 
     return instanceRelationships.stream()
-      .filter(instanceRelationship -> instanceRelationship.getString("id") == id)
+      .filter(instanceRelationship -> hasId(instanceRelationship, id))
       .findFirst()
       .orElse(null);
+  }
+
+  private static boolean hasId(JsonObject instanceRelationship, String id) {
+    return Objects.equals(instanceRelationship.getString("id"), id);
   }
 
   @SneakyThrows

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -80,10 +80,11 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   public static void testBaseWithInvUtilBeforeClass() {
     logger.info("starting @BeforeClass testBaseWithInvUtilBeforeClass()");
 
-    clearData();
     StorageTestSuite.deleteAll(TENANT_ID, "preceding_succeeding_title");
     StorageTestSuite.deleteAll(TENANT_ID, "instance_relationship");
     StorageTestSuite.deleteAll(TENANT_ID, "bound_with_part");
+
+    clearData();
 
     createDefaultInstanceType();
     setupMaterialTypes();

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -80,11 +80,11 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   public static void testBaseWithInvUtilBeforeClass() {
     logger.info("starting @BeforeClass testBaseWithInvUtilBeforeClass()");
 
+    clearData();
     StorageTestSuite.deleteAll(TENANT_ID, "preceding_succeeding_title");
     StorageTestSuite.deleteAll(TENANT_ID, "instance_relationship");
     StorageTestSuite.deleteAll(TENANT_ID, "bound_with_part");
 
-    clearData();
     createDefaultInstanceType();
     setupMaterialTypes();
     setupLoanTypes();

--- a/src/test/java/org/folio/utility/LocationUtility.java
+++ b/src/test/java/org/folio/utility/LocationUtility.java
@@ -8,10 +8,6 @@ import static org.folio.rest.support.http.InterfaceUrls.locationsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.servicePointsUrl;
 import static org.folio.utility.RestUtility.send;
 
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.json.Json;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -21,10 +17,17 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+
 import org.folio.rest.jaxrs.model.HoldShelfExpiryPeriod;
 import org.folio.rest.jaxrs.model.StaffSlip;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
+
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import lombok.SneakyThrows;
 
 public class LocationUtility {
   private static final String SUPPORTED_CONTENT_TYPE_JSON_DEF = "application/json";
@@ -37,26 +40,23 @@ public class LocationUtility {
     throw new UnsupportedOperationException("Cannot instantiate utility class.");
   }
 
+  @SneakyThrows
   public static void createLocationUnits(boolean force) {
+    if (force || institutionID == null) {
+      institutionID = UUID.randomUUID();
+      createInstitution(institutionID, "Primary Institution", "PI");
 
-    try {
-      if (force || institutionID == null) {
-        institutionID = UUID.randomUUID();
-        createInstitution(institutionID, "Primary Institution", "PI");
+      campusID = UUID.randomUUID();
+      createCampus(campusID, "Central Campus", "CC", institutionID);
 
-        campusID = UUID.randomUUID();
-        createCampus(campusID, "Central Campus", "CC", institutionID);
+      libraryID = UUID.randomUUID();
+      createLibrary(libraryID, "Main Library", "ML", campusID);
 
-        libraryID = UUID.randomUUID();
-        createLibrary(libraryID, "Main Library", "ML", campusID);
+      UUID spID = UUID.randomUUID();
+      servicePointIDs.add(spID);
+      String spName = "Service Point " + spID;
 
-        UUID spID = UUID.randomUUID();
-        servicePointIDs.add(spID);
-        String spName = "Service Point " + spID.toString();
-        createServicePoint(spID, spName, "SP" + spID.toString(), spName, "SP Description", 0, false, null);
-      }
-    } catch (Exception e) { // should not happen
-      throw new AssertionError("CreateLocUnits failed:", e);
+      createServicePoint(spID, spName, "SP" + spID, spName, "SP Description", 0, false, null);
     }
   }
 


### PR DESCRIPTION
A follow on from #862, #863, #865, #867, #869, #870, #872

Final (hopefully) pull request for removing throwing or catching assertion errors.

### Approach Taken
* Allow exceptions to bubble up to cause test failures
* Replace throwing assertion errors with separate assertions
* Also includes removing unnecessary removal of captures messages (that should've been part of previous PR)