### PR TITLE
Bound-with: Enforce main holdings ID inclusion (MODINVSTOR-1032)

### DIFF
--- a/ramls/bound-with-part.raml
+++ b/ramls/bound-with-part.raml
@@ -49,10 +49,20 @@ resourceTypes:
 
 /inventory-storage/bound-withs:
   put:
-    description: Manage all parts (holdings references) of a bound-with item
+    description: Manage the collective set of parts (holdings references) of a bound-with item
     body:
       application/json:
-        description: ID of the bound-with Item and IDs of the holdings within it.
+        description: The bound-with composite to PUT must contain the ID of the bound-with Item and a list of contents,
+          which contains the IDs of the holdings that should make up the bound-with.
+          The holdings record that the bound-with Item links directly to is by convention designated
+          as the main bound-with part. It is redundant to include this holdings record in the
+          list of contents but it can be very convenient for clients to have it there anyway.
+          The API will thus ensure that the main title is always stored in the parts list.
+          The client doesn't have to include it in the bound-with PUT request but it is allowed to do so.
+          The bound-with composite must include at least one other holdings ID in the list, or it will
+          not be considered a bound-with. If it _was_ a bound-with before a request including only the
+          main holdings ID (or a request including no holdings at all), then the list of contents will be emptied,
+          and the Item will become an ordinary Item.
         type: boundWith
         example: !include examples/boundWith.json
     responses:

--- a/src/main/java/org/folio/rest/impl/BoundWithAPI.java
+++ b/src/main/java/org/folio/rest/impl/BoundWithAPI.java
@@ -153,14 +153,17 @@ public class BoundWithAPI implements org.folio.rest.jaxrs.resource.InventoryStor
 
     List<Future<Response>> createFutures = new ArrayList<>();
     BoundWithPartService service = new BoundWithPartService(vertxContext, okapiHeaders);
