### PR TITLE
[MODINVSTOR-1096] Items with multiple circulation notes that do not have an id cannot be updated

### DIFF
--- a/src/main/resources/templates/db_scripts/populateCirculationNoteIds.sql
+++ b/src/main/resources/templates/db_scripts/populateCirculationNoteIds.sql
@@ -22,6 +22,6 @@ WITH item_circnotes as (
   GROUP BY itemId
 )
 UPDATE ${myuniversity}_${mymodule}.item
-SET jsonb = jsonb_set(jsonb, '{circulationNotes}', json_build_array(item_circnotes.circNotes)::jsonb)
+SET jsonb = jsonb_set(jsonb, '{circulationNotes}', to_jsonb(item_circnotes.circNotes))
 FROM item_circnotes
 WHERE item.id = item_circnotes.itemId;

--- a/src/main/resources/templates/db_scripts/populateCirculationNoteIds.sql
+++ b/src/main/resources/templates/db_scripts/populateCirculationNoteIds.sql
@@ -1,22 +1,14 @@
-WITH item_circnotes as (
-	SELECT itemId, ARRAY_AGG(circNote) AS circNotes FROM (
-	  SELECT item.id AS itemId, CASE
-	  WHEN circulationNote ->> 'id' IS NULL
-		  THEN jsonb_build_object(
-			  'id', gen_random_uuid(),
-			  'noteType' ,circulationNote ->> 'noteType',
-			  'note', circulationNote ->> 'note',
-			  'source', circulationNote ->> 'source',
-			  'date', circulationNote ->> 'date',
-			  'staffOnly', circulationNote ->> 'staffOnly')
-		  ELSE jsonb_build_object(
-			  'id', circulationNote ->> 'id',
-			  'noteType' ,circulationNote ->> 'noteType',
-			  'note', circulationNote ->> 'note',
-			  'source', circulationNote ->> 'source',
-			  'date', circulationNote ->> 'date',
-			  'staffOnly', circulationNote ->> 'staffOnly')
-		  END as circNote
+DROP EXTENSION "uuid-ossp";
+CREATE EXTENSION "uuid-ossp";
+
+--Update circulationNotes of item only if there is at least one circulationNote with id equals null
+WITH item_circnotes AS (
+  SELECT itemId, ARRAY_AGG(circNote) AS circNotes, BOOL_OR(changed) AS changed
+  FROM (
+    SELECT
+      item.id AS itemId,
+      CASE WHEN circulationNote ->> 'id' IS NULL THEN jsonb_set(circulationNote, '{id}', to_jsonb(uuid_generate_v4())) ELSE circulationNote END AS circNote,
+      CASE WHEN circulationNote ->> 'id' IS NULL THEN true ELSE false END AS changed
     FROM ${myuniversity}_${mymodule}.item, jsonb_array_elements((jsonb ->> 'circulationNotes')::jsonb) WITH ORDINALITY arr(circulationNote, index)
   ) AS tableA
   GROUP BY itemId
@@ -24,4 +16,4 @@ WITH item_circnotes as (
 UPDATE ${myuniversity}_${mymodule}.item
 SET jsonb = jsonb_set(jsonb, '{circulationNotes}', to_jsonb(item_circnotes.circNotes))
 FROM item_circnotes
-WHERE item.id = item_circnotes.itemId;
+WHERE item.id = item_circnotes.itemId AND item_circnotes.changed;

--- a/src/main/resources/templates/db_scripts/populateCirculationNoteIds.sql
+++ b/src/main/resources/templates/db_scripts/populateCirculationNoteIds.sql
@@ -1,5 +1,4 @@
-DROP EXTENSION "uuid-ossp";
-CREATE EXTENSION "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
 --Update circulationNotes of item only if there is at least one circulationNote with id equals null
 WITH item_circnotes AS (

--- a/src/main/resources/templates/db_scripts/populateCirculationNoteIds.sql
+++ b/src/main/resources/templates/db_scripts/populateCirculationNoteIds.sql
@@ -1,4 +1,4 @@
-CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp" WITH SCHEMA public;
 
 --Update circulationNotes of item only if there is at least one circulationNote with id equals null
 WITH item_circnotes AS (
@@ -6,7 +6,7 @@ WITH item_circnotes AS (
   FROM (
     SELECT
       item.id AS itemId,
-      CASE WHEN circulationNote ->> 'id' IS NULL THEN jsonb_set(circulationNote, '{id}', to_jsonb(uuid_generate_v4())) ELSE circulationNote END AS circNote,
+      CASE WHEN circulationNote ->> 'id' IS NULL THEN jsonb_set(circulationNote, '{id}', to_jsonb(public.uuid_generate_v4())) ELSE circulationNote END AS circNote,
       CASE WHEN circulationNote ->> 'id' IS NULL THEN true ELSE false END AS changed
     FROM ${myuniversity}_${mymodule}.item, jsonb_array_elements((jsonb ->> 'circulationNotes')::jsonb) WITH ORDINALITY arr(circulationNote, index)
   ) AS tableA

--- a/src/main/resources/templates/db_scripts/populateCirculationNoteIds.sql
+++ b/src/main/resources/templates/db_scripts/populateCirculationNoteIds.sql
@@ -1,0 +1,27 @@
+WITH item_circnotes as (
+	SELECT itemId, ARRAY_AGG(circNote) AS circNotes FROM (
+	  SELECT item.id AS itemId, CASE
+	  WHEN circulationNote ->> 'id' IS NULL
+		  THEN jsonb_build_object(
+			  'id', gen_random_uuid(),
+			  'noteType' ,circulationNote ->> 'noteType',
+			  'note', circulationNote ->> 'note',
+			  'source', circulationNote ->> 'source',
+			  'date', circulationNote ->> 'date',
+			  'staffOnly', circulationNote ->> 'staffOnly')
+		  ELSE jsonb_build_object(
+			  'id', circulationNote ->> 'id',
+			  'noteType' ,circulationNote ->> 'noteType',
+			  'note', circulationNote ->> 'note',
+			  'source', circulationNote ->> 'source',
+			  'date', circulationNote ->> 'date',
+			  'staffOnly', circulationNote ->> 'staffOnly')
+		  END as circNote
+    FROM ${myuniversity}_${mymodule}.item, jsonb_array_elements((jsonb ->> 'circulationNotes')::jsonb) WITH ORDINALITY arr(circulationNote, index)
+  ) AS tableA
+  GROUP BY itemId
+)
+UPDATE ${myuniversity}_${mymodule}.item
+SET jsonb = jsonb_set(jsonb, '{circulationNotes}', json_build_array(item_circnotes.circNotes)::jsonb)
+FROM item_circnotes
+WHERE item.id = item_circnotes.itemId;

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1125,6 +1125,11 @@
       "run": "after",
       "snippetPath": "hridSettingsView.sql",
       "fromModuleVersion": "26.1.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "populateCirculationNoteIds.sql",
+      "fromModuleVersion": "26.1.0"
     }
   ]
 }


### PR DESCRIPTION
**Resolves**
[MODINVSTOR-1096](https://issues.folio.org/browse/MODINVSTOR-1096) Items with multiple circulation notes that do not have an id cannot be updated

**Approach**
See Analysis in [MODFISTO-215](https://issues.folio.org/browse/MODFISTO-215) ticket, and [PR](https://github.com/folio-org/mod-finance-storage/pull/214/files):
- Why we need _uuid-ossp extension_
- When we can use _uuid_generate_v4()_ or _uuid_generate_v5()_