### PR TITLE
MODINVSTOR-1039 Remove reference to related instance types

### DIFF
--- a/src/main/java/org/folio/rest/impl/TenantRefAPI.java
+++ b/src/main/java/org/folio/rest/impl/TenantRefAPI.java
@@ -76,7 +76,6 @@ public class TenantRefAPI extends TenantAPI {
     "bound-with/holdingsrecords",
     "bound-with/items",
     "bound-with/bound-with-parts",
-    "related-instance-types",
     "authority-source-files"
   };
 


### PR DESCRIPTION
Remove reference to "Related Instance Types". This is a feature that has been deprecated.