### PR TITLE
MODINVSTOR-1103 - Ad hoc Shadow Instance creation when adding a Holdings to a Shared Instance

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 * disables `authority-storage`, `authority-source-files`, `authority-note-types` and `authority-reindex` APIs. They are not supported by this module anymore. [MODINVSTOR-1099](https://issues.folio.org/browse/MODINVSTOR-1099)
 * Added new column complete_updated_date into INSTANCE table that will be used in mod-oai-pmh module: [MODINVSTOR-1105](https://issues.folio.org/browse/MODINVSTOR-1105)
 * Shadow Instance Synchronization [MODINVSTOR-1076](https://issues.folio.org/browse/MODINVSTOR-1076)
+* Ad hoc Shadow Instance creation when adding a Holdings to a Shared Instance [MODINVSTOR-1103](https://issues.folio.org/browse/MODINVSTOR-1103)
 
 ## 25.0.0 2022-10-25
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -117,7 +117,11 @@
         {
           "methods": ["POST"],
           "pathPattern": "/holdings-storage/batch/synchronous",
-          "permissionsRequired": ["inventory-storage.holdings.batch.post"]
+          "permissionsRequired": ["inventory-storage.holdings.batch.post"],
+          "modulePermissions": [
+            "user-tenants.collection.get",
+            "consortia.sharing-instances.item.post"
+          ]
         }
       ]
     },
@@ -128,7 +132,11 @@
         {
           "methods": ["POST"],
           "pathPattern": "/holdings-storage/batch/synchronous-unsafe",
-          "permissionsRequired": ["inventory-storage.holdings.batch-unsafe.post"]
+          "permissionsRequired": ["inventory-storage.holdings.batch-unsafe.post"],
+          "modulePermissions": [
+            "user-tenants.collection.get",
+            "consortia.sharing-instances.item.post"
+          ]
         }
       ]
     },

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -90,7 +90,11 @@
         }, {
           "methods": ["POST"],
           "pathPattern": "/holdings-storage/holdings",
-          "permissionsRequired": ["inventory-storage.holdings.item.post"]
+          "permissionsRequired": ["inventory-storage.holdings.item.post"],
+          "modulePermissions": [
+            "user-tenants.collection.get",
+            "consortia.sharing-instances.item.post"
+          ]
         }, {
           "methods": ["PUT"],
           "pathPattern": "/holdings-storage/holdings/{id}",

--- a/src/test/java/org/folio/rest/InstallUpgradeIT.java
+++ b/src/test/java/org/folio/rest/InstallUpgradeIT.java
@@ -46,11 +46,7 @@ import org.testcontainers.utility.DockerImageName;
  */
 public class InstallUpgradeIT {
 
-  private static final Logger LOG = LoggerFactory.getLogger(InstallUpgradeIT.class);
-  private static final boolean IS_LOG_ENABLED = false;
-  private static final Network NETWORK = Network.newNetwork();
-  private static final String USER_TENANTS_PATH = "/user-tenants?limit=1";
-  private static final String USER_TENANTS_FIELD = "userTenants";
+  public static final Network NETWORK = Network.newNetwork();
 
   @ClassRule(order = 0)
   public static final KafkaContainer KAFKA =
@@ -89,6 +85,11 @@ public class InstallUpgradeIT {
       .withEnv("DB_DATABASE", "postgres")
       .withEnv("KAFKA_HOST", "mykafka")
       .withEnv("KAFKA_PORT", "9092");
+
+  private static final Logger LOG = LoggerFactory.getLogger(InstallUpgradeIT.class);
+  private static final boolean IS_LOG_ENABLED = false;
+  private static final String USER_TENANTS_PATH = "/user-tenants?limit=1";
+  private static final String USER_TENANTS_FIELD = "userTenants";
 
   @BeforeClass
   public static void beforeClass() {

--- a/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
+++ b/src/test/java/org/folio/rest/api/BoundWithStorageTest.java
@@ -12,10 +12,12 @@ import java.net.HttpURLConnection;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import junitparams.JUnitParamsRunner;
 import lombok.SneakyThrows;
+import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
@@ -418,10 +420,11 @@ public class BoundWithStorageTest extends TestBaseWithInventoryUtil {
   }
 
   private IndividualResource createHoldingsRecord(UUID instanceId) {
-    return holdingsClient.create(
-      new HoldingRequestBuilder()
-        .forInstance(instanceId)
-        .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID));
+    HoldingRequestBuilder holdingRequestBuilder = new HoldingRequestBuilder()
+      .forInstance(instanceId)
+      .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID);
+    return holdingsClient.create(holdingRequestBuilder.create(), TENANT_ID,
+      Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
   }
 
   private IndividualResource createItem(UUID holdingsRecordId) {

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -53,7 +53,6 @@ import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
@@ -123,7 +122,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   @SneakyThrows
   @BeforeClass
   public static void beforeClass() {
-    prepareTenant(CONSORTIUM_MEMBER_TENANT, true);
+    prepareTenant(CONSORTIUM_MEMBER_TENANT, false);
 
     StorageTestSuite.deleteAll(CONSORTIUM_MEMBER_TENANT, "preceding_succeeding_title");
     StorageTestSuite.deleteAll(CONSORTIUM_MEMBER_TENANT, "instance_relationship");
@@ -191,7 +190,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     holdingToCreate.put("administrativeNotes", new JsonArray().add(adminNote));
 
-    JsonObject holding = holdingsClient.create(holdingToCreate).getJson();
+    JsonObject holding = postHoldingsRecord(holdingToCreate).getJson();
 
     assertThat(holding.getString("id"), is(holdingId.toString()));
     assertThat(holding.getString("instanceId"), is(instanceId.toString()));
@@ -217,21 +216,21 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(tags.size(), is(1));
     assertThat(tags, hasItem(TAG_VALUE));
 
-    holdingsMessageChecks.createdMessagePublished(holding);
+    holdingsMessageChecks.createdMessagePublished(holding, TENANT_ID, mockServer.baseUrl());
   }
 
   @Test
   public void canCreateHoldingWithoutProvidingAnId() {
-
     UUID instanceId = UUID.randomUUID();
 
     instancesClient.create(smallAngryPlanet(instanceId));
 
-    IndividualResource holdingResponse = holdingsClient.create(new HoldingRequestBuilder()
+    HoldingRequestBuilder holdingBuilder = new HoldingRequestBuilder()
       .withId(null)
       .forInstance(instanceId)
       .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)
-      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE))));
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)));
+    IndividualResource holdingResponse = postHoldingsRecord(holdingBuilder.create());
 
     JsonObject holding = holdingResponse.getJson();
 