-    for (String holdingsId : incomingParts.keySet()) {
-      if (!existingParts.containsKey(holdingsId)) {
-        BoundWithPart part =
-          new BoundWithPart()
-            .withItemId(itemId)
-            .withHoldingsRecordId(holdingsId)
-            .withMetadata(new Metadata().withCreatedDate(new Date()).withUpdatedDate(new Date()));
-        createFutures.add(service.create(part));
+    if (!incomingParts.containsKey(mainHoldingsId) || incomingParts.size()>1) {
+      for (String holdingsId : incomingParts.keySet()) {
+        if (!existingParts.containsKey(holdingsId)) {
+          BoundWithPart part =
+            new BoundWithPart()
+              .withItemId(itemId)
+              .withHoldingsRecordId(holdingsId)
+              .withMetadata(new Metadata().withCreatedDate(new Date())
+                .withUpdatedDate(new Date()));
+          createFutures.add(service.create(part));
+        }
       }
     }
     // Add main holdings ID, but only if it doesn't exist already,

--- a/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
+++ b/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
@@ -279,19 +279,70 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
 
 
     // Provide only the main holdings record in list of contents (does not qualify as a bound-with
-    JsonObject emptyListOfContents = createBoundWithCompositeJson(item.getId(),
+    JsonObject onlyMainHoldingsRecordInListOfContents = createBoundWithCompositeJson(item.getId(),
       Arrays.asList(holdingsRecord1.getId()));
-    Response responseOnEmptyListOfContents = putCompositeBoundWith(emptyListOfContents);
-    logger.info("Response on request with only the main holdings ID in: " + responseOnEmptyListOfContents.getBody());
+    Response responseOnOnlyMainHoldingsInListOfContents
+      = putCompositeBoundWith(onlyMainHoldingsRecordInListOfContents);
+    logger.info("Response on request with only the main holdings ID in: "
+      + responseOnOnlyMainHoldingsInListOfContents.getBody());
     assertThat(
       "Expected 204 - no content on request with only the main holdings ID in",
-      responseOnEmptyListOfContents.getStatusCode(),is(204));
+      responseOnOnlyMainHoldingsInListOfContents.getStatusCode(),is(204));
     List<JsonObject> partsAfterUpdate
       = boundWithPartsClient.getByQuery("?query=itemId==" + item.getId());
     assertThat("Expected no parts left after update that only provided the main holdings ID in contents",
       partsAfterUpdate.size(),is(0));
   }
 
+  @Test
+  public void providingOnlyMainHoldingsRecordIdWhenBoundWithDoesNotExistYetHasNoEffect() {
+    IndividualResource instance1 = createInstance("Instance 1");
+    IndividualResource holdingsRecord1 = createHoldingsRecord(instance1.getId());
+    IndividualResource item = createItem(holdingsRecord1.getId());
+
+    List<JsonObject> partsBeforeUpdate
+      = boundWithPartsClient.getByQuery("?query=itemId==" + item.getId());
+
+    JsonObject onlyMainHoldingsRecordInListOfContents = createBoundWithCompositeJson(item.getId(),
+      Arrays.asList(holdingsRecord1.getId()));
+    Response responseOnOnlyMainHoldingsInListOfContents
+      = putCompositeBoundWith(onlyMainHoldingsRecordInListOfContents);
+    logger.info("Response on request with only the main holdings ID in: "
+      + responseOnOnlyMainHoldingsInListOfContents.getBody());
+    assertThat(
+      "Expected 204 - no content on request with only the main holdings ID in",
+      responseOnOnlyMainHoldingsInListOfContents.getStatusCode(),is(204));
+    List<JsonObject> partsAfterUpdate
+      = boundWithPartsClient.getByQuery("?query=itemId==" + item.getId());
+    assertThat("Expected no parts before update", partsBeforeUpdate.size(),is(0));
+    assertThat("Expected no parts after update that only provided the main holdings ID in contents",
+      partsAfterUpdate.size(),is(0));
+  }
+
+  @Test
+  public void providingEmptyListOfPartsWhenBoundWithDoesNotExistYetHasNoEffect() {
+    IndividualResource instance1 = createInstance("Instance 1");
+    IndividualResource holdingsRecord1 = createHoldingsRecord(instance1.getId());
+    IndividualResource item = createItem(holdingsRecord1.getId());
+
+    List<JsonObject> partsBeforeUpdate
+      = boundWithPartsClient.getByQuery("?query=itemId==" + item.getId());
+
+    JsonObject emptyListOfContents = createBoundWithCompositeJson(item.getId(),
+      Arrays.asList());
+    Response responseOnEmptyListOfContents
+      = putCompositeBoundWith(emptyListOfContents);
+    logger.info("Response on request with empty list of part: "
+      + responseOnEmptyListOfContents.getBody());
+    assertThat(
+      "Expected 204 - no content on request on empty list of parts",
+      responseOnEmptyListOfContents.getStatusCode(),is(204));
+    List<JsonObject> partsAfterUpdate
+      = boundWithPartsClient.getByQuery("?query=itemId==" + item.getId());
+    assertThat("Expected no parts before update", partsBeforeUpdate.size(),is(0));
+    assertThat("Expected no parts after update with empty list",
+      partsAfterUpdate.size(),is(0));
+  }
 
   @Test
   public void cannotUpdateBoundWithIfItemOrSomeHoldingsDoNotExist() {

--- a/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
+++ b/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
@@ -157,11 +157,14 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
     IndividualResource instance3 = createInstance("Instance 3");
     IndividualResource holdingsRecord3 = createHoldingsRecord(instance3.getId());
 
+    IndividualResource instance4 = createInstance("Instance 4");
+    IndividualResource holdingsRecord4 = createHoldingsRecord(instance4.getId());
+
+
+    // Listing the main holdings record plus one more
     JsonObject initialBoundWith = createBoundWithCompositeJson(item.getId(),
       Arrays.asList(holdingsRecord1.getId(),holdingsRecord2.getId()));
-    logger.info("before initial put");
     Response initialPut = putCompositeBoundWith(initialBoundWith);
-    logger.info("after initial put");
 
     assertThat(
       "Expected 204 - no content on initial boundWith create",
@@ -187,6 +190,7 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
     //* boundWithEventMessageChecks.createdMessagePublished(part1, instance1.getId());
     //* boundWithEventMessageChecks.createdMessagePublished(part2, instance2.getId());
 
+    // Listing the main holdings record plus two more
     JsonObject boundWithFirstUpdate = createBoundWithCompositeJson(item.getId(),
       Arrays.asList(holdingsRecord1.getId(), holdingsRecord2.getId(), holdingsRecord3.getId()));
     Response firstUpdate = putCompositeBoundWith(boundWithFirstUpdate);
@@ -199,30 +203,95 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
       "Expected three parts after first update.",
       partsAfterFirstUpdate.size(),is(3));
 
+    // Listing just one entry (not the main holdings record)
     JsonObject boundWithSecondUpdate = createBoundWithCompositeJson(item.getId(),
-      Arrays.asList(holdingsRecord1.getId()));
+      Arrays.asList(holdingsRecord4.getId()));
     Response secondUpdate = putCompositeBoundWith(boundWithSecondUpdate);
     assertThat(
-      "Expected 204 - no content on second boundWith update",
+      "Expected 204 - no content on initial boundWith create",
       secondUpdate.getStatusCode(),is(204));
     List<JsonObject> partsAfterSecondUpdate
       = boundWithPartsClient.getByQuery("?query=itemId==" + item.getId());
     assertThat(
-      "Expected one part after second update.",
-      partsAfterSecondUpdate.size(),is(1));
+      "Expected two parts after second update.",
+      partsAfterSecondUpdate.size(),is(2));
 
