### PR TITLE
MODINVSTOR-1048 - Handle deleted holdings/items in harvest (implementation)

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1269,7 +1269,7 @@
     },
     {
       "id": "inventory-hierarchy",
-      "version": "1.0",
+      "version": "0.3",
       "handlers": [
         {
           "methods": ["GET"],

--- a/src/test/java/org/folio/rest/api/AsyncMigrationTest.java
+++ b/src/test/java/org/folio/rest/api/AsyncMigrationTest.java
@@ -122,7 +122,7 @@ public class AsyncMigrationTest extends TestBaseWithInventoryUtil {
       var migrationJob = asyncMigration.postMigrationJob(new AsyncMigrationJobRequest()
         .withMigrations(List.of("subjectSeriesMigration")));
 
-      await().atMost(25, SECONDS).until(() -> asyncMigration.getMigrationJob(migrationJob.getId())
+      await().atMost(30, SECONDS).until(() -> asyncMigration.getMigrationJob(migrationJob.getId())
         .getJobStatus() == AsyncMigrationJob.JobStatus.COMPLETED);
 
       var job = asyncMigration.getMigrationJob(migrationJob.getId());

--- a/src/test/java/org/folio/rest/api/AsyncMigrationTest.java
+++ b/src/test/java/org/folio/rest/api/AsyncMigrationTest.java
@@ -122,7 +122,7 @@ public class AsyncMigrationTest extends TestBaseWithInventoryUtil {
       var migrationJob = asyncMigration.postMigrationJob(new AsyncMigrationJobRequest()
         .withMigrations(List.of("subjectSeriesMigration")));
 
-      await().atMost(30, SECONDS).until(() -> asyncMigration.getMigrationJob(migrationJob.getId())
+      await().atMost(25, SECONDS).until(() -> asyncMigration.getMigrationJob(migrationJob.getId())
         .getJobStatus() == AsyncMigrationJob.JobStatus.COMPLETED);
 
       var job = asyncMigration.getMigrationJob(migrationJob.getId());


### PR DESCRIPTION
[MODINVSTOR-1048](https://issues.folio.org/browse/MODINVSTOR-1048) - Handle deleted holdings/items in harvest (implementation)

Use minor version of inventory-hierarchy interface to avoid breaking change for mod-rtac module.

