### PR TITLE
MODINVSTOR-1066: add browse option for NLM call number type

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
     <raml-module-builder-version>35.0.4</raml-module-builder-version> <!-- also update vertx.version -->
     <vertx.version>4.3.5</vertx.version>
+    <marc4j.version>2.9.4</marc4j.version>
     <sonar.exclusions>src/main/java/org/folio/persist/entity/*Internal*</sonar.exclusions>
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/authority-storage/authorities,/record-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances,/inventory-hierarchy/updated-instance-ids,/inventory-hierarchy/items-and-holdings,/inventory-view/instances</generate_routing_context>
     <argLine />
@@ -72,7 +73,7 @@
     <dependency>
       <groupId>org.marc4j</groupId>
       <artifactId>marc4j</artifactId>
-      <version>2.9.2</version>
+      <version>${marc4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.folio.okapi</groupId>
@@ -139,6 +140,11 @@
     <dependency>
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-engine</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/org/folio/services/CallNumberUtils.java
+++ b/src/main/java/org/folio/services/CallNumberUtils.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 import org.marc4j.callnum.CallNumber;
 import org.marc4j.callnum.DeweyCallNumber;
 import org.marc4j.callnum.LCCallNumber;
+import org.marc4j.callnum.NlmCallNumber;
 
 public final class CallNumberUtils {
 
@@ -11,7 +12,8 @@ public final class CallNumberUtils {
 
   public static Optional<String> getShelfKeyFromCallNumber(String callNumber) {
     return Optional.ofNullable(callNumber)
-      .flatMap(cn -> getValidShelfKey(new LCCallNumber(cn))
+      .flatMap(cn -> getValidShelfKey(new NlmCallNumber(cn))
+        .or(() -> getValidShelfKey(new LCCallNumber(cn)))
         .or(() -> getValidShelfKey(new DeweyCallNumber(cn))))
       .or(() -> Optional.ofNullable(callNumber))
       .map(String::trim);

--- a/src/test/java/org/folio/services/CallNumberUtilsTest.java
+++ b/src/test/java/org/folio/services/CallNumberUtilsTest.java
@@ -3,19 +3,16 @@ package org.folio.services;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
-import junit.framework.TestCase;
-import junitparams.JUnitParamsRunner;
-import junitparams.Parameters;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.support.EffectiveCallNumberComponentsUtil;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
-@RunWith(JUnitParamsRunner.class)
-public class CallNumberUtilsTest extends TestCase {
+public class CallNumberUtilsTest {
 
-  @Parameters({
+  @ParameterizedTest
+  @CsvSource({
     "PN 12 A6,PN12 .A6,,PN2 .A6,,,,,",
     "PN 12 A6 V 13 NO 12 41999,PN2 .A6 v.3 no.2 1999,,PN2 .A6,v. 3,no. 2,1999,,",
     "PN 12 A6 41999,PN12 .A6 41999,,PN2 .A6 1999,,,,,",
@@ -47,10 +44,11 @@ public class CallNumberUtilsTest extends TestCase {
     "19 A2 C 6444218 MUSIC CD,,,9A2 C0444218 Music CD,,,,,",
     "GROUP Smith,,,GROUP Smith,,,,,",
     "free-text,,,free-text,,,,,",
-    "RR 3718,,,RR 718,,,,,"
+    "RR 3718,,,RR 718,,,,,",
+    "QS 211 G A1 E53 42005 42005,QS11 .GA1 E53 2005,,QS 11 .GA1 E53 2005,,,2005,,",
+    "WB 3102.5 B62 42018 42018,WB102.5 .B62 2018,,WB 102.5 B62 2018,,,2018,,"
   })
-  @Test
-  public void inputForShelvingNumber(
+  void inputForShelvingNumber(
     String desiredShelvingOrder,
     String initiallyDesiredShelvesOrder,
     String prefix,


### PR DESCRIPTION
Add browse option for National Library of Medicine (NLM) call number type and for this implement normalization for NLM that follows the normalization of LC classification:
- NLM call numbers have the item call number type "National Library of Medicine classification"
- LC call numbers have the item call number type "Library of Congress classification"

## Purpose
_Support browsing by NLM call number type_

## Approach
_Implements normalization for NLM that follows the normalization of LC classification_

### Changes checklist
- [x] Adjust existing tests and add new ones for the the new implementation 

### Learning
_Closes: [MODINVSTOR-1066](https://issues.folio.org/browse/MODINVSTOR-1066)_