### PR TITLE
[MODINVSTOR-1114] Not fail future if user not have permissions to load consortium data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-kafka-wrapper</artifactId>
-      <version>3.0.0-SNAPSHOT</version>
+      <version>3.0.0</version>
     </dependency>
     <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>

--- a/src/main/java/org/folio/services/caches/ConsortiumDataCache.java
+++ b/src/main/java/org/folio/services/caches/ConsortiumDataCache.java
@@ -1,6 +1,7 @@
 package org.folio.services.caches;
 
 import static io.vertx.core.http.HttpMethod.GET;
+import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.folio.okapi.common.XOkapiHeaders.URL;
 
@@ -71,6 +72,10 @@ public class ConsortiumDataCache {
         String msg = String.format("Error loading consortium data, tenantId: '%s' response status: '%s', body: '%s'",
           tenantId, response.statusCode(), response.bodyAsString());
         LOG.warn("loadConsortiumData:: {}", msg);
+        if (response.statusCode() == HTTP_FORBIDDEN) {
+          return Future.succeededFuture(Optional.<ConsortiumData>empty());
+        }
+
         return Future.failedFuture(msg);
       }
       JsonArray userTenants = response.bodyAsJsonObject().getJsonArray(USER_TENANTS_FIELD);

--- a/src/test/java/org/folio/services/caches/ConsortiumDataCacheTest.java
+++ b/src/test/java/org/folio/services/caches/ConsortiumDataCacheTest.java
@@ -121,4 +121,18 @@ public class ConsortiumDataCacheTest {
       async.complete();
     });
   }
+
+  @Test
+  public void shouldReturnOptionalEmptyWhenGetForbiddenErrorOnConsortiumDataLoading(TestContext context) {
+    Async async = context.async();
+    WireMock.stubFor(get(USER_TENANTS_PATH).willReturn(WireMock.forbidden()));
+
+    Future<Optional<ConsortiumData>> future = consortiumDataCache.getConsortiumData(TENANT_ID, okapiHeaders);
+
+    future.onComplete(ar -> {
+      context.assertTrue(ar.succeeded());
+      context.assertTrue(ar.result().isEmpty());
+      async.complete();
+    });
+  }
 }


### PR DESCRIPTION
### Purpose
Ignore permission errors during load of consortium data to allow supertenant create tenants at test envs

### Approach 
Ignore permission errors during load of consortium data, skip further ECS logic