### PR TITLE
MODINVSTOR-1186: RMB 35.2.1 fixing unintended optimistic locking

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 ## v27.2.0 In progress
 ### Breaking changes
-* Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))
+* Description ([ISSUE\_NUMBER](https://folio-org.atlassian.net/browse/ISSUE_NUMBER))
 
 ### New APIs versions
 * Provides `API_NAME vX.Y`
@@ -10,13 +10,14 @@
 * Implement domain event production for location create/update/delete ([MODINVSTOR-1181](https://issues.folio.org/browse/MODINVSTOR-1181))
 
 ### Bug fixes
-* Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))
+* Unintended update of instance records \_version (optimistic locking) whenever any of its holdings or items are created, updated or deleted. ([MODINVSTOR-1186](https://folio-org.atlassian.net/browse/MODINVSTOR-1186))
 
 ### Tech Dept
-* Description ([ISSUE_NUMBER](https://issues.folio.org/browse/ISSUE_NUMBER))
+* Description ([ISSUE\_NUMBER](https://folio-org.atlassian.net/browse/ISSUE_NUMBER))
 
 ### Dependencies
 * Bump `LIB_NAME` from `OLD_VERSION` to `NEW_VERSION`
+* Bump `domain-models-runtime` from `35.2.0` to `35.2.1`
 * Add `LIB_NAME` `2.7.4`
 * Remove `LIB_NAME`
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/record-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances,/inventory-hierarchy/updated-instance-ids,/inventory-hierarchy/items-and-holdings,/inventory-view/instances</generate_routing_context>
     <argLine />
 
-    <raml-module-builder-version>35.2.0</raml-module-builder-version> <!-- also update vertx.version -->
+    <raml-module-builder-version>35.2.1</raml-module-builder-version> <!-- also update vertx.version -->
     <vertx.version>4.5.7</vertx.version>
     <marc4j.version>2.9.5</marc4j.version>
     <aspectj.version>1.9.22</aspectj.version>

--- a/src/main/java/org/folio/services/consortium/ShadowInstanceSynchronizationHandler.java
+++ b/src/main/java/org/folio/services/consortium/ShadowInstanceSynchronizationHandler.java
@@ -32,6 +32,7 @@ import org.folio.kafka.KafkaHeaderUtils;
 import org.folio.okapi.common.GenericCompositeFuture;
 import org.folio.persist.InstanceRepository;
 import org.folio.rest.jaxrs.model.Instance;
+import org.folio.rest.persist.PostgresClient;
 import org.folio.services.caches.ConsortiumData;
 import org.folio.services.caches.ConsortiumDataCache;
 import org.folio.services.domainevent.DomainEvent;
@@ -138,16 +139,20 @@ public class ShadowInstanceSynchronizationHandler implements AsyncRecordHandler<
 
   private Future<Void> updateShadowInstances(DomainEvent<Instance> event, List<String> tenantIds,
                                              Map<String, String> headers) {
-    LOG.info("updateShadowInstances:: Trying to update shadow instances in the following tenants: {} ", tenantIds);
-    Instance instance = JsonObject.mapFrom(event.getNewEntity()).mapTo(Instance.class);
-    prepareInstanceForUpdate(instance);
-    List<List<String>> tenantsChunks = Lists.partition(tenantIds, instancesParallelUpdatesLimit);
+    try {
+      LOG.info("updateShadowInstances:: Trying to update shadow instances in the following tenants: {} ", tenantIds);
+      Instance instance = PostgresClient.pojo2JsonObject(event.getNewEntity()).mapTo(Instance.class);
+      prepareInstanceForUpdate(instance);
+      List<List<String>> tenantsChunks = Lists.partition(tenantIds, instancesParallelUpdatesLimit);
 
-    Future<CompositeFuture> future = Future.succeededFuture();
-    for (List<String> tenantsChunk : tenantsChunks) {
-      future = future.eventually(v -> updateShadowInstances(tenantsChunk, instance, headers));
+      Future<CompositeFuture> future = Future.succeededFuture();
+      for (List<String> tenantsChunk : tenantsChunks) {
+        future = future.eventually(v -> updateShadowInstances(tenantsChunk, instance, headers));
+      }
+      return future.mapEmpty();
+    } catch (Exception e) {
+      return Future.failedFuture(e);
     }
-    return future.mapEmpty();
   }
 
   private CompositeFuture updateShadowInstances(List<String> tenantIds, Instance instance,

--- a/src/test/java/org/folio/rest/api/AsyncMigrationTest.java
+++ b/src/test/java/org/folio/rest/api/AsyncMigrationTest.java
@@ -79,7 +79,7 @@ public class AsyncMigrationTest extends TestBaseWithInventoryUtil {
     var holdingsRecordId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
 
     IntStream.range(0, numberOfRecords).parallel().forEach(v ->
-      itemsClient.create(JsonObject.mapFrom(buildItem(holdingsRecordId, ONLINE_LOCATION_ID, ANNEX_LIBRARY_LOCATION_ID)
+      itemsClient.create(pojo2JsonObject(buildItem(holdingsRecordId, ONLINE_LOCATION_ID, ANNEX_LIBRARY_LOCATION_ID)
         .withItemLevelCallNumber("K1 .M44")
         .withEffectiveCallNumberComponents(new EffectiveCallNumberComponents().withCallNumber("K1 .M44")))));
 

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -194,7 +194,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject instanceToCreate = smallAngryPlanet(id);
     instanceToCreate.put("natureOfContentTermIds", Arrays.asList(natureOfContentIds));
-    instanceToCreate.put("publication", new JsonArray().add(JsonObject.mapFrom(publication)));
+    instanceToCreate.put("publication", new JsonArray().add(pojo2JsonObject(publication)));
     instanceToCreate.put("administrativeNotes", new JsonArray().add(adminNote));
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
@@ -1568,9 +1568,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       instancesArray.add(smallAngryPlanet(UUID.randomUUID()));
     }
 
-    JsonObject instanceCollection = JsonObject.mapFrom(new JsonObject()
+    JsonObject instanceCollection = new JsonObject()
       .put(INSTANCES_KEY, instancesArray)
-      .put(TOTAL_RECORDS_KEY, numberOfInstances));
+      .put(TOTAL_RECORDS_KEY, numberOfInstances);
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
@@ -1609,10 +1609,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     JsonObject secondErrorInstance = firstErrorInstance.copy()
       .put("id", UUID.randomUUID().toString());
 
-    JsonObject instanceCollection = JsonObject.mapFrom(new JsonObject()
+    JsonObject instanceCollection = new JsonObject()
       .put(INSTANCES_KEY, new JsonArray().add(firstCorrectInstance).add(firstErrorInstance)
         .add(secondCorrectInstance).add(secondErrorInstance))
-      .put(TOTAL_RECORDS_KEY, 4));
+      .put(TOTAL_RECORDS_KEY, 4);
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
@@ -1648,9 +1648,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     JsonObject errorInstance = smallAngryPlanet(null).put("modeOfIssuanceId", UUID.randomUUID().toString());
 
-    JsonObject instanceCollection = JsonObject.mapFrom(new JsonObject()
+    JsonObject instanceCollection = new JsonObject()
       .put(INSTANCES_KEY, new JsonArray().add(errorInstance).add(errorInstance).add(errorInstance))
-      .put(TOTAL_RECORDS_KEY, 3));
+      .put(TOTAL_RECORDS_KEY, 3);
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
@@ -2082,7 +2082,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       .put("source", "CONSORTIUM-MARC").put("hrid", newHrid);
 
     final IndividualResource updateInstance =
-      updateInstance(JsonObject.mapFrom(instance));
+      updateInstance(pojo2JsonObject(instance));
 
     assertThat(updateInstance.getJson().mapTo(Instance.class).getHrid(), is(newHrid));
 
@@ -2564,11 +2564,11 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     var entity = smallAngryPlanet(UUID.randomUUID()).mapTo(Instance.class)
       .withPublication(Collections.singletonList(new Publication().withDateOfPublication("1997")));
 
-    IndividualResource instance = createInstance(JsonObject.mapFrom(entity));
+    IndividualResource instance = createInstance(pojo2JsonObject(entity));
     entity = instance.getJson().mapTo(Instance.class)
       .withPublication(Collections.singletonList(new Publication().withDateOfPublication("2006")));
 
-    final IndividualResource updateInstance = updateInstance(JsonObject.mapFrom(entity));
+    final IndividualResource updateInstance = updateInstance(pojo2JsonObject(entity));
 
     assertEquals(Integer.valueOf(2006),
       updateInstance.getJson().mapTo(Instance.class).getPublicationPeriod().getStart());

--- a/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
+++ b/src/test/java/org/folio/rest/api/ItemEffectiveLocationTest.java
@@ -246,7 +246,7 @@ public class ItemEffectiveLocationTest extends TestBaseWithInventoryUtil {
     assertEquals(itemFetched.getEffectiveLocationId(), ANNEX_LIBRARY_LOCATION_ID.toString());
 
     itemsClient.replace(UUID.fromString(itemFetched.getId()),
-      JsonObject.mapFrom(itemFetched).copy()
+      pojo2JsonObject(itemFetched).copy()
         .put("holdingsRecordId", updatedHoldingRecordId.toString())
     );
 
@@ -265,7 +265,7 @@ public class ItemEffectiveLocationTest extends TestBaseWithInventoryUtil {
     assertEquals(itemFetched.getEffectiveLocationId(), ONLINE_LOCATION_ID.toString());
 
     itemsClient.replace(UUID.fromString(itemFetched.getId()),
-      JsonObject.mapFrom(itemFetched).copy()
+      pojo2JsonObject(itemFetched).copy()
         .put("holdingsRecordId", updatedHoldingRecordId.toString())
     );
 
@@ -283,7 +283,7 @@ public class ItemEffectiveLocationTest extends TestBaseWithInventoryUtil {
     item = getItem(item.getId());
 
     item.setTemporaryLocationId(SECOND_FLOOR_LOCATION_ID.toString());
-    itemsClient.replace(UUID.fromString(item.getId()), JsonObject.mapFrom(item));
+    itemsClient.replace(UUID.fromString(item.getId()), pojo2JsonObject(item));
 
     Row result = runSql(
       "SELECT jsonb, effectiveLocationId "

--- a/src/test/java/org/folio/rest/api/ItemShelvingOrderMigrationServiceApiTest.java
+++ b/src/test/java/org/folio/rest/api/ItemShelvingOrderMigrationServiceApiTest.java
@@ -50,7 +50,7 @@ public class ItemShelvingOrderMigrationServiceApiTest extends MigrationTestBase 
   }
 
   private JsonObject getTenantAttributes() {
-    return JsonObject.mapFrom(new TenantAttributes()
+    return pojo2JsonObject(new TenantAttributes()
       .withModuleFrom("20.1.1")
       .withModuleTo("20.2." + nextPatch.incrementAndGet())
       .withParameters(List.of(

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -2416,11 +2416,8 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
-  public void testItemHasLastCheckInProperties()
-    throws MalformedURLException,
-    InterruptedException,
-    ExecutionException,
-    TimeoutException {
+  @SneakyThrows
+  public void testItemHasLastCheckInProperties() {
     UUID itemId = UUID.randomUUID();
     UUID userId = UUID.randomUUID();
     UUID servicePointId = UUID.randomUUID();
@@ -2433,7 +2430,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     expected.setStaffMemberId(userId.toString());
     expected.setServicePointId(servicePointId.toString());
     expected.setDateTime(new Date());
-    JsonObject lastCheckInData = JsonObject.mapFrom(expected);
+    JsonObject lastCheckInData = pojo2JsonObject(expected);
     itemData.put("lastCheckIn", lastCheckInData);
 
     itemsClient.replace(itemId, itemData);

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -22,7 +22,6 @@ import lombok.SneakyThrows;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.postgres.testing.PostgresTesterContainer;
-import org.folio.rest.impl.CallNumberTypeApiTest;
 import org.folio.rest.impl.StorageHelperTest;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.HttpClient;
@@ -38,7 +37,6 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({
-  CallNumberTypeApiTest.class,
   AsyncMigrationTest.class,
   PublicationPeriodMigrationTest.class,
   CallNumberUtilsTest.class,

--- a/src/test/java/org/folio/rest/api/TestBase.java
+++ b/src/test/java/org/folio/rest/api/TestBase.java
@@ -17,6 +17,7 @@ import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 import java.net.HttpURLConnection;
@@ -29,6 +30,7 @@ import java.util.concurrent.TimeoutException;
 import lombok.SneakyThrows;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.fixtures.AsyncMigrationFixture;
@@ -202,6 +204,14 @@ public abstract class TestBase {
     getClient().get(url, tenantId, ResponseHandler.text(getCompleted));
     Response response = get(getCompleted);
     assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_NOT_FOUND));
+  }
+
+  public static JsonObject pojo2JsonObject(Object entity) {
+    try {
+      return PostgresClient.pojo2JsonObject(entity);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
   }
 
 }

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -21,7 +21,6 @@ import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.UnaryOperator;
-import lombok.SneakyThrows;
 import org.folio.HttpStatus;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.jaxrs.model.InstanceType;
@@ -82,7 +81,6 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   protected static String nonCirculatingLoanTypeID;
   private static final String USER_TENANTS_PATH = "/user-tenants?limit=1";
 
-  @SneakyThrows
   @BeforeClass
   public static void testBaseWithInvUtilBeforeClass() {
     logger.info("starting @BeforeClass testBaseWithInvUtilBeforeClass()");
@@ -276,7 +274,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
       it.withName("Default Instance Type");
       it.withSource("local");
 
-      instanceTypesClient.create(JsonObject.mapFrom(it));
+      instanceTypesClient.create(pojo2JsonObject(it));
     }
   }
 
@@ -336,7 +334,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   }
 
   protected IndividualResource createItem(Item item) {
-    return itemsClient.create(JsonObject.mapFrom(item));
+    return itemsClient.create(pojo2JsonObject(item));
   }
 
   protected IndividualResource createItem(ItemRequestBuilder item) {

--- a/src/test/java/org/folio/rest/impl/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/rest/impl/BaseIntegrationTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import org.folio.HttpStatus;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.RestVerticle;
+import org.folio.rest.api.TestBase;
 import org.folio.rest.tools.utils.Envs;
 import org.folio.rest.tools.utils.NetworkUtils;
 import org.junit.jupiter.api.BeforeAll;
@@ -152,6 +153,10 @@ public class BaseIntegrationTest {
     request.putHeader(ACCEPT, APPLICATION_JSON + ", " + TEXT_PLAIN);
 
     return request;
+  }
+
+  public static JsonObject pojo2JsonObject(Object entity) {
+    return TestBase.pojo2JsonObject(entity);
   }
 
   public record TestResponse(int status, Buffer body) {

--- a/src/test/java/org/folio/rest/impl/BaseReferenceDataIntegrationTest.java
+++ b/src/test/java/org/folio/rest/impl/BaseReferenceDataIntegrationTest.java
@@ -13,7 +13,6 @@ import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
-import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxTestContext;
 import java.util.ArrayList;
 import java.util.List;
@@ -178,7 +177,7 @@ abstract class BaseReferenceDataIntegrationTest<T, C> extends BaseIntegrationTes
 
     var newRecord = sampleRecord();
 
-    doPost(client, resourceUrl(), JsonObject.mapFrom(newRecord))
+    doPost(client, resourceUrl(), pojo2JsonObject(newRecord))
       .onComplete(verifyStatus(ctx, HTTP_CREATED))
       .onComplete(ctx.succeeding(response -> ctx.verify(() -> {
         var createdRecord = response.bodyAsClass(targetClass());
@@ -219,7 +218,7 @@ abstract class BaseReferenceDataIntegrationTest<T, C> extends BaseIntegrationTes
     postgresClient.save(referenceTable(), newRecord)
       .compose(id -> {
         var updatedRecord = recordModifyingFunction().apply(newRecord);
-        return doPut(client, resourceUrlById(id), JsonObject.mapFrom(updatedRecord))
+        return doPut(client, resourceUrlById(id), pojo2JsonObject(updatedRecord))
           .onComplete(verifyStatus(ctx, HTTP_NO_CONTENT))
           .compose(r -> postgresClient.getById(referenceTable(), id, targetClass())
             .onComplete(ctx.succeeding(dbRecord -> ctx.verify(() -> {

--- a/src/test/java/org/folio/rest/impl/CallNumberTypeApiTest.java
+++ b/src/test/java/org/folio/rest/impl/CallNumberTypeApiTest.java
@@ -25,7 +25,6 @@ import org.folio.rest.jaxrs.resource.CallNumberTypes;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.tools.utils.TenantTool;
-import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.MockedStatic;
@@ -35,53 +34,31 @@ import org.mockito.Mockito;
 public class CallNumberTypeApiTest extends TestBase {
 
   private static final String NAME_FIELD = "name";
-  private static final String NAME_VALUE = "test type";
   private static final String SOURCE_FIELD = "source";
-  private static final String SOURCE_VALUE = "system";
-
-  private static UUID callNumberTypeId;
-
-  @BeforeClass
-  public static void setUp() {
-  }
 
   @Test
   public void shouldRespondWith400_whenAttemptToDeleteSystemType() {
-    var requestBody = new JsonObject().put(NAME_FIELD, NAME_VALUE).put(SOURCE_FIELD, SOURCE_VALUE);
-    var createResponse = callNumberTypesClient.create(requestBody);
-    callNumberTypeId = createResponse.getId();
+    var callNumberTypeId = create("foo", "system");
 
     var response = callNumberTypesClient.attemptToDelete(callNumberTypeId);
     assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
-
-    var callNumberTypeResponse = callNumberTypesClient.getById(callNumberTypeId);
-    assertThat(callNumberTypeResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-    assertThat(callNumberTypeResponse.getJson().getString(NAME_FIELD), is(NAME_VALUE));
-    assertThat(callNumberTypeResponse.getJson().getString(SOURCE_FIELD), is(SOURCE_VALUE));
+    assertCallNumberType(callNumberTypeId, "foo", "system");
   }
 
   @Test
   public void shouldRespondWith400_whenAttemptToUpdateSystemType() {
+    var callNumberTypeId = create("bar", "system");
+
     var requestBody = new JsonObject().put(NAME_FIELD, "updated").put(SOURCE_FIELD, "local");
     var response = callNumberTypesClient.attemptToReplace(callNumberTypeId, requestBody);
     assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_BAD_REQUEST));
-
-    var callNumberTypeResponse = callNumberTypesClient.getById(callNumberTypeId);
-    assertThat(callNumberTypeResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-    assertThat(callNumberTypeResponse.getJson().getString(NAME_FIELD), is(NAME_VALUE));
-    assertThat(callNumberTypeResponse.getJson().getString(SOURCE_FIELD), is(SOURCE_VALUE));
+    assertCallNumberType(callNumberTypeId, "bar", "system");
   }
 
   @Test
   public void shouldRespondWith204_whenAttemptToDeleteNotSystemType() {
-    var requestBody = new JsonObject().put(NAME_FIELD, "NOT SYSTEM TYPE").put(SOURCE_FIELD, "NOT SYSTEM");
-    var createResponse = callNumberTypesClient.create(requestBody);
-    var callNumberTypeId = createResponse.getId();
-
-    var callNumberTypeResponse = callNumberTypesClient.getById(callNumberTypeId);
-    assertThat(callNumberTypeResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
-    assertThat(callNumberTypeResponse.getJson().getString(NAME_FIELD), is("NOT SYSTEM TYPE"));
-    assertThat(callNumberTypeResponse.getJson().getString(SOURCE_FIELD), is("NOT SYSTEM"));
+    var callNumberTypeId = create("baz", "non system");
+    assertCallNumberType(callNumberTypeId, "baz", "non system");
 
     var response = callNumberTypesClient.attemptToDelete(callNumberTypeId);
     assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
@@ -163,5 +140,19 @@ public class CallNumberTypeApiTest extends TestBase {
         CallNumberTypes.PutCallNumberTypesByIdResponse.class));
       Mockito.verify(errorHandler).handle(any());
     }
+  }
+
+  private UUID create(String name, String source) {
+    var requestBody = new JsonObject().put(NAME_FIELD, name).put(SOURCE_FIELD, source);
+    var createResponse = callNumberTypesClient.create(requestBody);
+    var callNumberTypeId = createResponse.getId();
+    return callNumberTypeId;
+  }
+
+  private void assertCallNumberType(UUID callNumberTypeId, String name, String source) {
+    var callNumberTypeResponse = callNumberTypesClient.getById(callNumberTypeId);
+    assertThat(callNumberTypeResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+    assertThat(callNumberTypeResponse.getJson().getString(NAME_FIELD), is(name));
+    assertThat(callNumberTypeResponse.getJson().getString(SOURCE_FIELD), is(source));
   }
 }

--- a/src/test/java/org/folio/rest/impl/LocationIT.java
+++ b/src/test/java/org/folio/rest/impl/LocationIT.java
@@ -10,7 +10,6 @@ import static org.folio.utility.RestUtility.TENANT_ID;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpClient;
-import io.vertx.core.json.JsonObject;
 import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.util.List;
@@ -140,7 +139,7 @@ class LocationIT extends BaseReferenceDataIntegrationTest<Location, Locations> {
     HttpClient client = vertx.createHttpClient();
     var invalidRecord = sampleRecord().withServicePointIds(null).withId(UUID.randomUUID().toString());
 
-    doPut(client, resourceUrlById(invalidRecord.getId()), JsonObject.mapFrom(invalidRecord))
+    doPut(client, resourceUrlById(invalidRecord.getId()), pojo2JsonObject(invalidRecord))
       .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
       .onComplete(ctx.succeeding(response -> ctx.verify(() -> {
         var actual = response.bodyAsClass(Errors.class);


### PR DESCRIPTION
### Purpose

Fix unintended update of instance records \_version (optimistic locking) whenever any of its holdings or items are created, updated or deleted.

### Approach

- Upgrade RMB from 35.2.0 to 35.2.1
- Fix test setup in CallNumberApiTest to make it independent of test execution order
- Remove CallNumberApiTest to avoid duplicate run (JUnit automatically runs it)
- Fix incorrect JsonObject.mapFrom usage

### Changes Checklist

- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues

https://folio-org.atlassian.net/browse/MODINVSTOR-1186