### PR TITLE
MODINVSTOR-1179 Add ecsRequestRouting field to service point schema

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 ### Features
 * Implement domain event production for location create/update/delete ([MODINVSTOR-1181](https://issues.folio.org/browse/MODINVSTOR-1181))
+* Add a new boolean field ecsRequestRouting to the service point schema ([MODINVSTOR-1179](https://issues.folio.org/browse/MODINVSTOR-1179))
 
 ### Bug fixes
 * Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1034,7 +1034,7 @@
     },
     {
       "id": "service-points",
-      "version": "3.3",
+      "version": "3.4",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/service-point.raml
+++ b/ramls/service-point.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Service Points API
-version: v3.3
+version: v3.4
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/servicepoint.json
+++ b/ramls/servicepoint.json
@@ -72,6 +72,11 @@
         ]
       }
     },
+    "ecsRequestRouting": {
+      "type": "boolean",
+      "description": "indicates service point used for ECS functionality",
+      "default" : false
+    },
     "metadata": {
       "type": "object",
       "$ref": "raml-util/schemas/metadata.schema",

--- a/ramls/servicepoint.json
+++ b/ramls/servicepoint.json
@@ -74,7 +74,7 @@
     },
     "ecsRequestRouting": {
       "type": "boolean",
-      "description": "indicates service point used for ECS functionality",
+      "description": "Indicates a service point used for the ECS functionality",
       "default" : false
     },
     "metadata": {

--- a/src/test/java/org/folio/rest/api/ServicePointTest.java
+++ b/src/test/java/org/folio/rest/api/ServicePointTest.java
@@ -74,6 +74,7 @@ public class ServicePointTest extends TestBase {
     assertThat(response.getJson().getString("id"), notNullValue());
     assertThat(response.getJson().getString("code"), is("cd1"));
     assertThat(response.getJson().getString("name"), is("Circ Desk 1"));
+    assertThat(response.getJson().getBoolean("ecsRequestRouting"), is(false));
   }
 
   @Test
@@ -780,8 +781,7 @@ public class ServicePointTest extends TestBase {
   private Response getById(UUID id)
     throws InterruptedException,
     ExecutionException,
-    TimeoutException,
-    MalformedURLException {
+    TimeoutException {
 
     CompletableFuture<Response> getCompleted = new CompletableFuture<>();
 


### PR DESCRIPTION
Covers: [MODINVSTOR-1179](https://folio-org.atlassian.net/browse/MODINVSTOR-1179)

### Purpose

Add a new boolean field ecsRequestRouting to the service point schema. 
It shouldn't be required, default value is false.

