### PR TITLE
MODINVSTOR-1219: Do not return routing service points by default

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1034,7 +1034,7 @@
     },
     {
       "id": "service-points",
-      "version": "3.4",
+      "version": "3.5",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/service-point.raml
+++ b/ramls/service-point.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Service Points API
-version: v3.4
+version: v3.5
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 
@@ -34,6 +34,12 @@ resourceTypes:
       searchable: { description: "with valid searchable fields", example: "name=aaa"},
       pageable
     ]
+    queryParameters:
+      includeRoutingServicePoints:
+        description: "Should routing service points (used in ECS) be included in the response"
+        default: false
+        required: false
+        type: boolean
     description: Return a list of service points
   post:
     description: Create a new service point

--- a/ramls/service-point.raml
+++ b/ramls/service-point.raml
@@ -36,7 +36,7 @@ resourceTypes:
     ]
     queryParameters:
       includeRoutingServicePoints:
-        description: "Should routing service points (used in ECS) be included in the response"
+        description: "Should ECS request routing service points be included in the response"
         default: false
         required: false
         type: boolean

--- a/src/main/java/org/folio/rest/impl/ServicePointApi.java
+++ b/src/main/java/org/folio/rest/impl/ServicePointApi.java
@@ -11,7 +11,6 @@ import io.vertx.core.Handler;
 import java.util.Map;
 import java.util.UUID;
 import javax.ws.rs.core.Response;
-
 import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;

--- a/src/main/java/org/folio/rest/impl/ServicePointApi.java
+++ b/src/main/java/org/folio/rest/impl/ServicePointApi.java
@@ -2,7 +2,7 @@ package org.folio.rest.impl;
 
 import static io.vertx.core.Future.succeededFuture;
 import static java.lang.Boolean.TRUE;
-import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.commons.lang3.StringUtils.isNotBlank;
 import static org.folio.rest.support.EndpointFailureHandler.handleFailure;
 
 import io.vertx.core.AsyncResult;
@@ -32,8 +32,8 @@ public class ServicePointApi implements org.folio.rest.jaxrs.resource.ServicePoi
     "Hold shelf expiry period must be specified when service point can be used for pickup.";
   public static final String SERVICE_POINT_CREATE_ERR_MSG_WITHOUT_BEING_PICKUP_LOC =
     "Hold shelf expiry period cannot be specified when service point cannot be used for pickup";
-  private static final Logger logger = LogManager.getLogger();
   private static final String ECS_ROUTING_QUERY_FILTER = "cql.allRecords=1 NOT ecsRequestRouting=true";
+  private static final Logger logger = LogManager.getLogger();
 
   @Validate
   @Override
@@ -272,7 +272,7 @@ public class ServicePointApi implements org.folio.rest.jaxrs.resource.ServicePoi
 
     logger.debug("updateGetServicePointsQuery:: original query: {}", query);
     String newQuery = ECS_ROUTING_QUERY_FILTER;