@@ -408,9 +407,11 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     instancesClient.create(smallAngryPlanet(newInstanceId));
     setHoldingsSequence(1);
 
-    IndividualResource holdingResource = holdingsClient.create(new HoldingRequestBuilder()
+    JsonObject holdingToCreate = new HoldingRequestBuilder()
       .forInstance(instanceId)
-      .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID));
+      .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)
+      .create();
+    IndividualResource holdingResource = postHoldingsRecord(holdingToCreate);
 
     UUID holdingId = holdingResource.getId();
 
@@ -510,9 +511,10 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     instancesClient.create(smallAngryPlanet(instanceId));
 
-    holdingsClient.create(new HoldingRequestBuilder()
+    postHoldingsRecord(new HoldingRequestBuilder()
       .forInstance(instanceId)
-      .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)).getId();
+      .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)
+      .create());
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 
@@ -674,26 +676,31 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     instancesClient.create(smallAngryPlanet(instanceId1));
     instancesClient.create(nod(instanceId2));
 
-    final var h1 = holdingsClient.create(new HoldingRequestBuilder()
+    final var h1 = postHoldingsRecord(new HoldingRequestBuilder()
       .forInstance(instanceId1)
       .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)
-      .withHrid("1234")).getJson();
-    final var h2 = holdingsClient.create(new HoldingRequestBuilder()
+      .withHrid("1234")
+      .create()).getJson();
+    final var h2 = postHoldingsRecord(new HoldingRequestBuilder()
       .forInstance(instanceId1)
       .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)
-      .withHrid("21234")).getJson();
-    final var h3 = holdingsClient.create(new HoldingRequestBuilder()
+      .withHrid("21234")
+      .create()).getJson();
+    final var h3 = postHoldingsRecord(new HoldingRequestBuilder()
       .forInstance(instanceId2)
       .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)
-      .withHrid("12")).getJson();
-    final var h4 = holdingsClient.create(new HoldingRequestBuilder()
+      .withHrid("12")
+      .create()).getJson();
+    final var h4 = postHoldingsRecord(new HoldingRequestBuilder()
       .forInstance(instanceId2)
       .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)
-      .withHrid("3123")).getJson();
-    final var h5 = holdingsClient.create(new HoldingRequestBuilder()
+      .withHrid("3123")
+      .create()).getJson();
+    final var h5 = postHoldingsRecord(new HoldingRequestBuilder()
       .forInstance(instanceId2)
       .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)
-      .withHrid("123")).getJson();
+      .withHrid("123")
+      .create()).getJson();
 
     var response = getClient().delete(holdingsStorageUrl("?query=hrid==12*"), TENANT_ID).get(10, SECONDS);
 
@@ -857,11 +864,12 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     instancesClient.create(smallAngryPlanet(instanceId));
     setHoldingsSequence(1);
 
-    JsonObject holding = holdingsClient.create(new HoldingRequestBuilder()
+    JsonObject holding = postHoldingsRecord(new HoldingRequestBuilder()
       .withId(holdingId)
       .forInstance(instanceId)
       .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)
-      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getJson();
+      .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))
+      .create()).getJson();
 
     assertThat(holding.getString("effectiveLocationId"), is(MAIN_LIBRARY_LOCATION_ID.toString()));
 
