### PR TITLE
MODINVSTOR-1198: RMB 35.2.2 fixing deserialization of Date from long

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@
 
 ### Bug fixes
 * Unintended update of instance records \_version (optimistic locking) whenever any of its holdings or items are created, updated or deleted. ([MODINVSTOR-1186](https://folio-org.atlassian.net/browse/MODINVSTOR-1186))
+* Deserialization of Date from long (MODINVSTOR-1198)[https://folio-org.atlassian.net/browse/MODINVSTOR-1198]
 * Do not delete Kafka topics on postTenant if collection topics is enabled ([MODINVSTOR-1192](https://folio-org.atlassian.net/browse/MODINVSTOR-1192))
 
 ### Tech Dept
@@ -18,7 +19,7 @@
 
 ### Dependencies
 * Bump `LIB_NAME` from `OLD_VERSION` to `NEW_VERSION`
-* Bump `domain-models-runtime` from `35.2.0` to `35.2.1`
+* Bump `domain-models-runtime` from `35.2.0` to `35.2.2`
 * Add `LIB_NAME` `2.7.4`
 * Remove `LIB_NAME`
 

--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,7 @@
     <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/record-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances,/inventory-hierarchy/updated-instance-ids,/inventory-hierarchy/items-and-holdings,/inventory-view/instances</generate_routing_context>
     <argLine />
 
-    <raml-module-builder-version>35.2.1</raml-module-builder-version> <!-- also update vertx.version -->
+    <raml-module-builder-version>35.2.2</raml-module-builder-version> <!-- also update vertx.version -->
     <vertx.version>4.5.7</vertx.version>
     <marc4j.version>2.9.5</marc4j.version>
     <aspectj.version>1.9.22</aspectj.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODINVSTOR-1198

Upgrade RMB from 35.2.1 to 35.2.2. Some non-RMB serializers serialize Date to long when generating JSON. To deserialize long to Date RMB 35.2.2 has added code to support this.

### Purpose
Allow JSON deserialization where Date has been serialized as long.

### Approach
Upgrade RMB from 35.2.1 to 35.2.2.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODINVSTOR-1198
https://folio-org.atlassian.net/browse/RMB-943