### PR TITLE
MODINVSTOR-1092 Sporadic test failure: ReindexJobRunnerTest.canGetAllInstancesReindexJobs

### DIFF
--- a/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
+++ b/src/test/java/org/folio/rest/api/ReindexJobRunnerTest.java
@@ -64,6 +64,7 @@ public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
     var numberOfRecords = 1100;
     var rowStream = new TestRowStream(numberOfRecords);
     var reindexJob = instanceReindexJob();
+    instanceReindex.postReindexJob(reindexJob);
     var postgresClientFuturized = spy(getPostgresClientFuturized());
 
     doReturn(succeededFuture(rowStream))
@@ -95,6 +96,7 @@ public class ReindexJobRunnerTest extends TestBaseWithInventoryUtil {
     var numberOfRecords = 2;
     var rowStream = new TestRowStream(numberOfRecords);
     var reindexJob = instanceReindexJob();
+    instanceReindex.postReindexJob(reindexJob);
     var postgresClientFuturized = spy(getPostgresClientFuturized());
 
     doReturn(succeededFuture(rowStream))


### PR DESCRIPTION
## Purpose
_Fix Sporadic test failure: ReindexJobRunnerTest.canGetAllInstancesReindexJobs_

## Approach
It turned out that test methods in `org.folio.rest.api.ReindexJobRunnerTest` are order dependent. And in some cases `ReindexJobRunnerTest#canGetAllInstancesReindexJobs` test may go before `ReindexJobRunnerTest#canStartInstanceReindex` test.

So, to avoid such behavior we should call `InstanceReindexFixture#postReindexJob` in each test separately.

### Learning
[_MODINVSTOR-1092_](https://issues.folio.org/browse/MODINVSTOR-1092)