### PR TITLE
MODINVSTOR-1139: Upgrade snappy-java 1.1.8.1 to 1.1.10.5 fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -182,6 +182,11 @@
       <version>${vertx.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.xerial.snappy</groupId>
+      <artifactId>snappy-java</artifactId>
+      <version>1.1.10.5</version>
+    </dependency>
+    <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
Upgrade snappy-java from 1.1.8.1 to 1.1.10.5 fixing four security vulnerabilities:
* https://nvd.nist.gov/vuln/detail/CVE-2023-43642
* https://nvd.nist.gov/vuln/detail/CVE-2023-34455
* https://nvd.nist.gov/vuln/detail/CVE-2023-34453
* https://nvd.nist.gov/vuln/detail/CVE-2023-34454