### PR TITLE
[MODINVSTOR-1114] Add a new system property to define if consotrium process should be executed

### DIFF
--- a/src/main/java/org/folio/services/holding/HoldingsService.java
+++ b/src/main/java/org/folio/services/holding/HoldingsService.java
@@ -48,6 +48,7 @@ import org.folio.validator.NotesValidators;
 
 public class HoldingsService {
   private static final Logger log = getLogger(HoldingsService.class);
+  private static final String CONSORTIUM_ENABLED_PARAM = "consortium.enabled";
   private static final String INSTANCE_ID = "instanceId";
   private final Context vertxContext;
   private final Map<String, String> okapiHeaders;
@@ -58,7 +59,6 @@ public class HoldingsService {
   private final HoldingDomainEventPublisher domainEventPublisher;
   private final InstanceInternalRepository instanceRepository;
   private final ConsortiumService consortiumService;
-  private final String CONSORTIUM_ENABLED_PARAM = "consortium.enabled";
   private final boolean consortiumEnabled;
 
   public HoldingsService(Context context, Map<String, String> okapiHeaders) {

--- a/src/main/java/org/folio/services/holding/HoldingsService.java
+++ b/src/main/java/org/folio/services/holding/HoldingsService.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
@@ -57,6 +58,8 @@ public class HoldingsService {
   private final HoldingDomainEventPublisher domainEventPublisher;
   private final InstanceInternalRepository instanceRepository;
   private final ConsortiumService consortiumService;
+  private final String CONSORTIUM_ENABLED_PARAM = "consortium.enabled";
+  private final boolean consortiumEnabled;
 
   public HoldingsService(Context context, Map<String, String> okapiHeaders) {
     this.vertxContext = context;
@@ -70,6 +73,7 @@ public class HoldingsService {
     instanceRepository = new InstanceInternalRepository(context, okapiHeaders);
     consortiumService = new ConsortiumServiceImpl(context.owner().createHttpClient(),
       context.get(ConsortiumDataCache.class.getName()));
+    consortiumEnabled = Boolean.parseBoolean(getPropertyValue(CONSORTIUM_ENABLED_PARAM, "false"));
   }
 
   /**
@@ -96,10 +100,7 @@ public class HoldingsService {
   public Future<Response> createHolding(HoldingsRecord entity) {
     entity.setEffectiveLocationId(calculateEffectiveLocation(entity));
 
-    return consortiumService.getConsortiumData(okapiHeaders)
-      .compose(consortiumDataOptional -> consortiumDataOptional
-        .map(consortiumData -> createShadowInstanceIfNeeded(entity.getInstanceId(), consortiumData).mapEmpty())
-        .orElse(Future.succeededFuture()))
+    return executeConsortiumLogicIfConsortiumEnabled(entity)
       .compose(v -> hridManager.populateHrid(entity))
       .compose(NotesValidators::refuseLongNotes)
       .compose(hr -> {
@@ -241,6 +242,16 @@ public class HoldingsService {
     }
   }
 
+  private Future<Object> executeConsortiumLogicIfConsortiumEnabled(HoldingsRecord entity) {
+    if (consortiumEnabled) {
+      return consortiumService.getConsortiumData(okapiHeaders)
+        .compose(consortiumDataOptional -> consortiumDataOptional
+          .map(consortiumData -> createShadowInstanceIfNeeded(entity.getInstanceId(), consortiumData).mapEmpty())
+          .orElse(Future.succeededFuture()));
+    }
+    return Future.succeededFuture();
+  }
+
   private CompositeFuture createShadowInstancesIfNeeded(List<HoldingsRecord> holdingsRecords,
                                                         ConsortiumData consortiumData) {
     Map<String, Future<SharingInstance>> instanceFuturesMap = new HashMap<>();
@@ -266,5 +277,11 @@ public class HoldingsService {
 
   private boolean holdingsRecordFound(HoldingsRecord holdingsRecord) {
     return holdingsRecord != null;
+  }
+
+  private String getPropertyValue(String propertyName, String defaultValue) {
+    return Optional.ofNullable(System.getProperty(propertyName))
+      .or(() -> Optional.ofNullable(System.getenv(propertyName)))
+      .orElse(defaultValue);
   }
 }

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -1,6 +1,10 @@
 package org.folio.rest.api;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToIgnoreCase;
+import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.http.Response.Builder.like;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.HttpStatus.HTTP_CREATED;
@@ -89,6 +93,7 @@ import org.folio.services.consortium.entities.SharingInstance;
 import org.folio.services.consortium.entities.SharingStatus;
 import org.junit.After;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
@@ -134,6 +139,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   @SneakyThrows
   @Before
   public void beforeEach() {
+    System.setProperty("consortium.enabled", "true");
     StorageTestSuite.deleteAll(TENANT_ID, "preceding_succeeding_title");
     StorageTestSuite.deleteAll(TENANT_ID, "instance_relationship");
     StorageTestSuite.deleteAll(TENANT_ID, "bound_with_part");
@@ -2397,6 +2403,44 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       CONSORTIUM_MEMBER_TENANT, mockServer.baseUrl());
 
     log.info("Finished canCreateHoldingAndCreateShadowInstance");
+  }
+
+  @Test
+  public void shouldNotExecuteConsortiumLogicIfConsortiumSystemPropertyDisabled() {
+    System.setProperty("consortium.enabled", "false");
+    log.info("Starting canCreateHoldingAndCreateShadowInstance");
+    mockSharingInstance();
+
+    UUID instanceId = UUID.randomUUID();
+    HoldingRequestBuilder builder = new HoldingRequestBuilder()
+      .withId(null)
+      .forInstance(instanceId)
+      .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID);
+
+    Response response = holdingsClient.attemptToCreate("", builder.create(), CONSORTIUM_MEMBER_TENANT,
+      Map.of(X_OKAPI_URL, mockServer.baseUrl()));
+
+    verify(0, postRequestedFor(urlEqualTo("/consortia/mobius/sharing/instances")));
+    assertThat(response.getStatusCode(), is(HTTP_UNPROCESSABLE_ENTITY.toInt()));
+  }
+
+  @Test
+  public void shouldNotExecuteConsortiumLogicIfConsortiumSystemPropertyIsNull() {
+    System.clearProperty("consortium.enabled");
+    log.info("Starting canCreateHoldingAndCreateShadowInstance");
+    mockSharingInstance();
+
+    UUID instanceId = UUID.randomUUID();
+    HoldingRequestBuilder builder = new HoldingRequestBuilder()
+      .withId(null)
+      .forInstance(instanceId)
+      .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID);
+
+    Response response = holdingsClient.attemptToCreate("", builder.create(), CONSORTIUM_MEMBER_TENANT,
+      Map.of(X_OKAPI_URL, mockServer.baseUrl()));
+
+    verify(0, postRequestedFor(urlEqualTo("/consortia/mobius/sharing/instances")));
+    assertThat(response.getStatusCode(), is(HTTP_UNPROCESSABLE_ENTITY.toInt()));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -1,7 +1,6 @@
 package org.folio.rest.api;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToIgnoreCase;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
@@ -93,7 +92,6 @@ import org.folio.services.consortium.entities.SharingInstance;
 import org.folio.services.consortium.entities.SharingStatus;
 import org.junit.After;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Ignore;


### PR DESCRIPTION
### Purpose 
Not run consortium logic for tenant which not have appropriate system property to fix the next problem during the load of sample data: 
`Tenant operation failed for module mod-inventory-storage-26.1.0-SNAPSHOT.904: GET http://mod-inventory-storage/holdings-storage/holdings/65032151-39a5-4cef-8810-5350eb316300 returned status 404: Not found POST http://mod-inventory-storage/holdings-storage/holdings returned status 500: Error loading consortium data, tenantId: 'aqa' response status: '403', body: 'Access for user 'UNDEFINED_USER_10.0.75.227:53462_2023-10-04T09:57:04.825+0000' (null) requires permission: user-tenants.collection.get'`

### Approach
Added system property **consortium.enabled**, which defines if we should execute consortium logic