-    if (!isBlank(query)) {
+    if (isNotBlank(query)) {
       newQuery += " and " + query;
     }
     logger.debug("updateGetServicePointsQuery:: updated query: {}", newQuery);

--- a/src/main/java/org/folio/rest/impl/ServicePointApi.java
+++ b/src/main/java/org/folio/rest/impl/ServicePointApi.java
@@ -11,6 +11,8 @@ import io.vertx.core.Handler;
 import java.util.Map;
 import java.util.UUID;
 import javax.ws.rs.core.Response;
+
+import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.rest.RestVerticle;
@@ -32,13 +34,22 @@ public class ServicePointApi implements org.folio.rest.jaxrs.resource.ServicePoi
   public static final String SERVICE_POINT_CREATE_ERR_MSG_WITHOUT_BEING_PICKUP_LOC =
     "Hold shelf expiry period cannot be specified when service point cannot be used for pickup";
   private static final Logger logger = LogManager.getLogger();
+  private static final String DEFAULT_QUERY = "cql.allRecords=1";
+  private static final String ECS_ROUTING_QUERY_FILTER = " NOT ecsRequestRouting=true";
 
   @Validate
   @Override
-  public void getServicePoints(String query, String totalRecords, int offset, int limit,
-                               Map<String, String> okapiHeaders,
-                               Handler<AsyncResult<Response>> asyncResultHandler,
-                               Context vertxContext) {
+  public void getServicePoints(boolean includeRoutingServicePoints, String query,
+    String totalRecords, int offset, int limit, Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler,
+    Context vertxContext) {
+
+    if (!includeRoutingServicePoints) {
+      if (StringUtils.isBlank(query)) {
+        query = DEFAULT_QUERY;
+      }
+      query += ECS_ROUTING_QUERY_FILTER;
+    }
 
     PgUtil.get(SERVICE_POINT_TABLE, Servicepoint.class, Servicepoints.class,
       query, offset, limit, okapiHeaders, vertxContext, GetServicePointsResponse.class, asyncResultHandler);

--- a/src/main/java/org/folio/rest/impl/ServicePointApi.java
+++ b/src/main/java/org/folio/rest/impl/ServicePointApi.java
@@ -40,9 +40,10 @@ public class ServicePointApi implements org.folio.rest.jaxrs.resource.ServicePoi
   @Validate
   @Override
   public void getServicePoints(boolean includeRoutingServicePoints, String query,
-    String totalRecords, int offset, int limit, Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+                               String totalRecords, int offset, int limit,
+                               Map<String, String> okapiHeaders,
+                               Handler<AsyncResult<Response>> asyncResultHandler,
+                               Context vertxContext) {
 
     if (!includeRoutingServicePoints) {
       if (StringUtils.isBlank(query)) {

--- a/src/test/java/org/folio/rest/api/ServicePointTest.java
+++ b/src/test/java/org/folio/rest/api/ServicePointTest.java
@@ -730,7 +730,7 @@ public class ServicePointTest extends TestBase {
     "true,  ?includeRoutingServicePoints=true&query=code=cd*"
   })
   public void ecsRequestRoutingServicePointsAreReturnedOnlyWhenExplicitlyRequested(
-    boolean isRoutingServicePointExpectedInResponse, String queryParameters) throws Exception {
+    boolean shouldReturnRoutingServicePoints, String queryParameters) throws Exception {
 
     UUID regularServicePointId1 = UUID.randomUUID();
     UUID regularServicePointId2 = UUID.randomUUID();
@@ -750,7 +750,7 @@ public class ServicePointTest extends TestBase {
 
     assertThat(servicePointIds,
       hasItems(regularServicePointId1.toString(), regularServicePointId2.toString()));
-    if (isRoutingServicePointExpectedInResponse) {
+    if (shouldReturnRoutingServicePoints) {
       assertThat(servicePointIds, hasItem(routingServicePointId.toString()));
       assertThat(servicePointIds, hasSize(3));
     } else {

--- a/src/test/java/org/folio/rest/api/ServicePointTest.java
+++ b/src/test/java/org/folio/rest/api/ServicePointTest.java
@@ -28,7 +28,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import lombok.SneakyThrows;

--- a/src/test/java/org/folio/rest/api/ServicePointTest.java
+++ b/src/test/java/org/folio/rest/api/ServicePointTest.java
@@ -13,6 +13,10 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.util.ArrayList;
@@ -22,7 +26,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-
+import lombok.SneakyThrows;
 import org.folio.rest.jaxrs.model.HoldShelfExpiryPeriod;
 import org.folio.rest.jaxrs.model.Servicepoint;
 import org.folio.rest.jaxrs.model.StaffSlip;
@@ -32,12 +36,6 @@ import org.folio.rest.support.ResponseHandler;
 import org.folio.rest.support.messages.ServicePointEventMessageChecks;
 import org.junit.Before;
 import org.junit.Test;
-
-import io.vertx.core.http.HttpMethod;
-import io.vertx.core.json.Json;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import lombok.SneakyThrows;
 
 public class ServicePointTest extends TestBase {
   private static final String SUPPORTED_CONTENT_TYPE_JSON_DEF = "application/json";
@@ -769,13 +767,13 @@ public class ServicePointTest extends TestBase {
   }
 
   @Test
-  public void routingServicePointsAreNotReturnedByDefault() throws Exception {
-    UUID regularSpId = UUID.randomUUID();
-    UUID routingSpId = UUID.randomUUID();
+  public void ecsRequestRoutingServicePointsAreNotReturnedByDefault() throws Exception {
+    UUID regularServicePointId = UUID.randomUUID();
+    UUID routingServicePointId = UUID.randomUUID();
 
-    createServicePoint(regularSpId, "Circ Desk 1", "cd1", "Circulation Desk -- Hallway", null, 20,
-      true, createHoldShelfExpiryPeriod(), emptyList(), null, TENANT_ID);
-    createServicePoint(routingSpId, "Circ Desk 2", "cd2", "Circulation Desk -- Basement",
+    createServicePoint(regularServicePointId, "Circ Desk 1", "cd1", "Circulation Desk -- Hallway",
+      null, 20, true, createHoldShelfExpiryPeriod(), emptyList(), null, TENANT_ID);
+    createServicePoint(routingServicePointId, "Circ Desk 2", "cd2", "Circulation Desk -- Basement",
       null, 20, true, createHoldShelfExpiryPeriod(), emptyList(), true, TENANT_ID);
 
     List<String> regularServicePointIds = get("")
@@ -784,7 +782,7 @@ public class ServicePointTest extends TestBase {
       .toList();
 
     assertThat(regularServicePointIds.size(), is(1));
-    assertThat(regularServicePointIds, hasItems(regularSpId.toString()));
+    assertThat(regularServicePointIds, hasItems(regularServicePointId.toString()));
 
     List<String> allServicePointIds = get("?includeRoutingServicePoints=true")
       .stream()
@@ -792,7 +790,8 @@ public class ServicePointTest extends TestBase {
       .toList();
 
     assertThat(allServicePointIds.size(), is(2));
-    assertThat(allServicePointIds, hasItems(regularSpId.toString(), routingSpId.toString()));
+    assertThat(allServicePointIds,
+      hasItems(regularServicePointId.toString(), routingServicePointId.toString()));
   }
 
   private List<JsonObject> getMany(String cql, Object... args) throws InterruptedException,

--- a/src/test/java/org/folio/rest/api/ServicePointTest.java
+++ b/src/test/java/org/folio/rest/api/ServicePointTest.java
@@ -729,7 +729,7 @@ public class ServicePointTest extends TestBase {
     "true,  ?includeRoutingServicePoints=true",
     "true,  ?includeRoutingServicePoints=true&query=code=cd*"
   })
-  public void ecsRequestRoutingServicePointsAreOnlyReturnedWhenExplicitlyRequested(
+  public void ecsRequestRoutingServicePointsAreReturnedOnlyWhenExplicitlyRequested(
     boolean isRoutingServicePointExpectedInResponse, String queryParameters) throws Exception {
 
     UUID regularServicePointId1 = UUID.randomUUID();
@@ -743,18 +743,18 @@ public class ServicePointTest extends TestBase {
     createServicePoint(routingServicePointId, "Circ Desk 3", "cd3", "Circulation Desk 3",
       null, 20, true, createHoldShelfExpiryPeriod(), emptyList(), true, TENANT_ID);
 
-    List<String> regularServicePointIds = get(queryParameters)
+    List<String> servicePointIds = get(queryParameters)
       .stream()
       .map(json -> json.getString("id"))
       .toList();
 
-    assertThat(regularServicePointIds,
+    assertThat(servicePointIds,
       hasItems(regularServicePointId1.toString(), regularServicePointId2.toString()));
     if (isRoutingServicePointExpectedInResponse) {
-      assertThat(regularServicePointIds, hasItem(routingServicePointId.toString()));
-      assertThat(regularServicePointIds, hasSize(3));
+      assertThat(servicePointIds, hasItem(routingServicePointId.toString()));
+      assertThat(servicePointIds, hasSize(3));
     } else {
-      assertThat(regularServicePointIds, hasSize(2));
+      assertThat(servicePointIds, hasSize(2));
     }
   }
 

--- a/src/test/java/org/folio/rest/api/ServicePointTest.java
+++ b/src/test/java/org/folio/rest/api/ServicePointTest.java
@@ -723,11 +723,11 @@ public class ServicePointTest extends TestBase {
   @Test
   @Parameters({
     "false, ", // no query parameters
-    "false, ?query=code=cd*",
+    "false, ?query=cql.allRecords=1%20sortby%20name&limit=1000",
     "false, ?includeRoutingServicePoints=false",
-    "false, ?includeRoutingServicePoints=false&query=code=cd*",
     "true,  ?includeRoutingServicePoints=true",
-    "true,  ?includeRoutingServicePoints=true&query=code=cd*"
+    "false, ?includeRoutingServicePoints=false&query=cql.allRecords=1%20sortby%20name&limit=1000",
+    "true,  ?includeRoutingServicePoints=true&query=cql.allRecords=1%20sortby%20name&limit=1000"
   })
   public void ecsRequestRoutingServicePointsAreReturnedOnlyWhenExplicitlyRequested(
     boolean shouldReturnRoutingServicePoints, String queryParameters) throws Exception {

--- a/src/test/java/org/folio/utility/LocationUtility.java
+++ b/src/test/java/org/folio/utility/LocationUtility.java
@@ -184,7 +184,7 @@ public final class LocationUtility {
     throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
 
     return createServicePoint(id, name, code, discoveryDisplayName, description,
-      shelvingLagTime, pickupLocation, shelfExpiryPeriod, Collections.emptyList(), TENANT_ID);
+      shelvingLagTime, pickupLocation, shelfExpiryPeriod, Collections.emptyList(), null, TENANT_ID);
   }
 
   public static Response createServicePoint(UUID id, String name, String code,
@@ -194,7 +194,7 @@ public final class LocationUtility {
     throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
 
     return createServicePoint(id, name, code, discoveryDisplayName, description,
-      shelvingLagTime, pickupLocation, shelfExpiryPeriod, Collections.emptyList(), tenantId);
+      shelvingLagTime, pickupLocation, shelfExpiryPeriod, Collections.emptyList(), null, tenantId);
   }
 
   public static Response createServicePoint(UUID id, String name, String code,
@@ -204,13 +204,13 @@ public final class LocationUtility {
     throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
 
     return createServicePoint(id, name, code, discoveryDisplayName, description, shelvingLagTime, pickupLocation,
-      shelfExpiryPeriod, slips, TENANT_ID);
+      shelfExpiryPeriod, slips, null, TENANT_ID);
   }
 
   public static Response createServicePoint(UUID id, String name, String code,
                                             String discoveryDisplayName, String description, Integer shelvingLagTime,
                                             Boolean pickupLocation, HoldShelfExpiryPeriod shelfExpiryPeriod,
-                                            List<StaffSlip> slips, String tenantId)
+                                            List<StaffSlip> slips, Boolean ecsRequestRouting, String tenantId)
     throws MalformedURLException, InterruptedException, ExecutionException, TimeoutException {
 
     final CompletableFuture<Response> createServicePoint = new CompletableFuture<>();
@@ -219,6 +219,9 @@ public final class LocationUtility {
       .put("name", name)
       .put("code", code)
       .put("discoveryDisplayName", discoveryDisplayName);
+    if (ecsRequestRouting != null) {
+      request.put("ecsRequestRouting", ecsRequestRouting);
+    }
     if (id != null) {
       request.put("id", id.toString());
     }


### PR DESCRIPTION
### Purpose
Return ECS routing service points in response to `GET /service-points` only when explicitly requested.
[MODINVSTOR-1219](https://github.com/folio-org/mod-inventory-storage/compare/MODINVSTOR-1219)

### Approach
Introduce a new query parameter `includeRoutingServicePoints` to `GET /service-points` endpoint. Set this flag to `false` by default. Return ECS routing service points only when it is explicitly set to `true`.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
_List any Jira issues related to this pull request._

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
