### PR TITLE
MODINVSTOR-1260: Add user-tenants.collection.get permission to POST /_/tenant API

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,7 @@
 * Do not delete Kafka topics on postTenant if collection topics is enabled ([MODINVSTOR-1192](https://folio-org.atlassian.net/browse/MODINVSTOR-1192))
 * Identifier types: change Cancelled LCCN to Canceled LCCN ([MODINVSTOR-1212](https://folio-org.atlassian.net/browse/MODINVSTOR-1212))
 * Add user-tenants.collection.get to all ECS APIs ([MODINVSTOR-1253](https://folio-org.atlassian.net/browse/MODINVSTOR-1253))
-* Add user-tenants.collection.get to POST /\_/tenant API ((MODINVSTOR-1260)[https://folio-org.atlassian.net/browse/MODINVSTOR-1260])
+* Add user-tenants.collection.get to POST /\_/tenant API ([MODINVSTOR-1260](https://folio-org.atlassian.net/browse/MODINVSTOR-1260))
 
 ### Tech Dept
 * Kafka testcontainers: kafka.KafkaContainer, apache/kafka-native:3.8.0, KafkaTopicsExistsTest fix ([MODINVSTOR-1251](https://folio-org.atlassian.net/browse/MODINVSTOR-1251))

--- a/NEWS.md
+++ b/NEWS.md
@@ -36,6 +36,7 @@
 * Do not delete Kafka topics on postTenant if collection topics is enabled ([MODINVSTOR-1192](https://folio-org.atlassian.net/browse/MODINVSTOR-1192))
 * Identifier types: change Cancelled LCCN to Canceled LCCN ([MODINVSTOR-1212](https://folio-org.atlassian.net/browse/MODINVSTOR-1212))
 * Add user-tenants.collection.get to all ECS APIs ([MODINVSTOR-1253](https://folio-org.atlassian.net/browse/MODINVSTOR-1253))
+* Add user-tenants.collection.get to POST /\_/tenant API ((MODINVSTOR-1260)[https://folio-org.atlassian.net/browse/MODINVSTOR-1260])
 
 ### Tech Dept
 * Kafka testcontainers: kafka.KafkaContainer, apache/kafka-native:3.8.0, KafkaTopicsExistsTest fix ([MODINVSTOR-1251](https://folio-org.atlassian.net/browse/MODINVSTOR-1251))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1280,7 +1280,10 @@
       "handlers": [
         {
           "methods": ["POST"],
-          "pathPattern": "/_/tenant"
+          "pathPattern": "/_/tenant",
+          "modulePermissions": [
+            "user-tenants.collection.get"
+          ]
         }, {
           "methods": ["DELETE", "GET"],
           "pathPattern": "/_/tenant/{id}"

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -1,10 +1,6 @@
 package org.folio.rest.api;
 
 import static com.github.tomakehurst.wiremock.client.WireMock.equalToIgnoreCase;
-import static com.github.tomakehurst.wiremock.client.WireMock.getRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static com.github.tomakehurst.wiremock.http.Response.Builder.like;
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.HttpStatus.HTTP_CREATED;
@@ -991,7 +987,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   public void updatingOrRemovingTemporaryLocationChangesEffectiveLocation()
     throws InterruptedException, ExecutionException, TimeoutException {
     UUID instanceId = UUID.randomUUID();
-    
+
     instancesClient.create(smallAngryPlanet(instanceId));
     setHoldingsSequence(1);
 
@@ -2569,25 +2565,6 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       CONSORTIUM_MEMBER_TENANT, mockServer.baseUrl());
 
     log.info("Finished canCreateHoldingAndCreateShadowInstance");
-  }
-
-  @Test
-  public void shouldNotExecuteConsortiumLogicIfUserNotHavePermissionsToRetrieveConsortiumData() {
-    mockSharingInstance();
-
-    UUID instanceId = UUID.randomUUID();
-    HoldingRequestBuilder builder = new HoldingRequestBuilder()
-      .withId(null)
-      .forInstance(instanceId)
-      .withSource(getPreparedHoldingSourceId())
-      .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID);
-
-    Response response = holdingsClient.attemptToCreate("", builder.create(), TENANT_WITHOUT_USER_TENANTS_PERMISSIONS,
-      Map.of(X_OKAPI_URL, mockServer.baseUrl()));
-
-    verify(1, getRequestedFor(urlEqualTo(USER_TENANTS_PATH)));
-    verify(0, postRequestedFor(urlEqualTo("/consortia/mobius/sharing/instances")));
-    assertThat(response.getStatusCode(), is(HTTP_UNPROCESSABLE_ENTITY.toInt()));
   }
 
   @Test

--- a/src/test/java/org/folio/services/caches/ConsortiumDataCacheTest.java
+++ b/src/test/java/org/folio/services/caches/ConsortiumDataCacheTest.java
@@ -131,15 +131,14 @@ public class ConsortiumDataCacheTest {
   }
 
   @Test
-  public void shouldReturnOptionalEmptyWhenGetForbiddenErrorOnConsortiumDataLoading(TestContext context) {
+  public void shouldFailWhenGetForbiddenErrorOnConsortiumDataLoading(TestContext context) {
     Async async = context.async();
     WireMock.stubFor(get(USER_TENANTS_PATH).willReturn(WireMock.forbidden()));
 
     Future<Optional<ConsortiumData>> future = consortiumDataCache.getConsortiumData(TENANT_ID, okapiHeaders);
 
     future.onComplete(ar -> {
-      context.assertTrue(ar.succeeded());
-      context.assertTrue(ar.result().isEmpty());
+      context.assertTrue(ar.failed());
       async.complete();
     });
   }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODINVSTOR-1260

### Purpose
Add user-tenants.collection.get permission to POST /_/tenant API

### Approach
Add the permission as "modulePermissions" in module descriptor.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [x] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODINVSTOR-1114
https://folio-org.atlassian.net/browse/MODINVSTOR-1253
https://folio-org.atlassian.net/browse/MODINVSTOR-1260