### PR TITLE
[MODINVSTOR-1253] Add user-tenants.collection.get to all ECS APIs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -34,6 +34,7 @@
 * Deserialization of Date from long (MODINVSTOR-1198)[https://folio-org.atlassian.net/browse/MODINVSTOR-1198]
 * Do not delete Kafka topics on postTenant if collection topics is enabled ([MODINVSTOR-1192](https://folio-org.atlassian.net/browse/MODINVSTOR-1192))
 * Identifier types: change Cancelled LCCN to Canceled LCCN ([MODINVSTOR-1212](https://folio-org.atlassian.net/browse/MODINVSTOR-1212))
+* Add user-tenants.collection.get to all ECS APIs ([MODINVSTOR-1253](https://folio-org.atlassian.net/browse/MODINVSTOR-1253))
 
 ### Tech Dept
 * Kafka testcontainers: kafka.KafkaContainer, apache/kafka-native:3.8.0, KafkaTopicsExistsTest fix ([MODINVSTOR-1251](https://folio-org.atlassian.net/browse/MODINVSTOR-1251))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -120,7 +120,10 @@
         }, {
           "methods": ["PUT"],
           "pathPattern": "/holdings-storage/holdings/{id}",
-          "permissionsRequired": ["inventory-storage.holdings.item.put"]
+          "permissionsRequired": ["inventory-storage.holdings.item.put"],
+          "modulePermissions": [
+            "user-tenants.collection.get"
+          ]
         }, {
           "methods": ["DELETE"],
           "pathPattern": "/holdings-storage/holdings/{id}",

--- a/src/main/java/org/folio/services/caches/ConsortiumDataCache.java
+++ b/src/main/java/org/folio/services/caches/ConsortiumDataCache.java
@@ -3,7 +3,6 @@ package org.folio.services.caches;
 import static io.vertx.core.Future.failedFuture;
 import static io.vertx.core.Future.succeededFuture;
 import static io.vertx.core.http.HttpMethod.GET;
-import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_OK;
 import static org.folio.okapi.common.XOkapiHeaders.TENANT;
 import static org.folio.okapi.common.XOkapiHeaders.URL;
@@ -132,11 +131,6 @@ public class ConsortiumDataCache {
   private Future<Optional<JsonObject>> getResponse(String tenantId, HttpRequest<Buffer> request) {
     LOG.info("getResponse:: Try to request method='{}' uri='{}'", request.method().name(), request.uri());
     return request.send().compose(response -> {
-      if (response.statusCode() == HTTP_FORBIDDEN) {
-        LOG.info("loadConsortiumData:: Skipping for tenant {} because {} returns 403 (forbidden)",
-          tenantId, USER_TENANTS_PATH);
-        return succeededFuture(Optional.empty());
-      }
       if (response.statusCode() != HTTP_OK) {
         String msg = String.format("Failed to request method='%s' uri='%s', status='%s', body='%s'",
           request.method().name(), request.uri(), response.statusCode(), response.bodyAsString());

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -991,7 +991,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   public void updatingOrRemovingTemporaryLocationChangesEffectiveLocation()
     throws InterruptedException, ExecutionException, TimeoutException {
     UUID instanceId = UUID.randomUUID();
-    
+
     instancesClient.create(smallAngryPlanet(instanceId));
     setHoldingsSequence(1);
 
@@ -2569,25 +2569,6 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       CONSORTIUM_MEMBER_TENANT, mockServer.baseUrl());
 
     log.info("Finished canCreateHoldingAndCreateShadowInstance");
-  }
-
-  @Test
-  public void shouldNotExecuteConsortiumLogicIfUserNotHavePermissionsToRetrieveConsortiumData() {
-    mockSharingInstance();
-
-    UUID instanceId = UUID.randomUUID();
-    HoldingRequestBuilder builder = new HoldingRequestBuilder()
-      .withId(null)
-      .forInstance(instanceId)
-      .withSource(getPreparedHoldingSourceId())
-      .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID);
-
-    Response response = holdingsClient.attemptToCreate("", builder.create(), TENANT_WITHOUT_USER_TENANTS_PERMISSIONS,
-      Map.of(X_OKAPI_URL, mockServer.baseUrl()));
-
-    verify(1, getRequestedFor(urlEqualTo(USER_TENANTS_PATH)));
-    verify(0, postRequestedFor(urlEqualTo("/consortia/mobius/sharing/instances")));
-    assertThat(response.getStatusCode(), is(HTTP_UNPROCESSABLE_ENTITY.toInt()));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -1,10 +1,6 @@
 package org.folio.rest.api;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToIgnoreCase;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.http.Response.Builder.like;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.HttpStatus.HTTP_CREATED;

--- a/src/test/java/org/folio/services/caches/ConsortiumDataCacheTest.java
+++ b/src/test/java/org/folio/services/caches/ConsortiumDataCacheTest.java
@@ -131,15 +131,14 @@ public class ConsortiumDataCacheTest {
   }
 
   @Test
-  public void shouldReturnOptionalEmptyWhenGetForbiddenErrorOnConsortiumDataLoading(TestContext context) {
+  public void shouldFailWhenGetForbiddenErrorOnConsortiumDataLoading(TestContext context) {
     Async async = context.async();
     WireMock.stubFor(get(USER_TENANTS_PATH).willReturn(WireMock.forbidden()));
 
     Future<Optional<ConsortiumData>> future = consortiumDataCache.getConsortiumData(TENANT_ID, okapiHeaders);
 
     future.onComplete(ar -> {
-      context.assertTrue(ar.succeeded());
-      context.assertTrue(ar.result().isEmpty());
+      context.assertTrue(ar.failed());
       async.complete();
     });
   }


### PR DESCRIPTION
### Purpose
Properly fix https://folio-org.atlassian.net/browse/MODINVSTOR-1114
### Approach
- Add user-tenants.collection.get to all ECS APIs
- Remove code that ignored forbidden response at consortium data cache

### Jira
https://folio-org.atlassian.net/browse/MODINVSTOR-1253