### PR TITLE
[DO NOT MERGE] streaming endpoint for inventory-view

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1239,7 +1239,7 @@
       "version": "2.0",
       "handlers": [
         {
-          "methods": ["GET"],
+          "methods": ["GET", "POST"],
           "pathPattern": "/inventory-view/instances",
           "permissionsRequired": ["inventory-storage.inventory-view.instances.collection.get"]
         }

--- a/pom.xml
+++ b/pom.xml
@@ -570,39 +570,39 @@
         </configuration>
       </plugin>
 
-<!--      <plugin>-->
-<!--        <groupId>org.apache.maven.plugins</groupId>-->
-<!--        <artifactId>maven-checkstyle-plugin</artifactId>-->
-<!--        <version>${maven-checkstyle-plugin.version}</version>-->
-<!--        <dependencies>-->
-<!--          <dependency>-->
-<!--            <groupId>com.puppycrawl.tools</groupId>-->
-<!--            <artifactId>checkstyle</artifactId>-->
-<!--            <version>${checkstyle.version}</version>-->
-<!--          </dependency>-->
-<!--        </dependencies>-->
-<!--        <executions>-->
-<!--          <execution>-->
-<!--            <id>verify-style</id>-->
-<!--            <phase>process-classes</phase>-->
-<!--            <goals>-->
-<!--              <goal>check</goal>-->
-<!--            </goals>-->
-<!--          </execution>-->
-<!--        </executions>-->
-<!--        <configuration>-->
-<!--          <sourceDirectories>-->
-<!--            <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>-->
-<!--            <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>-->
-<!--          </sourceDirectories>-->
-<!--          <failsOnError>true</failsOnError>-->
-<!--          <violationSeverity>warning</violationSeverity>-->
-<!--          <failOnViolation>true</failOnViolation>-->
-<!--          <logViolationsToConsole>true</logViolationsToConsole>-->
-<!--          <configLocation>checkstyle/checkstyle.xml</configLocation>-->
-<!--          <cacheFile>${basedir}/target/cachefile</cacheFile>-->
-<!--        </configuration>-->
-<!--      </plugin>-->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <version>${maven-checkstyle-plugin.version}</version>
+        <dependencies>
+          <dependency>
+            <groupId>com.puppycrawl.tools</groupId>
+            <artifactId>checkstyle</artifactId>
+            <version>${checkstyle.version}</version>
+          </dependency>
+        </dependencies>
+        <executions>
+          <execution>
+            <id>verify-style</id>
+            <phase>process-classes</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <sourceDirectories>
+            <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
+            <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
+          </sourceDirectories>
+          <failsOnError>true</failsOnError>
+          <violationSeverity>warning</violationSeverity>
+          <failOnViolation>true</failOnViolation>
+          <logViolationsToConsole>true</logViolationsToConsole>
+          <configLocation>checkstyle/checkstyle.xml</configLocation>
+          <cacheFile>${basedir}/target/cachefile</cacheFile>
+        </configuration>
+      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,10 @@
       <artifactId>vertx-kafka-client</artifactId>
     </dependency>
     <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-rx-java3</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.github.ben-manes.caffeine</groupId>
       <artifactId>caffeine</artifactId>
       <version>${caffeine.version}</version>
@@ -566,39 +570,39 @@
         </configuration>
       </plugin>
 
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>${maven-checkstyle-plugin.version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>${checkstyle.version}</version>
-          </dependency>
-        </dependencies>
-        <executions>
-          <execution>
-            <id>verify-style</id>
-            <phase>process-classes</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <sourceDirectories>
-            <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>
-            <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>
-          </sourceDirectories>
-          <failsOnError>true</failsOnError>
-          <violationSeverity>warning</violationSeverity>
-          <failOnViolation>true</failOnViolation>
-          <logViolationsToConsole>true</logViolationsToConsole>
-          <configLocation>checkstyle/checkstyle.xml</configLocation>
-          <cacheFile>${basedir}/target/cachefile</cacheFile>
-        </configuration>
-      </plugin>
+<!--      <plugin>-->
+<!--        <groupId>org.apache.maven.plugins</groupId>-->
+<!--        <artifactId>maven-checkstyle-plugin</artifactId>-->
+<!--        <version>${maven-checkstyle-plugin.version}</version>-->
+<!--        <dependencies>-->
+<!--          <dependency>-->
+<!--            <groupId>com.puppycrawl.tools</groupId>-->
+<!--            <artifactId>checkstyle</artifactId>-->
+<!--            <version>${checkstyle.version}</version>-->
+<!--          </dependency>-->
+<!--        </dependencies>-->
+<!--        <executions>-->
+<!--          <execution>-->
+<!--            <id>verify-style</id>-->
+<!--            <phase>process-classes</phase>-->
+<!--            <goals>-->
+<!--              <goal>check</goal>-->
+<!--            </goals>-->
+<!--          </execution>-->
+<!--        </executions>-->
+<!--        <configuration>-->
+<!--          <sourceDirectories>-->
+<!--            <sourceDirectory>${project.build.sourceDirectory}</sourceDirectory>-->
+<!--            <sourceDirectory>${project.build.testSourceDirectory}</sourceDirectory>-->
+<!--          </sourceDirectories>-->
+<!--          <failsOnError>true</failsOnError>-->
+<!--          <violationSeverity>warning</violationSeverity>-->
+<!--          <failOnViolation>true</failOnViolation>-->
+<!--          <logViolationsToConsole>true</logViolationsToConsole>-->
+<!--          <configLocation>checkstyle/checkstyle.xml</configLocation>-->
+<!--          <cacheFile>${basedir}/target/cachefile</cacheFile>-->
+<!--        </configuration>-->
+<!--      </plugin>-->
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/ramls/ids-request.json
+++ b/ramls/ids-request.json
@@ -1,0 +1,18 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A collection of IDs",
+  "type": "object",
+  "properties": {
+    "ids": {
+      "description": "List of IDs",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "ids"
+  ]
+}

--- a/ramls/inventory-view.raml
+++ b/ramls/inventory-view.raml
@@ -10,6 +10,7 @@ documentation:
 
 types:
   inventoryViewInstance: !include inventory-view-instance.json
+  idsRequest: !include ids-request.json
   errors: !include raml-util/schemas/errors.schema
 
 traits:
@@ -29,3 +30,11 @@ resourceTypes:
     description: Get instances by id with their holdings and items
     is: [pageable, searchable: {description: "using CQL",
                       example: "title=\"*uproot*\""}]
+  post:
+    description: Return Instances by id with their holdings and items
+    is: [validate]
+    body:
+      application/json:
+        type: idsRequest
+
+

--- a/src/main/java/org/folio/rest/impl/InventoryViewApi.java
+++ b/src/main/java/org/folio/rest/impl/InventoryViewApi.java
@@ -1,18 +1,37 @@
 package org.folio.rest.impl;
 
+import static io.vertx.core.http.HttpHeaders.CONNECTION;
+import static io.vertx.core.http.HttpHeaders.CONTENT_TYPE;
 import static org.folio.rest.persist.PgUtil.streamGet;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import io.vertx.core.Handler;
+import io.vertx.core.buffer.Buffer;
+import io.vertx.core.http.HttpServerResponse;
 import io.vertx.ext.web.RoutingContext;
+import io.vertx.rxjava3.FlowableHelper;
+import io.vertx.rxjava3.WriteStreamSubscriber;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.Tuple;
 import java.util.Map;
 import javax.ws.rs.core.Response;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.rest.annotations.Validate;
+import org.folio.rest.jaxrs.model.IdsRequest;
 import org.folio.rest.jaxrs.model.InventoryViewInstance;
 import org.folio.rest.jaxrs.resource.InventoryViewInstances;
+import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.support.EndpointFailureHandler;
+import org.folio.rest.tools.utils.TenantTool;
 
 public class InventoryViewApi implements InventoryViewInstances {
+
+  protected static final Logger log = LogManager.getLogger();
+
   @Validate
   @Override
   public void getInventoryViewInstances(String totalRecords, int offset, int limit, String query,
@@ -21,5 +40,76 @@ public class InventoryViewApi implements InventoryViewInstances {
 
     streamGet("instance_holdings_item_view", InventoryViewInstance.class, query,
       offset, limit, null, "instances", routingContext, okapiHeaders, vertxContext);
+  }
+
+  @Validate
+  @Override
+  public void postInventoryViewInstances(IdsRequest entity, RoutingContext routingContext,
+                                         Map<String, String> okapiHeaders,
+                                         Handler<AsyncResult<Response>> asyncResultHandler,
+                                         Context vertxContext) {
+    if(entity.getIds() == null) asyncResultHandler.handle(
+      Future.succeededFuture(EndpointFailureHandler
+        .failureResponse(new RuntimeException("no id(s) presents"))));
+    if(entity.getIds().size() > 30_000) asyncResultHandler.handle(
+      Future.succeededFuture(EndpointFailureHandler
+        .failureResponse(new RuntimeException("Over the limit of the identifiers present"))));
+    log.info("postInventoryViewInstances:: {} id(s)", entity.getIds().size());
+
+    //region create subscriber with the response object so that objects can be piped to it
+    HttpServerResponse response = prepareStreamResponse(routingContext);
+    WriteStreamSubscriber<Buffer> responseSubscriber = io.vertx.rxjava3.RxHelper.toSubscriber(response);
+    responseSubscriber.onError(throwable -> {
+      if (!response.headWritten() && response.closed()) {
+        response.setStatusCode(500).end("oops");
+      } else {
+        log.error(throwable);
+      }
+    });
+    responseSubscriber.onWriteStreamEnd(() -> {
+      log.info("write stream complete");
+    });
+    //endregion
+
+    String tenantId = TenantTool.tenantId(okapiHeaders);
+    PostgresClient postgresClient = PgUtil.postgresClient(vertxContext, okapiHeaders);
+    postgresClient.withTrans(conn ->
+        conn.execute("create temp table if not exists id_temp(id uuid) on commit delete rows;")
+          .compose(ar ->
+            conn
+              .execute("insert into id_temp values ($1);",
+                entity.getIds().stream().map(Tuple::of).toList()))
+          .compose(ar ->
+            conn.selectStream(
+              String.format("select id, jsonb from %s_%s.instance_holdings_item_view "
+                  + "where id in (select id from id_temp);",
+                tenantId, "mod_inventory_storage"),
+              Tuple.tuple(),
+              rowStream -> {
+                FlowableHelper.toFlowable(rowStream)
+                  .map(this::convertRow)
+                  .subscribe(responseSubscriber);
+              }
+            )
+          )
+          .onFailure(th -> {
+            log.error(th.getMessage(), th);
+            asyncResultHandler.handle(Future.succeededFuture(EndpointFailureHandler.failureResponse(th)));
+          })
+    );
+
+  }
+
+  private Buffer convertRow(Row row) {
+    // appended newline to conform to ndjson
+    return row.getJsonObject(1).toBuffer().appendString("\r\n");
+  }
+
+  private HttpServerResponse prepareStreamResponse(RoutingContext routingContext) {
+    return routingContext.response()
+      .setStatusCode(200)
+      .setChunked(true)
+      .putHeader(CONTENT_TYPE, "application/x-ndjson")
+      .putHeader(CONNECTION, "keep-alive");
   }
 }

--- a/src/main/java/org/folio/rest/impl/InventoryViewApi.java
+++ b/src/main/java/org/folio/rest/impl/InventoryViewApi.java
@@ -48,12 +48,16 @@ public class InventoryViewApi implements InventoryViewInstances {
                                          Map<String, String> okapiHeaders,
                                          Handler<AsyncResult<Response>> asyncResultHandler,
                                          Context vertxContext) {
-    if(entity.getIds() == null) asyncResultHandler.handle(
-      Future.succeededFuture(EndpointFailureHandler
-        .failureResponse(new RuntimeException("no id(s) presents"))));
-    if(entity.getIds().size() > 30_000) asyncResultHandler.handle(
-      Future.succeededFuture(EndpointFailureHandler
-        .failureResponse(new RuntimeException("Over the limit of the identifiers present"))));
+    if (entity.getIds() == null) {
+      asyncResultHandler.handle(
+        Future.succeededFuture(EndpointFailureHandler
+          .failureResponse(new RuntimeException("no id(s) presents"))));
+    }
+    if (entity.getIds().size() > 30_000) {
+      asyncResultHandler.handle(
+        Future.succeededFuture(EndpointFailureHandler
+          .failureResponse(new RuntimeException("Over the limit of the identifiers present"))));
+    }
     log.info("postInventoryViewInstances:: {} id(s)", entity.getIds().size());
 
     //region create subscriber with the response object so that objects can be piped to it


### PR DESCRIPTION
### Purpose
Spike  to provide a HTTP path to extract instances from mod-inventory-storage. Primary use is the mod-search during its reindex process.

### Approach
The previous endpoint GET /inventory-view/instances would only accept instance UUIDs via the CQL query parameter. This forced a limitation of about 50 instances to be retrieved from mod-inventory-storage. The new endpoint POST /inventory-view/instances accepts instance UUIDS via its request body. This will significantly increase the number of instance that can be returned with each call.
The list of instance identifiers is passed to the database via a temporary table. This is to overcome really long SQL clauses that join all identifiers with a OR or IN operator. Records from the database are returned via a cursor all the way to the http response for streaming.
HTTP response is chunked to allow for streaming of instance objects. The content-type of this new endpoint is NDJSON(newline-demilited JSON). Each JSON object is seperated by a new line.

### Advantages
- In local testing of 5,000 instance UUIDs, the GET endpoint was called in batches of 50 UUIDs and the POST endpoint was called with a single call with 5,000 UUIDs. The GET endpoint took 19 seconds while the single POST took 5 seconds. This represents a **73.68%** performance gain.
- Clients like mod-search do not need to wait till the end of the response body to begin processing, especially for really large payloads. This also allows better memory utilization on the client side. Imagine needing to create instance representations in memory totalling 10GB before intiating processing. Instead Instance representations can be created and indexed as responses are recieved and then garbage collected. This means >10 GB of memory does not need to be assigned to the mod-search module instance.
- With the POST endpoint, multiple calls to okapi and mod-authtoken do not occur. The request is authenticated once instead of many times with each batch of 50 UUIDs. This reduces overhead for these modules.
- In this implementation, the JSON objects in the database are transformed into HTTP responses without converting to a POJO with Jackson library. This saves some CPU for the mod-inventory-storage instance. If further edits are required on the JSON object before returning it as a HTTP response, this can still occur.
- There would be less thrashing of database connections since each batch of 50 would not be request a connection each time.
- The SQL statement to retrieve instances is generally stable since different number of instance UUIDs would not create "new" queries with different WHERE clauses; unlike the current CQL implementation with the GET endpoint. The means Postgres' query analyzer is not parsing new statements each time.

### Disadvantages
- Appropriate limits would need to be placed so that memory on the database and the module instance is not overrun. We don't 14 million instances to be retrieved in one shot.
- A database transaction has to be live for the duration of the cursor.


A PR showing mod-search consuming this endpoint is [here](https://github.com/folio-org/mod-search/pull/604)
