### PR TITLE
[MODINVSTOR-1093] Data import: circulation notes created via import cause blank references, rendering items uneditable within the UI

### DIFF
--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -499,13 +499,13 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject firstCirculationNote = savedCirculationNotes.getJsonObject(0);
     assertNotNull(firstCirculationNote.getString("id"));
-    if (Objects.equals(firstCirculationNote.getString("noteType"), "Check out note")) {
+    if (Objects.equals(firstCirculationNote.getString("noteType"), "Check out")) {
       assertThat(firstCirculationNote.getString("id"), is(circulationNoteId.toString()));
     }
 
     JsonObject secondCirculationNote = savedCirculationNotes.getJsonObject(1);
     assertNotNull(secondCirculationNote.getString("id"));
-    if (Objects.equals(secondCirculationNote.getString("noteType"), "Check out note")) {
+    if (Objects.equals(secondCirculationNote.getString("noteType"), "Check out")) {
       assertThat(secondCirculationNote.getString("id"), is(circulationNoteId.toString()));
     }
   }
@@ -735,8 +735,10 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     setItemSequence(1);
 
+    // create item
     createItem(itemToUpdate);
 
+    // populate circulationNotes and other necessary fields
     JsonObject checkInNoteWithoutId = new JsonObject()
       .put("noteType", "Check in")
       .put("note", "Check in note")
@@ -750,11 +752,11 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
       .put("staffOnly", false);
 
     itemToUpdate.put("circulationNotes", new JsonArray().add(checkInNoteWithoutId).add(checkOutNoteWithId));
+    itemToUpdate.put("hrid", "it00000000001");
+    itemToUpdate.put("_version", "1");
 
-    CompletableFuture<Response> completed = new CompletableFuture<>();
-
-    getClient().put(itemsStorageUrl("/" + itemId), itemToUpdate, TENANT_ID,
-      ResponseHandler.text(completed));
+    // update item
+    update(itemToUpdate);
 
     Response getResponse = getById(itemId);
 
@@ -764,19 +766,19 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(itemFromGet.getString("id"), is(itemId.toString()));
 
-    JsonArray savedCirculationNotes = itemFromGet.getJsonArray("circulationNotes");
+    JsonArray updatedCirculationNotes = itemFromGet.getJsonArray("circulationNotes");
 
-    assertThat(savedCirculationNotes.size(), is(2));
+    assertThat(updatedCirculationNotes.size(), is(2));
 
-    JsonObject firstCirculationNote = savedCirculationNotes.getJsonObject(0);
+    JsonObject firstCirculationNote = updatedCirculationNotes.getJsonObject(0);
     assertNotNull(firstCirculationNote.getString("id"));
-    if (Objects.equals(firstCirculationNote.getString("noteType"), "Check out note")) {
+    if (Objects.equals(firstCirculationNote.getString("noteType"), "Check out")) {
       assertThat(firstCirculationNote.getString("id"), is(circulationNoteId.toString()));
     }
 
-    JsonObject secondCirculationNote = savedCirculationNotes.getJsonObject(1);
+    JsonObject secondCirculationNote = updatedCirculationNotes.getJsonObject(1);
     assertNotNull(secondCirculationNote.getString("id"));
-    if (Objects.equals(secondCirculationNote.getString("noteType"), "Check out note")) {
+    if (Objects.equals(secondCirculationNote.getString("noteType"), "Check out")) {
       assertThat(secondCirculationNote.getString("id"), is(circulationNoteId.toString()));
     }
   }


### PR DESCRIPTION
Resolves: [MODINVSTOR-1093](https://issues.folio.org/browse/MODINVSTOR-1093) Data import: circulation notes created via import cause blank references, rendering items uneditable within the UI

**Overview:** Data import field mapping profiles for items allow the addition/update/removal of circulation notes. However, when adding circulation notes to items via data import, null ID values are added to the circulation notes. This prevents records from being editable in the UI after the fact. Once the circulation notes are removed via import or API, the records are editable again. 

**Approach**
Generate id for _circulationNote_ if empty, use existing otherwise
**Affected endpoints**
- POST /item-storage/items
<img width="697" alt="POST-single" src="https://github.com/folio-org/mod-inventory-storage/assets/112848437/82d76afa-10c6-4687-8a72-8f266ef5e3af">

- PUT /item-storage/items
<img width="703" alt="PUT" src="https://github.com/folio-org/mod-inventory-storage/assets/112848437/97fad526-9def-4971-98d7-fe67f428477d">

- POST /item-storage/batch/synchronous
<img width="726" alt="POST-batch" src="https://github.com/folio-org/mod-inventory-storage/assets/112848437/aeee4d89-54a9-46d2-b8c0-c01d65e24e16">

- POST /item-storage/batch/synchronous-unsafe