@@ -1008,8 +1016,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void updatingHoldingsUpdatesItemEffectiveCallNumber()
-    throws MalformedURLException, InterruptedException,
-    ExecutionException, TimeoutException {
+    throws InterruptedException, ExecutionException, TimeoutException {
 
     UUID instanceId = UUID.randomUUID();
 
@@ -2376,6 +2383,32 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  public void canCreateHoldingAndCreateShadowInstance() {
+    log.info("Starting canCreateHoldingAndCreateShadowInstance");
+    mockSharingInstance();
+
+    UUID instanceId = UUID.randomUUID();
+    HoldingRequestBuilder builder = new HoldingRequestBuilder()
+      .withId(null)
+      .forInstance(instanceId)
+      .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID);
+
+    JsonObject holding = holdingsClient.create(builder.create(), CONSORTIUM_MEMBER_TENANT,
+      Map.of(X_OKAPI_URL, mockServer.baseUrl())).getJson();
+
+    assertThat(holding.getString("id"), is(notNullValue()));
+    assertThat(holding.getString("instanceId"), is(instanceId.toString()));
+    assertThat(holding.getString("permanentLocationId"), is(MAIN_LIBRARY_LOCATION_ID.toString()));
+    assertExists(holding, CONSORTIUM_MEMBER_TENANT);
+
+    holdingsMessageChecks.createdMessagePublished(
+      getById(holding.getString("id"), CONSORTIUM_MEMBER_TENANT).getJson(),
+      CONSORTIUM_MEMBER_TENANT, mockServer.baseUrl());
+
+    log.info("Finished canCreateHoldingAndCreateShadowInstance");
+  }
+
+  @Test
   public void canPostSynchronousBatchWithGeneratedHrid() {
     log.info("Starting canPostSynchronousBatchWithGeneratedHRID");
 
@@ -3076,6 +3109,10 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
         .put("status", new JsonObject().put("name", "Available")));
     }
     return items;
+  }
+
+  private IndividualResource postHoldingsRecord(JsonObject holdingsRecord) {
+    return holdingsClient.create(holdingsRecord, TENANT_ID, Map.of(X_OKAPI_URL, mockServer.baseUrl()));
   }
 
   private Response postSynchronousBatchUnsafe(JsonArray holdingsArray) {

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -113,7 +113,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   @SneakyThrows
   @BeforeClass
   public static void beforeClass() {
-    prepareTenant(CONSORTIUM_MEMBER_TENANT, true);
+    prepareTenant(CONSORTIUM_MEMBER_TENANT, false);
 
     StorageTestSuite.deleteAll(CONSORTIUM_MEMBER_TENANT, "preceding_succeeding_title");
     StorageTestSuite.deleteAll(CONSORTIUM_MEMBER_TENANT, "instance_relationship");
@@ -3330,14 +3330,6 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     WireMock.stubFor(WireMock.get(USER_TENANTS_PATH)
       .withHeader(X_OKAPI_TENANT, equalToIgnoreCase(CONSORTIUM_MEMBER_TENANT))
       .willReturn(WireMock.ok().withBody(userTenantsCollection.encodePrettily())));
-  }
-
-  private void mockUserTenantsForNonConsortiumMember() {
-    JsonObject emptyUserTenantsCollection = new JsonObject()
-      .put("userTenants", JsonArray.of());
-    WireMock.stubFor(WireMock.get(USER_TENANTS_PATH)
-      .withHeader(X_OKAPI_TENANT, equalToIgnoreCase(TENANT_ID))
-      .willReturn(WireMock.ok().withBody(emptyUserTenantsCollection.encodePrettily())));
   }
 
   private void mockSharingInstance() {

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -3343,8 +3343,8 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     @SneakyThrows
     @Override
     public com.github.tomakehurst.wiremock.http.Response transform(Request request,
-        com.github.tomakehurst.wiremock.http.Response response, FileSource fileSource,
-        com.github.tomakehurst.wiremock.extension.Parameters parameters) {
+       com.github.tomakehurst.wiremock.http.Response response, FileSource fileSource,
+       com.github.tomakehurst.wiremock.extension.Parameters parameters) {
 
       SharingInstance sharingInstance = Json.getObjectMapper().readValue(request.getBody(),
         SharingInstance.class);

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -43,13 +43,10 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.fail;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
-import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
 import com.github.tomakehurst.wiremock.common.FileSource;
 import com.github.tomakehurst.wiremock.common.Json;
-import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
 import com.github.tomakehurst.wiremock.extension.ResponseTransformer;
 import com.github.tomakehurst.wiremock.http.Request;
-import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.net.HttpURLConnection;
@@ -94,18 +91,12 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
-import org.junit.ClassRule;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(JUnitParamsRunner.class)
 public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
-  @ClassRule
-  public static WireMockRule mockServer = new WireMockRule(WireMockConfiguration.wireMockConfig()
-    .notifier(new ConsoleNotifier(false))
-    .dynamicPort()
-    .extensions(ConsortiumInstanceSharingTransformer.class));
   public static final String NEW_TEST_TAG = "new test tag";
   private static final Logger log = LogManager.getLogger();
   private static final String TAG_VALUE = "test-tag";
@@ -122,7 +113,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   @SneakyThrows
   @BeforeClass
   public static void beforeClass() {
-    prepareTenant(CONSORTIUM_MEMBER_TENANT, false);
+    prepareTenant(CONSORTIUM_MEMBER_TENANT, true);
 
     StorageTestSuite.deleteAll(CONSORTIUM_MEMBER_TENANT, "preceding_succeeding_title");
     StorageTestSuite.deleteAll(CONSORTIUM_MEMBER_TENANT, "instance_relationship");
@@ -2309,7 +2300,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
     assertThat(response.getBody(),
       is("ERROR: Cannot change hrid of holdings record id=" + holdingsId
-          + ", old hrid=ho00000000001, new hrid=ABC123 (239HR)"));
+        + ", old hrid=ho00000000001, new hrid=ABC123 (239HR)"));
 
     log.info("Finished cannotChangeHRIDAfterCreation");
   }
@@ -2639,7 +2630,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       final JsonObject holding = (JsonObject) hrObj;
       assertExists(holding, CONSORTIUM_MEMBER_TENANT);
       holdingsMessageChecks.createdMessagePublished(getById(holding.getString("id"),
-          CONSORTIUM_MEMBER_TENANT).getJson(), CONSORTIUM_MEMBER_TENANT, mockServer.baseUrl());
+        CONSORTIUM_MEMBER_TENANT).getJson(), CONSORTIUM_MEMBER_TENANT, mockServer.baseUrl());
     }
   }
 