-    JsonObject boundWithThirdUpdate = createBoundWithCompositeJson(item.getId(),
-      Arrays.asList());
-    Response thirdUpdate = putCompositeBoundWith(boundWithThirdUpdate);
+
+  }
+
+  @Test
+  public void canDeleteAllPartsOfBoundWithByEmptyContentsList() {
+    IndividualResource instance1 = createInstance("Instance 1");
+    IndividualResource holdingsRecord1 = createHoldingsRecord(instance1.getId());
+    IndividualResource item = createItem(holdingsRecord1.getId());
+
+    IndividualResource instance2 = createInstance("Instance 2");
+    IndividualResource holdingsRecord2 = createHoldingsRecord(instance2.getId());
+
+    // List one holdings-record but not the main holdings record (should be implied)
+    JsonObject initialSample = createBoundWithCompositeJson(item.getId(),
+      Arrays.asList(holdingsRecord2.getId()));
+    Response responseOnInitial = putCompositeBoundWith(initialSample);
     assertThat(
-      "Expected 204 - no content on third boundWith update",
-      thirdUpdate.getStatusCode(),is(204));
-    List<JsonObject> partsAfterThirdUpdate
+      "Expected 204 - no content on initial request",
+      responseOnInitial.getStatusCode(),is(204));
+    List<JsonObject> partsAfterInitialRequest
       = boundWithPartsClient.getByQuery("?query=itemId==" + item.getId());
     assertThat(
-      "Expected no parts left after third update.",
-      partsAfterThirdUpdate.size(),is(0));
+      "Expected two parts (including the main holdings record) after initial request.",
+      partsAfterInitialRequest.size(),is(2));
+
+    // Provide empty list of contents
+    JsonObject emptyListOfContents = createBoundWithCompositeJson(item.getId(),
+      Arrays.asList(holdingsRecord1.getId()));
+    Response responseOnEmptyListOfContents = putCompositeBoundWith(emptyListOfContents);
+    assertThat(
+      "Expected 204 - no content on request with empty list of contents",
+      responseOnEmptyListOfContents.getStatusCode(),is(204));
+    List<JsonObject> partsAfterUpdate
+      = boundWithPartsClient.getByQuery("?query=itemId==" + item.getId());
+    assertThat("Expected no parts left after update with empty list of contents.",
+      partsAfterUpdate.size(),is(0));
   }
