### PR TITLE
fix(inventory-reindex-records): fetch maps instead of object + add instanceId into item

### DIFF
--- a/src/main/java/org/folio/persist/HoldingsRepository.java
+++ b/src/main/java/org/folio/persist/HoldingsRepository.java
@@ -7,6 +7,8 @@ import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import org.folio.cql2pgjson.CQL2PgJSON;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
@@ -31,5 +33,18 @@ public class HoldingsRepository extends AbstractRepository<HoldingsRecord> {
     } catch (Exception e) {
       return Future.failedFuture(e);
     }
+  }
+
+  public Future<List<Map<String, Object>>> getReindexHoldingsRecords(String fromId, String toId) {
+    var sql = "SELECT jsonb FROM " + postgresClientFuturized.getFullTableName(HOLDINGS_RECORD_TABLE)
+                 + " i WHERE id >= '" + fromId + "' AND id <= '" + toId + "'"
+                 + ";";
+    return postgresClient.select(sql).map(rows -> {
+      var resultList = new LinkedList<Map<String, Object>>();
+      for (var row : rows) {
+        resultList.add(row.getJsonObject(0).getMap());
+      }
+      return resultList;
+    });
   }
 }

--- a/src/main/java/org/folio/services/holding/HoldingsService.java
+++ b/src/main/java/org/folio/services/holding/HoldingsService.java
@@ -33,8 +33,6 @@ import org.folio.persist.HoldingsRepository;
 import org.folio.persist.InstanceRepository;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
-import org.folio.rest.persist.Criteria.Criteria;
-import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.SQLConnection;
 import org.folio.rest.support.CqlQuery;
@@ -177,15 +175,8 @@ public class HoldingsService {
       .map(ResponseHandlerUtil::handleHridError);
   }
 
-  public Future<Void> publishReindexHoldingsRecords(String rangeId, String idStart, String idEnd) {
-    var criteriaFrom = new Criteria().setJSONB(false)
-      .addField("id").setOperation(">=").setVal(idStart);
-    var criteriaTo = new Criteria().setJSONB(false)
-      .addField("id").setOperation("<=").setVal(idEnd);
-    final Criterion criterion = new Criterion(criteriaFrom)
-      .addCriterion(criteriaTo);
-
-    return holdingsRepository.get(criterion)
+  public Future<Void> publishReindexHoldingsRecords(String rangeId, String fromId, String toId) {
+    return holdingsRepository.getReindexHoldingsRecords(fromId, toId)
       .compose(holdings -> domainEventPublisher.publishReindexHoldings(rangeId, holdings));
   }
 

--- a/src/main/java/org/folio/services/item/ItemService.java
+++ b/src/main/java/org/folio/services/item/ItemService.java
@@ -49,8 +49,6 @@ import org.folio.rest.jaxrs.model.CirculationNote;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
 import org.folio.rest.jaxrs.model.Metadata;
-import org.folio.rest.persist.Criteria.Criteria;
-import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PgExceptionUtil;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.PostgresClientFuturized;
@@ -240,15 +238,8 @@ public class ItemService {
         .map(items));
   }
 
-  public Future<Void> publishReindexItemRecords(String rangeId, String idStart, String idEnd) {
-    var criteriaFrom = new Criteria().setJSONB(false)
-      .addField("id").setOperation(">=").setVal(idStart);
-    var criteriaTo = new Criteria().setJSONB(false)
-      .addField("id").setOperation("<=").setVal(idEnd);
-    final Criterion criterion = new Criterion(criteriaFrom)
-      .addCriterion(criteriaTo);
-
-    return itemRepository.get(criterion)
+  public Future<Void> publishReindexItemRecords(String rangeId, String fromId, String toId) {
+    return itemRepository.getReindexItemRecords(fromId, toId)
       .compose(items -> domainEventService.publishReindexItems(rangeId, items));
   }
 


### PR DESCRIPTION
### Purpose
If database contains invalid data then the range publishing failed due to deserialization issue.

### Approach
fetch maps instead of object + add instanceId into item

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.