@@ -2668,7 +2659,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       assertExists(holding, CONSORTIUM_MEMBER_TENANT);
 
       holdingsMessageChecks.createdMessagePublished(getById(holding.getString("id"),
-          CONSORTIUM_MEMBER_TENANT).getJson(), CONSORTIUM_MEMBER_TENANT, mockServer.baseUrl());
+        CONSORTIUM_MEMBER_TENANT).getJson(), CONSORTIUM_MEMBER_TENANT, mockServer.baseUrl());
     }
   }
 
@@ -2693,7 +2684,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       assertExists(holding, CONSORTIUM_MEMBER_TENANT);
 
       holdingsMessageChecks.createdMessagePublished(getById(holding.getString("id"),
-          CONSORTIUM_MEMBER_TENANT).getJson(), CONSORTIUM_MEMBER_TENANT, mockServer.baseUrl());
+        CONSORTIUM_MEMBER_TENANT).getJson(), CONSORTIUM_MEMBER_TENANT, mockServer.baseUrl());
     }
   }
 
@@ -2805,9 +2796,9 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     final Response itemResponse = postItemSynchronousBatch("?upsert=true", items);
     assertThat(itemResponse, statusCodeIs(HTTP_CREATED));
 
-    assertItemEffectiveCallNumbers(items, "prefix",     "hcnp", "icnp", "icnp", "icnp", "hcnp", "icnp");
-    assertItemEffectiveCallNumbers(items, "callNumber", "hcn",  "icn",  "icn",  "icn",  "hcn",  "icn");
-    assertItemEffectiveCallNumbers(items, "suffix",     "hcns", "icns", "icns", "icns", "hcns", "icns");
+    assertItemEffectiveCallNumbers(items, "prefix", "hcnp", "icnp", "icnp", "icnp", "hcnp", "icnp");
+    assertItemEffectiveCallNumbers(items, "callNumber", "hcn", "icn", "icn", "icn", "hcn", "icn");
+    assertItemEffectiveCallNumbers(items, "suffix", "hcns", "icns", "icns", "icns", "hcns", "icns");
 
     for (int i = 0; i < 3; i++) {
       if (i == 0 || i == 1) {
@@ -2820,9 +2811,9 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     final Response response2 = postSynchronousBatch("?upsert=true", holdings);
     assertThat(response2, statusCodeIs(HTTP_CREATED));
 
-    assertItemEffectiveCallNumbers(items, "prefix",     "xcnp", "icnp", "icnp", "icnp", "hcnp", "icnp");
-    assertItemEffectiveCallNumbers(items, "callNumber", "xcn",  "icn",  "icn",  "icn",  "hcn",  "icn");
-    assertItemEffectiveCallNumbers(items, "suffix",     "xcns", "icns", "icns", "icns", "hcns", "icns");
+    assertItemEffectiveCallNumbers(items, "prefix", "xcnp", "icnp", "icnp", "icnp", "hcnp", "icnp");
+    assertItemEffectiveCallNumbers(items, "callNumber", "xcn", "icn", "icn", "icn", "hcn", "icn");
+    assertItemEffectiveCallNumbers(items, "suffix", "xcns", "icns", "icns", "icns", "hcns", "icns");
   }
 
   @Test
@@ -3239,11 +3230,11 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
    * Fetch the item using the id from items.
    */
   private void assertItemEffectiveCallNumbers(JsonArray items, String property,
-      String n1, String n2, String n3, String n4, String n5, String n6) {
+                                              String n1, String n2, String n3, String n4, String n5, String n6) {
 
     var actual = fetchItems(items).stream()
-        .map(item -> item.getJsonObject("effectiveCallNumberComponents").getString(property))
-        .collect(Collectors.toList());
+      .map(item -> item.getJsonObject("effectiveCallNumberComponents").getString(property))
+      .collect(Collectors.toList());
     assertThat(actual, is(List.of(n1, n2, n3, n4, n5, n6)));
   }
 
@@ -3360,8 +3351,8 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     @SneakyThrows
     @Override
     public com.github.tomakehurst.wiremock.http.Response transform(Request request,
-       com.github.tomakehurst.wiremock.http.Response response, FileSource fileSource,
-       com.github.tomakehurst.wiremock.extension.Parameters parameters) {
+        com.github.tomakehurst.wiremock.http.Response response, FileSource fileSource,
+        com.github.tomakehurst.wiremock.extension.Parameters parameters) {
 
       SharingInstance sharingInstance = Json.getObjectMapper().readValue(request.getBody(),
         SharingInstance.class);

--- a/src/test/java/org/folio/rest/api/InstanceDomainEventTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceDomainEventTest.java
@@ -4,12 +4,15 @@ import static org.folio.rest.api.InstanceStorageTest.smallAngryPlanet;
 import static org.folio.rest.support.http.InterfaceUrls.holdingsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
+import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.vertx.core.json.JsonObject;
+import java.util.Map;
 import java.util.UUID;
 import lombok.SneakyThrows;
+import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.messages.InstanceEventMessageChecks;
@@ -64,9 +67,11 @@ public class InstanceDomainEventTest extends TestBaseWithInventoryUtil {
     final var instance = instancesClient.create(
       smallAngryPlanet(UUID.randomUUID()));
     // create a holding so that instance is not allowed to be removed
-    holdingsClient.create(new HoldingRequestBuilder()
+    HoldingRequestBuilder holdingBuilder = new HoldingRequestBuilder()
       .forInstance(instance.getId())
-      .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID));
+      .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID);
+    holdingsClient.create(holdingBuilder.create(), TENANT_ID,
+      Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
 
     final Response removeResponse = instancesClient.attemptToDelete(instance.getId());
 
@@ -82,9 +87,11 @@ public class InstanceDomainEventTest extends TestBaseWithInventoryUtil {
     instancesClient.create(smallAngryPlanet(UUID.randomUUID()));
 
     // create a holding so that instance is not allowed to be removed
-    holdingsClient.create(new HoldingRequestBuilder()
+    HoldingRequestBuilder holdingBuilder = new HoldingRequestBuilder()
       .forInstance(instance.getId())
-      .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID));
+      .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID);
+    holdingsClient.create(holdingBuilder.create(), TENANT_ID,
+      Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
 
     final Response removeResponse = instancesClient.attemptDeleteAll();
 

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -52,7 +52,6 @@ import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
 import java.io.IOException;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -77,6 +76,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.HttpStatus;
+import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Instance;
 import org.folio.rest.jaxrs.model.InstancesBatchResponse;
@@ -256,8 +256,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void canCreateAnInstanceWithoutProvidingId()
-    throws MalformedURLException,
-    InterruptedException,
+    throws InterruptedException,
     ExecutionException,
     TimeoutException {
 
@@ -295,8 +294,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void cannotCreateAnInstanceWithIdThatIsNotUuid()
-    throws MalformedURLException,
-    InterruptedException,
+    throws InterruptedException,
     ExecutionException,
     TimeoutException {
 
@@ -331,10 +329,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void cannotPutAnInstanceAtNonexistingLocation()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+    throws InterruptedException, ExecutionException, TimeoutException {
 
     UUID id = UUID.randomUUID();
 
@@ -430,10 +425,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void cannotProvideAdditionalPropertiesInInstance()
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
+    throws InterruptedException, TimeoutException, ExecutionException {
 
     JsonObject requestWithAdditionalProperty = nod(UUID.randomUUID());
 
@@ -452,10 +444,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void cannotProvideAdditionalPropertiesInInstanceIdentifiers()
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
+    throws InterruptedException, TimeoutException, ExecutionException {
 
     JsonObject requestWithAdditionalProperty = nod(UUID.randomUUID());
 
@@ -590,11 +579,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canGetInstanceById()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+  public void canGetInstanceById() throws InterruptedException, ExecutionException, TimeoutException {
 
     UUID id = UUID.randomUUID();
 
@@ -622,11 +607,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canGetAllInstances()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+  public void canGetAllInstances() throws InterruptedException, ExecutionException, TimeoutException {
 
     UUID firstInstanceId = UUID.randomUUID();
 
@@ -682,10 +663,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void canSearchByClassificationNumberWithoutArrayModifier()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+    throws InterruptedException, ExecutionException, TimeoutException {
 
     createInstancesWithClassificationNumbers();
 
@@ -698,10 +676,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void canSearchUsingMetadataDateUpdatedIndex()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+    throws InterruptedException, ExecutionException, TimeoutException {
 
     UUID firstInstanceId = UUID.randomUUID();
 
@@ -738,11 +713,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void canPageAllInstances()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+  public void canPageAllInstances() throws InterruptedException, ExecutionException, TimeoutException {
 
     createInstance(smallAngryPlanet(UUID.randomUUID()));
     createInstance(nod(UUID.randomUUID()));
@@ -780,10 +751,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void canProvideLargePageOffsetAndLimit()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+    throws InterruptedException, ExecutionException, TimeoutException {
 
     createInstance(smallAngryPlanet(UUID.randomUUID()));
     createInstance(nod(UUID.randomUUID()));
@@ -1133,10 +1101,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     matchInstanceTitles(searchForInstances("subjects=\"abc xyz\""));
   }
 
+  //todo
   @Test
   public void canSearchByBarcode()
     throws InterruptedException,
-    MalformedURLException,
     TimeoutException,
     ExecutionException {
 
@@ -1181,12 +1149,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   // This is intended to demonstrate usage of the two different views
+  // todo
   @Test
   public void canSearchByBarcodeAndPermanentLocation()
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
+    throws InterruptedException, TimeoutException, ExecutionException {
 
     UUID smallAngryPlanetInstanceId = UUID.randomUUID();
     UUID mainLibrarySmallAngryHoldingId = UUID.randomUUID();
@@ -1251,12 +1217,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
   // This is intended to demonstrate that instances without holdings or items
   // are not excluded from searching
+  //todo
   @Test
   public void canSearchByTitleAndBarcodeWithMissingHoldingsAndItemsAndStillGetInstances()
-    throws InterruptedException,
-    MalformedURLException,
-    TimeoutException,
-    ExecutionException {
+    throws InterruptedException, TimeoutException, ExecutionException {
 
     UUID smallAngryPlanetInstanceId = UUID.randomUUID();
     UUID mainLibrarySmallAngryHoldingId = UUID.randomUUID();
@@ -1683,10 +1647,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void shouldReturnErrorResponseIfAllInstancesFailed()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+    throws InterruptedException, ExecutionException, TimeoutException {
 
     JsonObject errorInstance = smallAngryPlanet(null).put("modeOfIssuanceId", UUID.randomUUID().toString());
 
@@ -2327,10 +2288,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void canCreateCollectionOfInstancesWithGeneratedHrids()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+    throws InterruptedException, ExecutionException, TimeoutException {
     log.info("Starting canCreateACollectionOfInstancesWithGeneratedHRIDs");
 
     final JsonArray instancesArray = new JsonArray();
@@ -2908,15 +2866,14 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   private void createHoldings(JsonObject holdingsToCreate)
-    throws MalformedURLException,
-    InterruptedException,
+    throws InterruptedException,
     ExecutionException,
     TimeoutException {
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
     getClient().post(holdingsStorageUrl(""), holdingsToCreate,
-      TENANT_ID, json(createCompleted));
+      Map.of(XOkapiHeaders.URL, mockServer.baseUrl()), TENANT_ID, json(createCompleted));
 
     Response response = createCompleted.get(2, SECONDS);
 

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -1101,7 +1101,6 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     matchInstanceTitles(searchForInstances("subjects=\"abc xyz\""));
   }
 
-  //todo
   @Test
   public void canSearchByBarcode()
     throws InterruptedException,

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -1148,7 +1148,6 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   // This is intended to demonstrate usage of the two different views
-  // todo
   @Test
   public void canSearchByBarcodeAndPermanentLocation()
     throws InterruptedException, TimeoutException, ExecutionException {
@@ -1216,7 +1215,6 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
   // This is intended to demonstrate that instances without holdings or items
   // are not excluded from searching
-  //todo
   @Test
   public void canSearchByTitleAndBarcodeWithMissingHoldingsAndItemsAndStillGetInstances()
     throws InterruptedException, TimeoutException, ExecutionException {

--- a/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
@@ -29,7 +29,6 @@ import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.messages.ItemEventMessageChecks;
-import org.folio.utility.RestUtility;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;

--- a/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
@@ -6,6 +6,7 @@ import static org.folio.rest.support.matchers.ItemMatchers.hasCallNumber;
 import static org.folio.rest.support.matchers.ItemMatchers.hasPrefix;
 import static org.folio.rest.support.matchers.ItemMatchers.hasSuffix;
 import static org.folio.rest.support.matchers.ItemMatchers.hasTypeId;
+import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -14,18 +15,21 @@ import static org.junit.Assert.assertNotNull;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.net.HttpURLConnection;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.apache.commons.lang3.StringUtils;
+import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.api.testdata.ItemEffectiveCallNumberComponentsTestData;
 import org.folio.rest.api.testdata.ItemEffectiveCallNumberComponentsTestData.CallNumberComponentPropertyNames;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.messages.ItemEventMessageChecks;
+import org.folio.utility.RestUtility;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -275,13 +279,14 @@ public class ItemEffectiveCallNumberComponentsTest extends TestBaseWithInventory
 
     IndividualResource instance = instancesClient.create(instance(UUID.randomUUID()));
 
-    IndividualResource holdings = holdingsClient.create(new HoldingRequestBuilder()
+    JsonObject holdingToCreate = new HoldingRequestBuilder()
       .withId(UUID.randomUUID())
       .forInstance(instance.getId())
       .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)
       .create()
-      .put(propertyName, propertyValue)
-    );
+      .put(propertyName, propertyValue);
+    IndividualResource holdings =
+      holdingsClient.create(holdingToCreate, TENANT_ID, Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
     assertThat(holdings.getJson().getString(propertyName), is(propertyValue));
 
     return holdings;

--- a/src/test/java/org/folio/rest/api/RecordBulkTest.java
+++ b/src/test/java/org/folio/rest/api/RecordBulkTest.java
@@ -221,10 +221,7 @@ public class RecordBulkTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void canGetHoldingsBulkOfId()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+    throws InterruptedException, ExecutionException, TimeoutException {
 
     int totalHoldingsIds = 2;
     List<String> holdingIds = createAndGetHoldingsIds(totalHoldingsIds);
@@ -240,10 +237,7 @@ public class RecordBulkTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void canGetHoldingsBulkOfIdWithLimitAndOffset()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+    throws InterruptedException, ExecutionException, TimeoutException {
 
     int totalHoldingsIds = 20;
     List<String> holdingIds = createAndGetHoldingsIds(totalHoldingsIds);

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -104,6 +104,14 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     logger.info("finishing @BeforeClass testBaseWithInvUtilBeforeClass()");
   }
 
+  public static void mockUserTenantsForNonConsortiumMember() {
+    JsonObject emptyUserTenantsCollection = new JsonObject()
+      .put("userTenants", JsonArray.of());
+    WireMock.stubFor(WireMock.get(USER_TENANTS_PATH)
+      .withHeader(XOkapiHeaders.TENANT, equalToIgnoreCase(TENANT_ID))
+      .willReturn(WireMock.ok().withBody(emptyUserTenantsCollection.encodePrettily())));
+  }
+
   protected static void setupMaterialTypes() {
     setupMaterialTypes(TENANT_ID);
   }
@@ -355,13 +363,5 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
       .getJsonArray("instanceStatuses").getJsonObject(0);
 
     return new IndividualResource(instanceStatus);
-  }
-
-  private static void mockUserTenantsForNonConsortiumMember() {
-    JsonObject emptyUserTenantsCollection = new JsonObject()
-      .put("userTenants", JsonArray.of());
-    WireMock.stubFor(WireMock.get(USER_TENANTS_PATH)
-      .withHeader(XOkapiHeaders.TENANT, equalToIgnoreCase(TENANT_ID))
-      .willReturn(WireMock.ok().withBody(emptyUserTenantsCollection.encodePrettily())));
   }
 }

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -166,7 +166,8 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
       .withPermanentLocation(holdingsPermanentLocationId);
 
     return holdingsClient
-      .create(holdingsBuilderProcessor.apply(holdingsBuilder))
+      .create(holdingsBuilderProcessor.apply(holdingsBuilder).create(), TENANT_ID,
+        Map.of(XOkapiHeaders.URL, mockServer.baseUrl()))
       .getId();
   }
 

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -43,7 +43,8 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   @ClassRule
   public static WireMockRule mockServer = new WireMockRule(WireMockConfiguration.wireMockConfig()
     .notifier(new ConsoleNotifier(false))
-    .dynamicPort());
+    .dynamicPort()
+    .extensions(HoldingsStorageTest.ConsortiumInstanceSharingTransformer.class));
 
   public static final String MAIN_LIBRARY_LOCATION = "Main Library";
   public static final String SECOND_FLOOR_LOCATION = "Second Floor";

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -1,5 +1,6 @@
 package org.folio.rest.api;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToIgnoreCase;
 import static org.folio.rest.support.http.InterfaceUrls.instanceStatusesUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.loanTypesStorageUrl;
@@ -9,14 +10,20 @@ import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.common.ConsoleNotifier;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.junit.WireMockRule;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.UnaryOperator;
 import lombok.SneakyThrows;
 import org.folio.HttpStatus;
+import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.jaxrs.model.InstanceType;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.support.IndividualResource;
@@ -28,9 +35,16 @@ import org.folio.rest.support.client.LoanTypesClient;
 import org.folio.rest.support.client.MaterialTypesClient;
 import org.folio.utility.LocationUtility;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 
 
 public abstract class TestBaseWithInventoryUtil extends TestBase {
+
+  @ClassRule
+  public static WireMockRule mockServer = new WireMockRule(WireMockConfiguration.wireMockConfig()
+    .notifier(new ConsoleNotifier(false))
+    .dynamicPort());
+
   public static final String MAIN_LIBRARY_LOCATION = "Main Library";
   public static final String SECOND_FLOOR_LOCATION = "Second Floor";
   public static final String ANNEX_LIBRARY_LOCATION = "Annex Library";
@@ -65,6 +79,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   protected static String canCirculateLoanTypeID;
   protected static UUID nonCirculatingLoanTypeId;
   protected static String nonCirculatingLoanTypeID;
+  private static final String USER_TENANTS_PATH = "/user-tenants?limit=1";
 
   @SneakyThrows
   @BeforeClass
@@ -83,6 +98,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     setupLocations();
 
     KAFKA_CONSUMER.discardAllMessages();
+    mockUserTenantsForNonConsortiumMember();
 
     logger.info("finishing @BeforeClass testBaseWithInvUtilBeforeClass()");
   }
@@ -163,7 +179,8 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
         .forInstance(instanceId)
         .withPermanentLocation(holdingsPermanentLocationId)
         .withTemporaryLocation(holdingsTemporaryLocationId)
-    ).getId();
+        .create(),
+      TENANT_ID, Map.of(XOkapiHeaders.URL, mockServer.baseUrl())).getId();
   }
 
   protected static UUID createInstanceAndHoldingWithCallNumber(UUID holdingsPermanentLocationId) {
@@ -336,5 +353,13 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
       .getJsonArray("instanceStatuses").getJsonObject(0);
 
     return new IndividualResource(instanceStatus);
+  }
+
+  private static void mockUserTenantsForNonConsortiumMember() {
+    JsonObject emptyUserTenantsCollection = new JsonObject()
+      .put("userTenants", JsonArray.of());
+    WireMock.stubFor(WireMock.get(USER_TENANTS_PATH)
+      .withHeader(XOkapiHeaders.TENANT, equalToIgnoreCase(TENANT_ID))
+      .willReturn(WireMock.ok().withBody(emptyUserTenantsCollection.encodePrettily())));
   }
 }

--- a/src/test/java/org/folio/rest/support/http/ResourceClient.java
+++ b/src/test/java/org/folio/rest/support/http/ResourceClient.java
@@ -210,17 +210,7 @@ public final class ResourceClient {
   }
 
   public Response attemptToCreate(String subPath, JsonObject request, String tenantId) {
-
-    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
-
-    try {
-      client.post(urlMaker.combine(subPath), request, tenantId,
-        ResponseHandler.any(createCompleted));
-    } catch (MalformedURLException e) {
-      throw new RuntimeException(subPath + ": " + e.getMessage(), e);
-    }
-
-    return TestBase.get(createCompleted);
+    return attemptToCreate(subPath, request, tenantId, Map.of());
   }
 
   public Response attemptToCreate(String subPath, JsonObject request, String tenantId, Map<String, String> headers) {

--- a/src/test/java/org/folio/rest/support/http/ResourceClient.java
+++ b/src/test/java/org/folio/rest/support/http/ResourceClient.java
@@ -9,6 +9,7 @@ import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -177,8 +178,12 @@ public final class ResourceClient {
   }
 
   public IndividualResource create(JsonObject request, String tenantId) {
+    return create(request, tenantId, Map.of());
+  }
 
-    Response response = attemptToCreate("", request, tenantId);
+  public IndividualResource create(JsonObject request, String tenantId, Map<String, String> headers) {
+
+    Response response = attemptToCreate("", request, tenantId, headers);
 
     assertThat(
       String.format("Failed to create %s: %s", resourceName, response.getBody()),
@@ -210,6 +215,20 @@ public final class ResourceClient {
 
     try {
       client.post(urlMaker.combine(subPath), request, tenantId,
+        ResponseHandler.any(createCompleted));
+    } catch (MalformedURLException e) {
+      throw new RuntimeException(subPath + ": " + e.getMessage(), e);
+    }
+
+    return TestBase.get(createCompleted);
+  }
+
+  public Response attemptToCreate(String subPath, JsonObject request, String tenantId, Map<String, String> headers) {
+
+    CompletableFuture<Response> createCompleted = new CompletableFuture<>();
+
+    try {
+      client.post(urlMaker.combine(subPath), request, headers, tenantId,
         ResponseHandler.any(createCompleted));
     } catch (MalformedURLException e) {
       throw new RuntimeException(subPath + ": " + e.getMessage(), e);


### PR DESCRIPTION
## Purpose
to provide the creation of corresponding shadow instance upon creation of holdings record on a shared instance

## Approach
* create a shadow instance on the local tenant through the consortium sharing process if such instance doesn't exist with the instance id specified in the received holding to be created
* add and update tests


## Learning
[MODINVSTOR-1103](https://issues.folio.org/browse/MODINVSTOR-1103)