+
+  @Test
+  public void canDeleteAllPartsOfBoundWithByOnlyProvidingMainHoldingsRecordId() {
+    IndividualResource instance1 = createInstance("Instance 1");
+    IndividualResource holdingsRecord1 = createHoldingsRecord(instance1.getId());
+    IndividualResource item = createItem(holdingsRecord1.getId());
+
+    IndividualResource instance2 = createInstance("Instance 2");
+    IndividualResource holdingsRecord2 = createHoldingsRecord(instance2.getId());
+
+    // List one holdings-record but not the main holdings record (should be implied)
+    JsonObject initialSample = createBoundWithCompositeJson(item.getId(),
+      Arrays.asList(holdingsRecord2.getId()));
+    Response responseOnInitial = putCompositeBoundWith(initialSample);
+    logger.info("Response, initial sample: " + responseOnInitial.getBody());
+    assertThat(
+      "Expected 204 - no content on initial request",
+      responseOnInitial.getStatusCode(),is(204));
+    List<JsonObject> partsAfterInitialRequest
+      = boundWithPartsClient.getByQuery("?query=itemId==" + item.getId());
+    assertThat(
+      "Expected two parts (including the main holdings record) after initial request.",
+      partsAfterInitialRequest.size(),is(2));
+
+
+    // Provide only the main holdings record in list of contents (does not qualify as a bound-with
+    JsonObject emptyListOfContents = createBoundWithCompositeJson(item.getId(),
+      Arrays.asList(holdingsRecord1.getId()));
+    Response responseOnEmptyListOfContents = putCompositeBoundWith(emptyListOfContents);
+    logger.info("Response on request with only the main holdings ID in: " + responseOnEmptyListOfContents.getBody());
+    assertThat(
+      "Expected 204 - no content on request with only the main holdings ID in",
+      responseOnEmptyListOfContents.getStatusCode(),is(204));
+    List<JsonObject> partsAfterUpdate
+      = boundWithPartsClient.getByQuery("?query=itemId==" + item.getId());
+    assertThat("Expected no parts left after update that only provided the main holdings ID in contents",
+      partsAfterUpdate.size(),is(0));
+  }
+
 
   @Test
   public void cannotUpdateBoundWithIfItemOrSomeHoldingsDoNotExist() {
@@ -255,7 +324,7 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
     boundWithParts
       = boundWithPartsClient.getByQuery("?query=itemId==" + item.getId());
     assertThat(
-      "Expected no parts created for the given item.",
+      "Expected no parts found for the given item.",
       boundWithParts.size(),is(0));
   }
 

--- a/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
+++ b/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
@@ -243,7 +243,7 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
 
     // Provide empty list of contents
     JsonObject emptyListOfContents = createBoundWithCompositeJson(item.getId(),
-      Arrays.asList(holdingsRecord1.getId()));
+      Arrays.asList());
     Response responseOnEmptyListOfContents = putCompositeBoundWith(emptyListOfContents);
     assertThat(
       "Expected 204 - no content on request with empty list of contents",

--- a/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
+++ b/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
@@ -242,8 +242,7 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
       partsAfterInitialRequest.size(),is(2));
 
     // Provide empty list of contents
-    JsonObject emptyListOfContents = createBoundWithCompositeJson(item.getId(),
-      Arrays.asList());
+    JsonObject emptyListOfContents = createBoundWithCompositeJson(item.getId(),Arrays.asList());
     Response responseOnEmptyListOfContents = putCompositeBoundWith(emptyListOfContents);
     assertThat(
       "Expected 204 - no content on request with empty list of contents",


### PR DESCRIPTION
 - If the main holdings ID (the one directly linked to the bound-with item) is not included in the composite bound-with request, the API will include it
 - Unless the main holdings ID would then be the only part of the bound-with, in which case it will we left out whether it was provided or not. If it was inserted as the lone part of a bound-with through the bound-with-parts API (which will still allow this) it would be removed by a subsequent composite request as described.