### PR TITLE
MODINVSTOR-1143. Add source field to contributor name type

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -535,7 +535,7 @@
     },
     {
       "id": "contributor-name-types",
-      "version": "1.2",
+      "version": "1.3",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/contributor-name-type.raml
+++ b/ramls/contributor-name-type.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Contributor Name Types API
-version: v1.2
+version: v1.3
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/contributornametype.json
+++ b/ramls/contributornametype.json
@@ -14,6 +14,10 @@
       "description": "used for ordering of contributor name types in displays, i.e. in select lists",
       "type": "string"
     },
+    "source": {
+      "type": "string",
+      "description": "origin of the contributor name type record, e.g. 'local', 'consortium' etc."
+    },
     "metadata": {
       "type": "object",
       "$ref": "raml-util/schemas/metadata.schema",

--- a/ramls/electronicaccessrelationship.json
+++ b/ramls/electronicaccessrelationship.json
@@ -11,7 +11,7 @@
       "type": "string"
     },
     "source": {
-      "description": "Origin of the electronic access relationship record, e.g. 'System', 'User', 'Consortium', 'folio', 'local' etc.",
+      "description": "Origin of the electronic access relationship record, e.g. 'local', 'consortium' etc.",
       "type": "string"
     },
     "metadata": {

--- a/ramls/examples/contributornametype.json
+++ b/ramls/examples/contributornametype.json
@@ -1,4 +1,5 @@
 {
   "id": "2b94c631-fca9-4892-a730-03ee529ffe2a",
-  "name": "Personal name"
+  "name": "Personal name",
+  "source": "local"
 }

--- a/ramls/examples/contributornametypes.json
+++ b/ramls/examples/contributornametypes.json
@@ -2,15 +2,18 @@
   "contributorNameTypes": [
     {
       "id": "2b94c631-fca9-4892-a730-03ee529ffe2a",
-      "name": "Personal name"
+      "name": "Personal name",
+      "source": "local"
     },
     {
       "id": "2e48e713-17f3-4c13-a9f8-23845bb210aa",
-      "name": "Corporate name"
+      "name": "Corporate name",
+      "source": "consortium"
     },
     {
       "id": "e8b311a6-3b21-43f2-a269-dd9310cb2d0a",
-      "name": "Meeting name"
+      "name": "Meeting name",
+      "source": "consortium"
     }
   ],
   "totalRecords": 3

--- a/ramls/examples/electronicaccessrelationship.json
+++ b/ramls/examples/electronicaccessrelationship.json
@@ -1,5 +1,5 @@
 {
   "id": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
   "name": "Resource",
-  "source": "System"
+  "source": "local"
 }

--- a/ramls/examples/electronicaccessrelationships.json
+++ b/ramls/examples/electronicaccessrelationships.json
@@ -3,22 +3,22 @@
     {
       "id": "f5d0068e-6272-458e-8a81-b85e7b9a14aa",
       "name": "Resource",
-      "source": "System"
+      "source": "local"
     },
     {
       "id": "f50c90c9-bae0-4add-9cd0-db9092dbc9dd",
       "name": "No information provided",
-      "source": "User"
+      "source": "local"
     },
     {
       "id": "3b430592-2e09-4b48-9a0c-0636d66b9fb3",
       "name": "Version of resource",
-      "source": "Consortium"
+      "source": "consortium"
     },
     {
       "id": "5bfe1b7b-f151-4501-8cfa-23b321d5cd1e",
       "name": "Related resource",
-      "source": "folio"
+      "source": "consortium"
     },
     {
       "id": "ef03d582-219c-4221-8635-bc92f1107021",

--- a/ramls/examples/loantype.json
+++ b/ramls/examples/loantype.json
@@ -1,5 +1,5 @@
 {
   "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
   "name": "Can circulate",
-  "source": "System"
+  "source": "local"
 }

--- a/ramls/examples/loantypes.json
+++ b/ramls/examples/loantypes.json
@@ -3,17 +3,17 @@
     {
       "id": "2b94c631-fca9-4892-a730-03ee529ffe27",
       "name": "Can circulate",
-      "source": "System"
+      "source": "local"
     },
     {
       "id": "2e48e713-17f3-4c13-a9f8-23845bb210a4",
       "name": "Reading room",
-      "source": "User"
+      "source": "local"
     },
     {
       "id": "e8b311a6-3b21-43f2-a269-dd9310cb2d0e",
       "name": "Course reserves",
-      "source": "Consortium"
+      "source": "consortium"
     }
   ],
   "totalRecords": 3

--- a/ramls/holdings-sources/holdingsRecordsSource.json
+++ b/ramls/holdings-sources/holdingsRecordsSource.json
@@ -16,7 +16,8 @@
       "type": "string",
       "enum": [
         "folio",
-        "local"
+        "local",
+        "consortium"
       ],
       "description": "The holdings records source"
     },


### PR DESCRIPTION
### Purpose
https://issues.folio.org/browse/MODINVSTOR-1143

### Approach
Add 'source' field to Contributor Name type, also enum of allowed values extended with 'consortium' value for Holdings Record Source.
Also there was some improvements with examples(here is original PR https://github.com/folio-org/mod-inventory-storage/pull/912/files ) to remove unused options and remain only 'consortium' and 'local', because only these 2 values used in mod-consortia [Link  ](https://github.com/folio-org/mod-consortia/blob/master/src/main/java/org/folio/consortia/utils/HelperUtils.java#L10)

### Related Issues
https://issues.folio.org/browse/MODCON-122
https://issues.folio.org/browse/MODCON-121

