### PR TITLE
MODINVSTOR-1251: kafka.KafkaContainer, apache/kafka-native:3.8.0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,7 +32,7 @@
 * Identifier types: change Cancelled LCCN to Canceled LCCN ([MODINVSTOR-1212](https://folio-org.atlassian.net/browse/MODINVSTOR-1212))
 
 ### Tech Dept
-* Description ([ISSUE\_NUMBER](https://folio-org.atlassian.net/browse/ISSUE_NUMBER))
+* Kafka testcontainers: kafka.KafkaContainer, apache/kafka-native:3.8.0, KafkaTopicsExistsTest fix ([MODINVSTOR-1251](https://folio-org.atlassian.net/browse/MODINVSTOR-1251))
 
 ### Dependencies
 * Bump `LIB_NAME` from `OLD_VERSION` to `NEW_VERSION`

--- a/src/test/java/org/folio/rest/InstallUpgradeIT.java
+++ b/src/test/java/org/folio/rest/InstallUpgradeIT.java
@@ -21,6 +21,7 @@ import java.nio.file.Path;
 import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.utility.KafkaUtility;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -31,12 +32,11 @@ import org.testcontainers.Testcontainers;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.Container.ExecResult;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.containers.output.Slf4jLogConsumer;
 import org.testcontainers.images.builder.ImageFromDockerfile;
-import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.kafka.KafkaContainer;
 
 /**
  * Check the shaded fat uber jar and Dockerfile:
@@ -59,7 +59,7 @@ public class InstallUpgradeIT {
 
   @ClassRule(order = 0)
   public static final KafkaContainer KAFKA =
-    new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.0.3"))
+    new KafkaContainer(KafkaUtility.getImageName())
       .withNetwork(NETWORK)
       .withNetworkAliases("mykafka");
 

--- a/src/test/java/org/folio/rest/impl/BaseIntegrationTest.java
+++ b/src/test/java/org/folio/rest/impl/BaseIntegrationTest.java
@@ -43,15 +43,15 @@ import org.folio.rest.support.extension.Tenants;
 import org.folio.rest.support.kafka.FakeKafkaConsumer;
 import org.folio.rest.tools.utils.Envs;
 import org.folio.rest.tools.utils.NetworkUtils;
+import org.folio.utility.KafkaUtility;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
-import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.kafka.KafkaContainer;
 
 @EnableTenant
 @Testcontainers(parallel = true)
@@ -73,8 +73,7 @@ public class BaseIntegrationTest {
     .withPassword("admin_password");
 
   @Container
-  private static final KafkaContainer KAFKA_CONTAINER
-    = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:5.4.3"));
+  private static final KafkaContainer KAFKA_CONTAINER = new KafkaContainer(KafkaUtility.getImageName());
   private static int port;
 
   @BeforeEach

--- a/src/test/java/org/folio/utility/KafkaUtility.java
+++ b/src/test/java/org/folio/utility/KafkaUtility.java
@@ -5,14 +5,16 @@ import static org.testcontainers.shaded.org.awaitility.Awaitility.await;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.kafka.KafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 public final class KafkaUtility {
   private static final Logger logger = LogManager.getLogger();
 
-  private static final KafkaContainer KAFKA_CONTAINER
-    = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:5.4.3"));
+  private static final DockerImageName IMAGE_NAME
+    = DockerImageName.parse("apache/kafka-native:3.8.0");
+
+  private static final KafkaContainer KAFKA_CONTAINER = new KafkaContainer(IMAGE_NAME);
 
   private KafkaUtility() {
     throw new UnsupportedOperationException("Cannot instantiate utility class.");
@@ -45,5 +47,9 @@ public final class KafkaUtility {
     } else {
       logger.info("Kafka container already stopped");
     }
+  }
+
+  public static DockerImageName getImageName() {
+    return IMAGE_NAME;
   }
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODINVSTOR-1251

Upgrade from deprecated org.testcontainers.containers.KafkaContainer to org.testcontainers.kafka.KafkaContainer, see https://java.testcontainers.org/modules/kafka/

Upgrade from confluentinc/cp-kafka:5.4.3 and confluentinc/cp-kafka:7.0.3 to apache/kafka-native:3.8.0, see https://hub.docker.com/r/apache/kafka-native

Fix KafkaTopicsExistsTest to await topics. The test order may put load on Kafka resulting in delays until topics appears. 900 retries is too small.

### Purpose
Upgrade Kafka testcontainers.
kafka-native has smaller image size (47 MB compared to 446 MB or 382 MB), starts faster, and uses less memory.
Fix race condition in KafkaTopicsExistsTest.

### Approach
Upgrade from org.testcontainers.containers.KafkaContainer to org.testcontainers.kafka.KafkaContainer.
Upgrade from confluentinc/cp-kafka:5.4.3 and confluentinc/cp-kafka:7.0.3 to apache/kafka-native:3.8.0.
Add retries to KafkaTopicsExistsTest.

### Changes Checklist
- [x] n/a **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [x] n/a **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [x] n/a **Interface Version Changes**: Indicate any changes to interface versions.
- [x] n/a **Interface Dependencies**: Document added or removed dependencies.
- [x] n/a **Permissions**: Document any changes to permissions.
- [x] n/a **Logging**: Confirm that logging is appropriately handled.
- [x] n/a **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] n/a **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.