### PR TITLE
MODINVSTOR-1092 Sporadic test failure: ReindexJobRunnerTest.canGetAll…

### DIFF
--- a/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
+++ b/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
@@ -14,6 +14,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
@@ -110,9 +111,10 @@ public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
 
     var jobs = instanceReindex.getReindexJobs();
 
-    assertThat(jobs.getReindexJobs().get(0).getPublished(), is(0));
-    assertThat(jobs.getReindexJobs().get(0).getJobStatus(), is(IDS_PUBLISHED));
-    assertThat(jobs.getTotalRecords(), notNullValue());
+    assertAll("jobs",
+      () -> assertThat(jobs.getReindexJobs().get(0).getPublished(), is(numberOfRecords)),
+      () -> assertThat(jobs.getReindexJobs().get(0).getJobStatus(), is(IDS_PUBLISHED)),
+      () -> assertThat(jobs.getTotalRecords(), notNullValue()));
 
     instanceMessageChecks.countOfAllPublishedInstancesIs(
       greaterThanOrEqualTo(numberOfRecords));


### PR DESCRIPTION
## Purpose
_Fix falling test ReindexJobRunnerTest.canGetAllInstancesReindexJobs_

## Approach

1.  From my point of view there was the wrong assertion. Because from my point of view I can't see the way how number of published could be other then 2.
2. On local environment the test always gets fail.

### Changes checklist
- [ ] API paths, methods, request or response bodies changed, added, or removed
- [ ] Database schema changes
- [ ] Interface versions changes
- [ ] Interface dependencies added, or removed
- [ ] Permissions changed, added, or removed
- [ ] Check logging.

### Learning
[_MODINVSTOR-1092_](https://issues.folio.org/browse/MODINVSTOR-1092)