### PR TITLE
MODINVSTOR-1099: Remove authorities permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1331,36 +1331,6 @@
       "description": "delete an instance relationship"
     },
     {
-      "permissionName": "inventory-storage.authorities.collection.get",
-      "displayName": "inventory storage - get authority collection",
-      "description": "get authority collection from the storage"
-    },
-    {
-      "permissionName": "inventory-storage.authorities.collection.delete",
-      "displayName": "inventory storage - delete entire authority collection",
-      "description": "delete entire authority collection from the storage"
-    },
-    {
-      "permissionName": "inventory-storage.authorities.item.get",
-      "displayName": "inventory storage - get individual authority record",
-      "description": "get individual authority record from the storage"
-    },
-    {
-      "permissionName": "inventory-storage.authorities.item.post",
-      "displayName": "inventory storage - create individual authority record",
-      "description": "create individual authority record in the storage"
-    },
-    {
-      "permissionName": "inventory-storage.authorities.item.put",
-      "displayName": "inventory storage - modify authority record",
-      "description": "modify authority record in the storage"
-    },
-    {
-      "permissionName": "inventory-storage.authorities.item.delete",
-      "displayName": "inventory storage - delete individual authority record",
-      "description": "delete individual authority record from the storage"
-    },
-    {
       "permissionName": "inventory-storage.items.collection.get",
       "displayName": "inventory storage - get item collection",
       "description": "get item collection from storage"
@@ -2467,12 +2437,6 @@
         "inventory-storage.items.collection.delete",
         "inventory-storage.items.batch.post",
         "inventory-storage.items.batch-unsafe.post",
-        "inventory-storage.authorities.collection.get",
-        "inventory-storage.authorities.item.get",
-        "inventory-storage.authorities.item.post",
-        "inventory-storage.authorities.item.put",
-        "inventory-storage.authorities.item.delete",
-        "inventory-storage.authorities.collection.delete",
         "inventory-storage.holdings.collection.get",
         "inventory-storage.holdings.item.get",
         "inventory-storage.holdings.item.post",


### PR DESCRIPTION
The APIs the authorities permissions belong to have been moved to mod-entities-links:

https://issues.folio.org/browse/MODINVSTOR-1099
https://issues.folio.org/browse/MODELINKS-108