### PR TITLE
MODINVSTOR-1223 Implement a POST request to get holdings and instances

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 ### Features
 * Implement domain event production for location create/update/delete ([MODINVSTOR-1181](https://issues.folio.org/browse/MODINVSTOR-1181))
+* Implement a POST request to get Holdings and Instances
 
 ### Bug fixes
 * Unintended update of instance records \_version (optimistic locking) whenever any of its holdings or items are created, updated or deleted. ([MODINVSTOR-1186](https://folio-org.atlassian.net/browse/MODINVSTOR-1186))

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,12 +3,12 @@
 * Description ([ISSUE\_NUMBER](https://folio-org.atlassian.net/browse/ISSUE_NUMBER))
 
 ### New APIs versions
-* Provides `API_NAME vX.Y`
-* Requires `API_NAME vX.Y`
+* Provides `instance-storage 10.1`
+* Requires `holdings-storage 6.1`
 
 ### Features
 * Implement domain event production for location create/update/delete ([MODINVSTOR-1181](https://issues.folio.org/browse/MODINVSTOR-1181))
-* Implement a POST request to get Holdings and Instances
+* Implement a POST request to get Holdings and Instances ([MODINVSTOR-1223](https://folio-org.atlassian.net/browse/MODINVSTOR-1223))
 
 ### Bug fixes
 * Unintended update of instance records \_version (optimistic locking) whenever any of its holdings or items are created, updated or deleted. ([MODINVSTOR-1186](https://folio-org.atlassian.net/browse/MODINVSTOR-1186))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -77,7 +77,7 @@
     },
     {
       "id": "holdings-storage",
-      "version": "6.0",
+      "version": "6.1",
       "handlers": [
         {
           "methods": ["GET"],
@@ -146,7 +146,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "10.0",
+      "version": "10.1",
       "handlers": [
         {
           "methods": ["GET"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -83,6 +83,10 @@
           "methods": ["GET"],
           "pathPattern": "/holdings-storage/holdings",
           "permissionsRequired": ["inventory-storage.holdings.collection.get"]
+        },{
+          "methods": ["POST"],
+          "pathPattern": "/holdings-storage/holdings/retrieve",
+          "permissionsRequired": ["inventory-storage.holdings.collection.get"]
         }, {
           "methods": ["GET"],
           "pathPattern": "/holdings-storage/holdings/{id}",
@@ -148,7 +152,12 @@
           "methods": ["GET"],
           "pathPattern": "/instance-storage/instances",
           "permissionsRequired": ["inventory-storage.instances.collection.get"]
-        }, {
+        },{
+          "methods": ["POST"],
+          "pathPattern": "/instance-storage/instances/retrieve",
+          "permissionsRequired": ["inventory-storage.instances.collection.get"]
+        },
+        {
           "methods": ["GET"],
           "pathPattern": "/instance-storage/instances/{id}",
           "permissionsRequired": ["inventory-storage.instances.item.get"]

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <assertj.version>3.25.3</assertj.version>
 
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
-    <build-helper-maven-plugin.version>3.5.0</build-helper-maven-plugin.version>
+    <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
     <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
     <maven-release-plugin.version>3.0.1</maven-release-plugin.version>
     <aspectj-maven-plugin.version>1.14</aspectj-maven-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <ramlfiles_path>${basedir}/ramls/</ramlfiles_path>
-    <generate_routing_context>/instance-storage/instances,/holdings-storage/holdings,/item-storage/items,/record-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances,/inventory-hierarchy/updated-instance-ids,/inventory-hierarchy/items-and-holdings,/inventory-view/instances</generate_routing_context>
+    <generate_routing_context>/instance-storage/instances,/instance-storage/instances/retrieve,/holdings-storage/holdings,/holdings-storage/holdings/retrieve,/item-storage/items,/record-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances,/inventory-hierarchy/updated-instance-ids,/inventory-hierarchy/items-and-holdings,/inventory-view/instances</generate_routing_context>
     <argLine />
 
     <raml-module-builder-version>35.2.2</raml-module-builder-version> <!-- also update vertx.version -->

--- a/ramls/examples/retrieveEntitiesDto.json
+++ b/ramls/examples/retrieveEntitiesDto.json
@@ -1,0 +1,5 @@
+{
+  "limit": 10,
+  "offset": 10,
+  "query": "status=\"Available\""
+}

--- a/ramls/holdings-storage.raml
+++ b/ramls/holdings-storage.raml
@@ -13,6 +13,7 @@ types:
   holdingsRecords: !include holdings-storage/holdingsRecords.json
   holdingsRecordView: !include holdings-storage/holdingsRecordView.json
   holdingsRecordViews: !include holdings-storage/holdingsRecordViews.json
+  retrieveDto: !include retrieveEntitiesDto.json
   errors: !include raml-util/schemas/errors.schema
 
 traits:
@@ -82,3 +83,14 @@ resourceTypes:
             example:
               strict: false
               value: !include examples/holdings-storage/holdingsRecord_get.json
+    /retrieve:
+      post:
+        is: [ validate ]
+        body:
+          application/json:
+            type: retrieveDto
+            example:
+              strict: false
+              value: !include examples/retrieveEntitiesDto.json
+        description: |
+          Get Holdings by POST request

--- a/ramls/instance-storage.raml
+++ b/ramls/instance-storage.raml
@@ -14,10 +14,13 @@ types:
   marcJson: !include marc.json
   instanceRelationship: !include instancerelationship.json
   instanceRelationships: !include instancerelationships.json
+  retrieveDto: !include retrieveEntitiesDto.json
+  errors: !include raml-util/schemas/errors.schema
 
 traits:
   pageable: !include raml-util/traits/pageable.raml
   searchable: !include raml-util/traits/searchable.raml
+  validate: !include raml-util/traits/validation.raml
 
 resourceTypes:
   collection: !include raml-util/rtypes/collection.raml
@@ -144,3 +147,14 @@ resourceTypes:
                 body:
                   text/plain:
                     example: "Not implemented yet"
+    /retrieve:
+      post:
+        is: [ validate ]
+        body:
+          application/json:
+            type: retrieveDto
+            example:
+              strict: false
+              value: !include examples/retrieveEntitiesDto.json
+        description: |
+          Get Instances by POST request

--- a/ramls/retrieveEntitiesDto.json
+++ b/ramls/retrieveEntitiesDto.json
@@ -1,20 +1,24 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "DTO for fetching Holding and Instances by POST request",
   "type": "object",
   "properties": {
     "offset": {
+      "description": "Skip over a number of elements by specifying an offset value for the query",
       "type": "integer",
       "minimum": 0,
       "maximum": 2147483647,
       "default": 0
     },
     "limit": {
+      "description": "Limit the number of elements returned in the response",
       "type": "integer",
       "minimum": 0,
       "maximum": 2147483647,
       "default": 10
     },
     "query": {
+      "description": "A query expressed as a CQL string",
       "type": "string"
     }
   }

--- a/ramls/retrieveEntitiesDto.json
+++ b/ramls/retrieveEntitiesDto.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "description": "DTO for fetching Holding and Instances by POST request",
+  "description": "DTO for fetching records by POST request",
   "type": "object",
   "properties": {
     "offset": {

--- a/ramls/retrieveEntitiesDto.json
+++ b/ramls/retrieveEntitiesDto.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "properties": {
+    "offset": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647,
+      "default": 0
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 0,
+      "maximum": 2147483647,
+      "default": 10
+    },
+    "query": {
+      "type": "string"
+    }
+  }
+}

--- a/src/main/java/org/folio/rest/impl/HoldingsStorageApi.java
+++ b/src/main/java/org/folio/rest/impl/HoldingsStorageApi.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.Response;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.HoldingsRecordView;
+import org.folio.rest.jaxrs.model.RetrieveDto;
 import org.folio.rest.jaxrs.resource.HoldingsStorage;
 import org.folio.rest.persist.PgUtil;
 import org.folio.rest.support.EndpointFailureHandler;
@@ -83,6 +84,17 @@ public class HoldingsStorageApi implements HoldingsStorage {
     new HoldingsService(vertxContext, okapiHeaders).deleteHolding(holdingsRecordId)
       .otherwise(EndpointFailureHandler::failureResponse)
       .onComplete(asyncResultHandler);
+  }
+
+  @Validate
+  @Override
+  public void postHoldingsStorageHoldingsRetrieve(RetrieveDto entity,
+                                                  RoutingContext routingContext,
+                                                  Map<String, String> okapiHeaders,
+                                                  Handler<AsyncResult<Response>> asyncResultHandler,
+                                                  Context vertxContext) {
+    PgUtil.streamGet(HOLDINGS_RECORD_TABLE, HoldingsRecordView.class, entity.getQuery(), entity.getOffset(),
+      entity.getLimit(), null, "holdingsRecords", routingContext, okapiHeaders, vertxContext);
   }
 
   @Validate

--- a/src/main/java/org/folio/rest/impl/InstanceStorageApi.java
+++ b/src/main/java/org/folio/rest/impl/InstanceStorageApi.java
@@ -43,6 +43,8 @@ public class InstanceStorageApi implements InstanceStorage {
   private static final Logger log = LogManager.getLogger();
   private final Messages messages = Messages.getInstance();
 
+  private static final String TITLE = "title";
+
   @Validate
   @Override
   public void getInstanceStorageInstanceRelationships(String totalRecords, int offset, int limit, String query,
@@ -201,11 +203,11 @@ public class InstanceStorageApi implements InstanceStorage {
                                           Handler<AsyncResult<Response>> asyncResultHandler,
                                           Context vertxContext) {
 
-    if (PgUtil.checkOptimizedCQL(query, "title") != null) { // Until RMB-573 is fixed
+    if (PgUtil.checkOptimizedCQL(query, TITLE) != null) { // Until RMB-573 is fixed
       try {
         PreparedCql preparedCql = handleCql(query, limit, offset);
         PgUtil.getWithOptimizedSql(preparedCql.getTableName(), Instance.class, Instances.class,
-          "title", query, offset, limit,
+          TITLE, query, offset, limit,
           okapiHeaders, vertxContext, GetInstanceStorageInstancesResponse.class, asyncResultHandler);
       } catch (Exception e) {
         log.error(e.getMessage(), e);
@@ -395,11 +397,11 @@ public class InstanceStorageApi implements InstanceStorage {
                                                    Map<String, String> okapiHeaders,
                                                    Handler<AsyncResult<Response>> asyncResultHandler,
                                                    Context vertxContext) {
-    if (PgUtil.checkOptimizedCQL(entity.getQuery(), "title") != null) {
+    if (PgUtil.checkOptimizedCQL(entity.getQuery(), TITLE) != null) {
       try {
         PreparedCql preparedCql = handleCql(entity.getQuery(), entity.getLimit(), entity.getOffset());
         PgUtil.getWithOptimizedSql(preparedCql.getTableName(), Instance.class, Instances.class,
-          "title", entity.getQuery(), entity.getOffset(), entity.getLimit(),
+          TITLE, entity.getQuery(), entity.getOffset(), entity.getLimit(),
           okapiHeaders, vertxContext, GetInstanceStorageInstancesResponse.class, asyncResultHandler);
       } catch (Exception e) {
         log.error(e.getMessage(), e);

--- a/src/main/java/org/folio/rest/impl/InstanceStorageApi.java
+++ b/src/main/java/org/folio/rest/impl/InstanceStorageApi.java
@@ -41,9 +41,8 @@ import org.folio.services.instance.InstanceService;
 
 public class InstanceStorageApi implements InstanceStorage {
   private static final Logger log = LogManager.getLogger();
-  private final Messages messages = Messages.getInstance();
-
   private static final String TITLE = "title";
+  private final Messages messages = Messages.getInstance();
 
   @Validate
   @Override

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -533,28 +533,27 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     instancesClient.create(nod(secondInstanceId));
     instancesClient.create(uprooted(thirdInstanceId));
 
-    var firstHoldingId = holdingsClient.create(new HoldingRequestBuilder()
+    CompletableFuture<Response> getCompleted = new CompletableFuture<>();
+
+    final var firstHoldingId = holdingsClient.create(new HoldingRequestBuilder()
       .forInstance(firstInstanceId)
       .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)).getId();
 
-    var secondHoldingId = holdingsClient.create(new HoldingRequestBuilder()
+    final var secondHoldingId = holdingsClient.create(new HoldingRequestBuilder()
       .forInstance(secondInstanceId)
       .withPermanentLocation(ANNEX_LIBRARY_LOCATION_ID)).getId();
 
-    var thirdHoldingId = holdingsClient.create(new HoldingRequestBuilder()
+    final var thirdHoldingId = holdingsClient.create(new HoldingRequestBuilder()
       .forInstance(thirdInstanceId)
       .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)
       .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getId();
-
-    var getCompleted = new CompletableFuture<Response>();
 
     getClient().post(holdingsStorageUrl("/retrieve"), new JsonObject(), TENANT_ID,
       ResponseHandler.json(getCompleted));
 
     var response = getCompleted.get(TIMEOUT, TimeUnit.SECONDS);
     var responseBody = response.getJson();
-    var allHoldings = JsonArrayHelper.toList(
-      responseBody.getJsonArray("holdingsRecords"));
+    var allHoldings = JsonArrayHelper.toList(responseBody.getJsonArray("holdingsRecords"));
 
     assertThat(allHoldings.size(), is(3));
     assertThat(responseBody.getInteger("totalRecords"), is(3));

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -525,37 +525,35 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   @SneakyThrows
   @Test
   public void canRetrieveAllHoldings() {
-    UUID firstInstanceId = UUID.randomUUID();
-    UUID secondInstanceId = UUID.randomUUID();
-    UUID thirdInstanceId = UUID.randomUUID();
+    var firstInstanceId = UUID.randomUUID();
+    var secondInstanceId = UUID.randomUUID();
+    var thirdInstanceId = UUID.randomUUID();
 
     instancesClient.create(smallAngryPlanet(firstInstanceId));
     instancesClient.create(nod(secondInstanceId));
     instancesClient.create(uprooted(thirdInstanceId));
 
-    final UUID firstHoldingId = holdingsClient.create(new HoldingRequestBuilder()
+    var firstHoldingId = holdingsClient.create(new HoldingRequestBuilder()
       .forInstance(firstInstanceId)
       .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)).getId();
 
-    final UUID secondHoldingId = holdingsClient.create(new HoldingRequestBuilder()
+    var secondHoldingId = holdingsClient.create(new HoldingRequestBuilder()
       .forInstance(secondInstanceId)
       .withPermanentLocation(ANNEX_LIBRARY_LOCATION_ID)).getId();
 
-    final UUID thirdHoldingId = holdingsClient.create(new HoldingRequestBuilder()
+    var thirdHoldingId = holdingsClient.create(new HoldingRequestBuilder()
       .forInstance(thirdInstanceId)
       .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)
       .withTags(new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))).getId();
 
-    CompletableFuture<Response> getCompleted = new CompletableFuture<>();
+    var getCompleted = new CompletableFuture<Response>();
 
     getClient().post(holdingsStorageUrl("/retrieve"), new JsonObject(), TENANT_ID,
       ResponseHandler.json(getCompleted));
 
-    Response response = getCompleted.get(TIMEOUT, TimeUnit.SECONDS);
-
-    JsonObject responseBody = response.getJson();
-
-    List<JsonObject> allHoldings = JsonArrayHelper.toList(
+    var response = getCompleted.get(TIMEOUT, TimeUnit.SECONDS);
+    var responseBody = response.getJson();
+    var allHoldings = JsonArrayHelper.toList(
       responseBody.getJsonArray("holdingsRecords"));
 
     assertThat(allHoldings.size(), is(3));

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -671,7 +671,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     createInstance(firstInstanceToCreate);
     createInstance(secondInstanceToCreate);
 
-    var query = "title=\"Nod\"";
+    var query = "(cql.allRecords=1) sortBy title";
     var retrieveCompleted = new CompletableFuture<Response>();
     var retrieveByTitleCompleted = new CompletableFuture<Response>();
 
@@ -684,10 +684,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     var allInstances = retrieveBody.getJsonArray(INSTANCES_KEY);
 
     var retrieveByTitleBody = retrieveByTitleCompleted.get(10, SECONDS).getJson();
-    var foundInstances = retrieveByTitleBody.getJsonArray(INSTANCES_KEY);
+    var sortedInstances = retrieveByTitleBody.getJsonArray(INSTANCES_KEY);
 
     assertThat(allInstances.size(), is(2));
-    assertThat(foundInstances.size(), is(1));
+    assertThat(sortedInstances.size(), is(2));
     assertThat(retrieveBody.getInteger(TOTAL_RECORDS_KEY), is(2));
 
     var firstInstance = allInstances.getJsonObject(0);
@@ -699,7 +699,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       firstInstance = secondInstance;
       secondInstance = tmp;
     }
-    final var foundInstance = foundInstances.getJsonObject(0);
+    final var sortedInstance = sortedInstances.getJsonObject(0);
 
     assertThat(firstInstance.getString("id"), is(firstInstanceId.toString()));
     assertThat(firstInstance.getString("title"), is("Long Way to a Small Angry Planet"));
@@ -715,7 +715,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(secondInstance.getJsonArray("identifiers"),
       hasItem(identifierMatches(UUID_ASIN.toString(), "B01D1PLMDO")));
 
-    assertThat(foundInstance.getString("title"), is("Nod"));
+    assertThat(sortedInstance.getString("title"), is("Long Way to a Small Angry Planet"));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -667,11 +667,11 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     var firstInstanceToCreate = smallAngryPlanet(firstInstanceId);
     var secondInstanceId = UUID.randomUUID();
     var secondInstanceToCreate = nod(secondInstanceId);
-    var query = "title=\"Nod\"";
 
     createInstance(firstInstanceToCreate);
     createInstance(secondInstanceToCreate);
 
+    var query = "title=\"Nod\"";
     var retrieveCompleted = new CompletableFuture<Response>();
     var retrieveByTitleCompleted = new CompletableFuture<Response>();
 
@@ -692,7 +692,6 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     var firstInstance = allInstances.getJsonObject(0);
     var secondInstance = allInstances.getJsonObject(1);
-    var foundInstance = foundInstances.getJsonObject(0);
     // no "sortBy" used so the database can return them in any order.
     // swap if needed:
     if (firstInstanceId.toString().equals(secondInstance.getString("id"))) {
@@ -700,6 +699,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
       firstInstance = secondInstance;
       secondInstance = tmp;
     }
+    final var foundInstance = foundInstances.getJsonObject(0);
 
     assertThat(firstInstance.getString("id"), is(firstInstanceId.toString()));
     assertThat(firstInstance.getString("title"), is("Long Way to a Small Angry Planet"));


### PR DESCRIPTION
### Purpose
When requesting `instance-storage/instance` or `holding-storage/holdings` API, a `414` error sometimes occurs if the query parameter contains too many characters

### Approach
Add POST requests `instance-storage/instances/retrieve` and `holding-storage/holdings/retrieve` and pass values in the request body

### Changes Checklist
- [x] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODINVSTOR-1223
