### PR TITLE
MODINVSTOR-1080 Modify inventory dtos to include source field

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -312,7 +312,7 @@
     },
     {
       "id": "loan-types",
-      "version": "2.2",
+      "version": "2.3",
       "handlers": [
         {
           "methods": ["GET"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -799,7 +799,7 @@
     },
     {
       "id": "electronic-access-relationships",
-      "version": "1.0",
+      "version": "1.1",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/electronic-access-relationship.raml
+++ b/ramls/electronic-access-relationship.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Electronic access relationship terms reference API
-version: v1.0
+version: v1.1
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/electronicaccessrelationship.json
+++ b/ramls/electronicaccessrelationship.json
@@ -10,6 +10,10 @@
       "description": "label for the type of relationship between a URL and an Instance",
       "type": "string"
     },
+    "source": {
+      "description": "Origin of the electronic access relationship record, e.g. 'System', 'User', 'Consortium', 'folio', 'local' etc.",
+      "type": "string"
+    },
     "metadata": {
       "type": "object",
       "$ref": "raml-util/schemas/metadata.schema",

--- a/ramls/examples/electronicaccessrelationship.json
+++ b/ramls/examples/electronicaccessrelationship.json
@@ -1,4 +1,5 @@
 {
   "id": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
-  "name": "Resource"
+  "name": "Resource",
+  "source": "System"
 }

--- a/ramls/examples/electronicaccessrelationships.json
+++ b/ramls/examples/electronicaccessrelationships.json
@@ -2,23 +2,28 @@
   "electronicAccessRelationships": [
     {
       "id": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
-      "name": "Resource"
+      "name": "Resource",
+      "source": "System"
     },
     {
       "id": "f50c90c9-bae0-4add-9cd0-db9092dbc9dd",
-      "name": "No information provided"
+      "name": "No information provided",
+      "source": "User"
     },
     {
       "id": "3b430592-2e09-4b48-9a0c-0636d66b9fb3",
-      "name": "Version of resource"
+      "name": "Version of resource",
+      "source": "Consortium"
     },
     {
       "id": "5bfe1b7b-f151-4501-8cfa-23b321d5cd1e",
-      "name": "Related resource"
+      "name": "Related resource",
+      "source": "folio"
     },
     {
       "id": "ef03d582-219c-4221-8635-bc92f1107021",
-      "name": "No display constant generated"
+      "name": "No display constant generated",
+      "source": "local"
     }
   ],
   "totalRecords": 5

--- a/ramls/examples/loantype.json
+++ b/ramls/examples/loantype.json
@@ -1,4 +1,5 @@
 {
   "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
-  "name": "Can circulate"
+  "name": "Can circulate",
+  "source": "System"
 }

--- a/ramls/examples/loantypes.json
+++ b/ramls/examples/loantypes.json
@@ -2,15 +2,18 @@
   "loantypes": [
     {
       "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
-      "name": "Can circulate"
+      "name": "Can circulate",
+      "source": "System"
     },
     {
       "id": "2e48e713-17f3-4c13-a9f8-23845bb210a4",
-      "name": "Reading room"
+      "name": "Reading room",
+      "source": "User"
     },
     {
       "id": "e8b311a6-3b21-43f2-a269-dd9310cb2d0e",
-      "name": "Course reserves"
+      "name": "Course reserves",
+      "source": "Consortium"
     }
   ],
   "totalRecords": 3

--- a/ramls/loan-type.raml
+++ b/ramls/loan-type.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Loan Types API
-version: v2.2
+version: v2.3
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/loantype.json
+++ b/ramls/loantype.json
@@ -10,6 +10,10 @@
       "description": "label for the loan type",
       "type": "string"
     },
+    "source": {
+      "description": "Origin of the loan type record, i.e. 'System', 'User', 'Consortium' etc.",
+      "type": "string"
+    },
     "metadata": {
       "type": "object",
       "$ref": "raml-util/schemas/metadata.schema",

--- a/ramls/loantype.json
+++ b/ramls/loantype.json
@@ -11,7 +11,7 @@
       "type": "string"
     },
     "source": {
-      "description": "Origin of the loan type record, i.e. 'System', 'User', 'Consortium' etc.",
+      "description": "Origin of the loan type record, e.g. 'System', 'User', 'Consortium' etc.",
       "type": "string"
     },
     "metadata": {

--- a/src/test/java/org/folio/rest/api/LoanTypeTest.java
+++ b/src/test/java/org/folio/rest/api/LoanTypeTest.java
@@ -39,6 +39,7 @@ public class LoanTypeTest extends TestBaseWithInventoryUtil {
 
   private static final String POST_REQUEST_CIRCULATE = "{\"name\": \"Can circulate\"}";
   private static final String POST_REQUEST_COURSE = "{\"name\": \"Course reserve\"}";
+  private static final String POST_READING_ROOM = "{\"name\": \"Reading room\", \"source\": \"System\"}";
   private static final String PUT_REQUEST = "{\"name\": \"Reading room\"}";
 
   /**
@@ -106,6 +107,20 @@ public class LoanTypeTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  public void canCreateLoanTypeWithSourceFieldPopulated()
+    throws MalformedURLException {
+
+    // post new loan type with 'source' field populated
+    JsonObject response = send(loanTypesStorageUrl(""), HttpMethod.POST,
+      POST_READING_ROOM, HTTP_CREATED);
+
+    // verify all fields have been saved
+    assertThat(response.getString("id"), notNullValue());
+    assertThat(response.getString("name"), is("Reading room"));
+    assertThat(response.getString("source"), is("System"));
+  }
+
+  @Test
   public void cannotCreateLoanTypeWithAdditionalProperties()
     throws MalformedURLException {
 
@@ -154,6 +169,26 @@ public class LoanTypeTest extends TestBaseWithInventoryUtil {
 
     assertThat(getResponse.getString("id"), is(loanTypeId));
     assertThat(getResponse.getString("name"), is("Can circulate"));
+  }
+
+  @Test
+  public void canGetLoanTypeByIdWithSourceFieldPopulated()
+    throws MalformedURLException {
+
+    // post new loan type with 'source' field populated
+    JsonObject response = send(loanTypesStorageUrl(""), HttpMethod.POST,
+      POST_READING_ROOM, HTTP_CREATED);
+
+    // get id of created loan type
+    String loanTypeId = response.getString("id");
+
+    // get saved loan type by id and verify all fields have been populated
+    JsonObject getResponse = send(loanTypesStorageUrl("/" + loanTypeId), HttpMethod.GET,
+      null, HTTP_OK);
+
+    assertThat(getResponse.getString("id"), is(loanTypeId));
+    assertThat(response.getString("name"), is("Reading room"));
+    assertThat(response.getString("source"), is("System"));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/LoanTypeTest.java
+++ b/src/test/java/org/folio/rest/api/LoanTypeTest.java
@@ -176,19 +176,19 @@ public class LoanTypeTest extends TestBaseWithInventoryUtil {
     throws MalformedURLException {
 
     // post new loan type with 'source' field populated
-    JsonObject response = send(loanTypesStorageUrl(""), HttpMethod.POST,
+    JsonObject createResponse = send(loanTypesStorageUrl(""), HttpMethod.POST,
       POST_READING_ROOM, HTTP_CREATED);
 
     // get id of created loan type
-    String loanTypeId = response.getString("id");
+    String loanTypeId = createResponse.getString("id");
 
     // get saved loan type by id and verify all fields have been populated
     JsonObject getResponse = send(loanTypesStorageUrl("/" + loanTypeId), HttpMethod.GET,
       null, HTTP_OK);
 
     assertThat(getResponse.getString("id"), is(loanTypeId));
-    assertThat(response.getString("name"), is("Reading room"));
-    assertThat(response.getString("source"), is("System"));
+    assertThat(getResponse.getString("name"), is("Reading room"));
+    assertThat(getResponse.getString("source"), is("System"));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/ReferenceTablesTest.java
+++ b/src/test/java/org/folio/rest/api/ReferenceTablesTest.java
@@ -27,6 +27,7 @@ import static org.folio.utility.ModuleUtility.getClient;
 import static org.folio.utility.ModuleUtility.vertxUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -258,6 +259,38 @@ public class ReferenceTablesTest extends TestBase {
     String updateProperty = ElectronicAccessRelationship.NAME_KEY;
 
     testGetPutDeletePost(entityPath, entityUuid, entity, updateProperty);
+  }
+
+  @Test
+  public void canCreateAndGetElectronicAccessRelationshipWithSourceFieldPopulated()
+    throws InterruptedException,
+    MalformedURLException,
+    TimeoutException,
+    ExecutionException,
+    UnsupportedEncodingException {
+    String entityId;
+    String entityName = "Electronic access relationship with 'source' field";
+    String entitySource = "Consortium";
+
+    String apiUrl = electronicAccessRelationshipsUrl("").toString();
+    ElectronicAccessRelationship entity = new ElectronicAccessRelationship(entityName);
+    entity.put("source", entitySource);
+
+    // post new electronic access relationship with 'source' field populated
+    Response postResponse = createReferenceRecord(apiUrl, entity);
+    assertThat(postResponse.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+    assertThat(postResponse.getJson().getString("id"), notNullValue());
+    assertThat(postResponse.getJson().getString("name"), is(entityName));
+    assertThat(postResponse.getJson().getString("source"), is(entitySource));
+
+    // get saved electronic access relationship by id and verify all fields have been populated
+    entityId = postResponse.getJson().getString("id");
+
+    Response getResponse = getById(vertxUrl(apiUrl + "/" + entityId));
+    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+    assertThat(getResponse.getJson().getString("id"), is(entityId));
+    assertThat(getResponse.getJson().getString("name"), is(entityName));
+    assertThat(getResponse.getJson().getString("source"), is(entitySource));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/ReferenceTablesTest.java
+++ b/src/test/java/org/folio/rest/api/ReferenceTablesTest.java
@@ -271,7 +271,7 @@ public class ReferenceTablesTest extends TestBase {
     String entityName = "Electronic access relationship with 'source' field";
     String entitySource = "Consortium";
 
-    String apiUrl = electronicAccessRelationshipsUrl("").toString();
+    String apiUrl = "/electronic-access-relationships";
     ElectronicAccessRelationship entity = new ElectronicAccessRelationship(entityName);
     entity.put("source", entitySource);
 
@@ -290,6 +290,9 @@ public class ReferenceTablesTest extends TestBase {
     assertThat(getResponse.getJson().getString("id"), is(entityId));
     assertThat(getResponse.getJson().getString("name"), is(entityName));
     assertThat(getResponse.getJson().getString("source"), is(entitySource));
+
+    // delete created resource
+    deleteReferenceRecordById(vertxUrl(apiUrl + "/" + entityId));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/ReferenceTablesTest.java
+++ b/src/test/java/org/folio/rest/api/ReferenceTablesTest.java
@@ -268,7 +268,6 @@ public class ReferenceTablesTest extends TestBase {
     TimeoutException,
     ExecutionException,
     UnsupportedEncodingException {
-    String entityId;
     String entityName = "Electronic access relationship with 'source' field";
     String entitySource = "Consortium";
 
@@ -284,7 +283,7 @@ public class ReferenceTablesTest extends TestBase {
     assertThat(postResponse.getJson().getString("source"), is(entitySource));
 
     // get saved electronic access relationship by id and verify all fields have been populated
-    entityId = postResponse.getJson().getString("id");
+    String entityId = postResponse.getJson().getString("id");
 
     Response getResponse = getById(vertxUrl(apiUrl + "/" + entityId));
     assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));


### PR DESCRIPTION
Resolves [MODINVSTOR-1080](https://issues.folio.org/browse/MODINVSTOR-1080) Modify inventory dtos to include source field

This table describes what setting we are going to implement in Consortium Manager:
https://wiki.folio.org/display/FOLIJET/Consortium+manager+settings
For _mod-inventory-storage_ they are _loan type_ and _electronic access relationship_. (All other already have 'source' field.)
Setting created in Consortium Manager will have value _'Consortium'_ and we will add validation to prevent updating them