### PR TITLE
MODINVSTOR-1073: Convert Local Instance to Shared Instance

### DIFF
--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -22,7 +22,7 @@
     },
     "source": {
       "type": "string",
-      "description": "The metadata source and its format of the underlying record to the instance record. (e.g. FOLIO if it's a record created in Inventory;  MARC if it's a MARC record created in MARCcat or EPKB if it's a record coming from eHoldings)"
+      "description": "The metadata source and its format of the underlying record to the instance record. (e.g. FOLIO if it's a record created in Inventory; MARC if it's a MARC record created in MARCcat or EPKB if it's a record coming from eHoldings; CONSORTIUM-MARC or CONSORTIUM-FOLIO for sharing Instances)."
     },
     "title": {
       "type": "string",

--- a/src/main/java/org/folio/services/instance/InstanceService.java
+++ b/src/main/java/org/folio/services/instance/InstanceService.java
@@ -37,6 +37,7 @@ import org.folio.validator.CommonValidators;
 import org.folio.validator.NotesValidators;
 
 public class InstanceService {
+
   private final HridManager hridManager;
   private final Context vertxContext;
   private final Map<String, String> okapiHeaders;
@@ -124,7 +125,12 @@ public class InstanceService {
     return refuseLongNotes(newInstance)
       .compose(notUsed -> instanceRepository.getById(id))
       .compose(CommonValidators::refuseIfNotFound)
-      .compose(oldInstance -> refuseWhenHridChanged(oldInstance, newInstance))
+      .compose(oldInstance -> {
+        if (!newInstance.getSource().startsWith("CONSORTIA")) {
+          return refuseWhenHridChanged(oldInstance, newInstance);
+        }
+        return Future.succeededFuture(oldInstance);
+      })
       .compose(oldInstance -> {
         final Promise<Response> putResult = promise();
 

--- a/src/main/java/org/folio/services/instance/InstanceService.java
+++ b/src/main/java/org/folio/services/instance/InstanceService.java
@@ -126,7 +126,7 @@ public class InstanceService {
       .compose(notUsed -> instanceRepository.getById(id))
       .compose(CommonValidators::refuseIfNotFound)
       .compose(oldInstance -> {
-        if (!newInstance.getSource().startsWith("CONSORTIA-")) {
+        if (!newInstance.getSource().startsWith("CONSORTIUM-")) {
           return refuseWhenHridChanged(oldInstance, newInstance);
         }
         return Future.succeededFuture(oldInstance);

--- a/src/main/java/org/folio/services/instance/InstanceService.java
+++ b/src/main/java/org/folio/services/instance/InstanceService.java
@@ -126,7 +126,7 @@ public class InstanceService {
       .compose(notUsed -> instanceRepository.getById(id))
       .compose(CommonValidators::refuseIfNotFound)
       .compose(oldInstance -> {
-        if (!newInstance.getSource().startsWith("CONSORTIA")) {
+        if (!newInstance.getSource().startsWith("CONSORTIA-")) {
           return refuseWhenHridChanged(oldInstance, newInstance);
         }
         return Future.succeededFuture(oldInstance);

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -2129,9 +2129,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(instance.getString("hrid"), is(expectedHrid));
 
-    final String newHRID = "testHRID";
+    final String new_hrid = "testHRID";
     instance.put("source", "CONSORTIA-MARC");
-    instance.put("hrid", newHRID);
+    instance.put("hrid", new_hrid);
 
     final CompletableFuture<Response> replaceCompleted = new CompletableFuture<>();
 
@@ -2142,7 +2142,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(putResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
 
     final JsonObject updatedInstance = getById(id).getJson();
-    assertThat(updatedInstance.getString("hrid"), is(newHRID));
+    assertThat(updatedInstance.getString("hrid"), is(new_hrid));
 
     log.info("Finished allowChangeHridWhenSourceIsConsortia");
   }

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -2129,8 +2129,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(instance.getString("hrid"), is(expectedHrid));
 
+    final String newHRID = "testHRID";
     instance.put("source", "CONSORTIA-MARC");
-    instance.put("hrid", "testHRID");
+    instance.put("hrid", newHRID);
 
     final CompletableFuture<Response> replaceCompleted = new CompletableFuture<>();
 
@@ -2138,11 +2139,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       TENANT_ID, ResponseHandler.text(replaceCompleted));
 
     final Response putResponse = replaceCompleted.get(10, SECONDS);
+    assertThat(putResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
 
-    log.info("statusCode: {}", putResponse.getStatusCode());
-    log.info("body: {}", putResponse.getBody());
-
-    assertThat(putResponse.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+    final JsonObject updatedInstance = getById(id).getJson();
+    assertThat(updatedInstance.getString("hrid"), is(newHRID));
 
     log.info("Finished allowChangeHridWhenSourceIsConsortia");
   }

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -2133,16 +2133,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     instance.put("source", "CONSORTIA-MARC");
     instance.put("hrid", new_hrid);
 
-    final CompletableFuture<Response> replaceCompleted = new CompletableFuture<>();
+    final IndividualResource updateInstance =
+      updateInstance(JsonObject.mapFrom(instance));
 
-    getClient().put(instancesStorageUrl(format("/%s", id)), instance,
-      TENANT_ID, ResponseHandler.text(replaceCompleted));
-
-    final Response putResponse = replaceCompleted.get(10, SECONDS);
-    assertThat(putResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
-
-    final JsonObject updatedInstance = getById(id).getJson();
-    assertThat(updatedInstance.getString("hrid"), is(new_hrid));
+    assertThat(updateInstance.getJson().mapTo(Instance.class).getHrid(), is(new_hrid));
 
     log.info("Finished allowChangeHridWhenSourceIsConsortia");
   }

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -2122,7 +2122,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     final String newHrid = "newHRID";
     final JsonObject instance = getById(id).getJson()
-      .put("source", "CONSORTIA-MARC").put("hrid", newHrid);
+      .put("source", "CONSORTIUM-MARC").put("hrid", newHrid);
 
     final IndividualResource updateInstance =
       updateInstance(JsonObject.mapFrom(instance));

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -2117,26 +2117,17 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     log.info("Starting allowChangeHridWhenSourceIsConsortia");
 
     final UUID id = UUID.randomUUID();
-    final JsonObject instanceToCreate = smallAngryPlanet(id);
-    instanceToCreate.remove("hrid");
-
-    setInstanceSequence(1);
-
+    final JsonObject instanceToCreate = smallAngryPlanet(id).put("hrid", "oldHRID");
     createInstance(instanceToCreate);
 
-    final JsonObject instance = getById(id).getJson();
-    final String expectedHrid = "in00000000001";
-
-    assertThat(instance.getString("hrid"), is(expectedHrid));
-
-    final String new_hrid = "testHRID";
-    instance.put("source", "CONSORTIA-MARC");
-    instance.put("hrid", new_hrid);
+    final String newHrid = "newHRID";
+    final JsonObject instance = getById(id).getJson()
+      .put("source", "CONSORTIA-MARC").put("hrid", newHrid);
 
     final IndividualResource updateInstance =
       updateInstance(JsonObject.mapFrom(instance));
 
-    assertThat(updateInstance.getJson().mapTo(Instance.class).getHrid(), is(new_hrid));
+    assertThat(updateInstance.getJson().mapTo(Instance.class).getHrid(), is(newHrid));
 
     log.info("Finished allowChangeHridWhenSourceIsConsortia");
   }

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -2113,6 +2113,41 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  public void allowChangeHridWhenSourceIsConsortia() throws Exception {
+    log.info("Starting allowChangeHridWhenSourceIsConsortia");
+
+    final UUID id = UUID.randomUUID();
+    final JsonObject instanceToCreate = smallAngryPlanet(id);
+    instanceToCreate.remove("hrid");
+
+    setInstanceSequence(1);
+
+    createInstance(instanceToCreate);
+
+    final JsonObject instance = getById(id).getJson();
+    final String expectedHrid = "in00000000001";
+
+    assertThat(instance.getString("hrid"), is(expectedHrid));
+
+    instanceToCreate.put("source", "CONSORTIA-MARC");
+    instance.put("hrid", "testHRID");
+
+    final CompletableFuture<Response> replaceCompleted = new CompletableFuture<>();
+
+    getClient().put(instancesStorageUrl(format("/%s", id)), instance,
+      TENANT_ID, ResponseHandler.text(replaceCompleted));
+
+    final Response putResponse = replaceCompleted.get(10, SECONDS);
+
+    log.info("statusCode: {}", putResponse.getStatusCode());
+    log.info("body: {}", putResponse.getBody());
+
+    assertThat(putResponse.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+
+    log.info("Finished allowChangeHridWhenSourceIsConsortia");
+  }
+
+  @Test
   @SneakyThrows
   public void cannotCreateAnInstanceWhenAlreadyAllocatedHridIsAllocated() {
     final var instanceRequest = smallAngryPlanet(UUID.randomUUID());

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -2129,7 +2129,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(instance.getString("hrid"), is(expectedHrid));
 
-    instanceToCreate.put("source", "CONSORTIA-MARC");
+    instance.put("source", "CONSORTIA-MARC");
     instance.put("hrid", "testHRID");
 
     final CompletableFuture<Response> replaceCompleted = new CompletableFuture<>();


### PR DESCRIPTION
## Purpose
When a local instance is promoted to a Shared Instance in the central tenant, the local instance will be converted to a Shadow instance. The details of the Shadow Instance will mirror the Shared Instance, including its HRID.

## Approach
Allow HRID to be updated when transitioning to a Shadow Instance only.

## Learning
[MODINVSTOR-1073](https://issues.folio.org/browse/MODINVSTOR-1073)