### PR TITLE
feat(instance-dates): Migration: Population of Date type, Date 1, and Date 2 for FOLIO source records

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,11 +7,8 @@
 * Provides `instance-storage-batch 3.0`
 * Provides `instance-storage-batch-sync 3.0`
 * Provides `instance-storage-batch-sync-unsafe 3.0`
-* Provides `instance-storage-bulk 2.0`
-* Provides `inventory-reindex-records 2.0`
 * Provides `inventory-view 3.0`
 * Provides `inventory-view-instance-set 3.0`
-* Provides `instance-reindex 1.0`
 * Provides `instance-iteration 1.0`
 
 ## v27.2.0 2024-09-24

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,15 @@
 
 ### New APIs versions
 * Provides `instance-storage 11.0`
+* Provides `instance-storage-batch 3.0`
+* Provides `instance-storage-batch-sync 3.0`
+* Provides `instance-storage-batch-sync-unsafe 3.0`
+* Provides `instance-storage-bulk 2.0`
+* Provides `inventory-reindex-records 2.0`
+* Provides `inventory-view 3.0`
+* Provides `inventory-view-instance-set 3.0`
+* Provides `instance-reindex 1.0`
+* Provides `instance-iteration 1.0`
 
 ## v27.2.0 2024-09-24
 ### Breaking changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
-## v27.2.0 In progress
+## v28.0.0 In progress
+### Breaking changes
+* Migrate "publicationPeriod" data to the Dates object and remove it from the Instance schema ([MODINVSTOR-1232](https://folio-org.atlassian.net/browse/MODINVSTOR-1232))
 
+### New APIs versions
+* Provides `instance-storage 11.0`
+
+## v27.2.0 2024-09-24
 ### Breaking changes
 * Required sourceId field in holdings record ([MODINVSTOR-1161](https://folio-org.atlassian.net/browse/MODINVSTOR-1161))
 
@@ -9,7 +15,7 @@
 * Provides `instance-storage-bulk 1.0`
 * Provides `instance-date-types 1.0`
 * Provides `locations 3.1`
-* Provides `instance-storage 10.4`
+* Provides `instance-storage 10.3`
 * Requires `holdings-storage 6.1`
 
 ### Features
@@ -28,8 +34,6 @@
 * Add new date type fields to Instance schema ([MODINVSTOR-1188](https://folio-org.atlassian.net/browse/MODINVSTOR-1188))
 * Implement endpoint for bulk instances upsert from external file ([MODINVSTOR-1225](https://folio-org.atlassian.net/browse/MODINVSTOR-1225))
 * Add Subject source and Subject type to schema ([MODINVSTOR-1205](https://folio-org.atlassian.net/browse/MODINVSTOR-1205))
-* Migrate "publicationPeriod" data to the Dates object and remove it from the Instance schema ([MODINVSTOR-1232](https://folio-org.atlassian.net/browse/MODINVSTOR-1232))
-
 
 ### Bug fixes
 * Unintended update of instance records \_version (optimistic locking) whenever any of its holdings or items are created, updated or deleted. ([MODINVSTOR-1186](https://folio-org.atlassian.net/browse/MODINVSTOR-1186))

--- a/NEWS.md
+++ b/NEWS.md
@@ -9,7 +9,7 @@
 * Provides `instance-storage-bulk 1.0`
 * Provides `instance-date-types 1.0`
 * Provides `locations 3.1`
-* Provides `instance-storage 10.3`
+* Provides `instance-storage 10.4`
 * Requires `holdings-storage 6.1`
 
 ### Features
@@ -28,6 +28,7 @@
 * Add new date type fields to Instance schema ([MODINVSTOR-1188](https://folio-org.atlassian.net/browse/MODINVSTOR-1188))
 * Implement endpoint for bulk instances upsert from external file ([MODINVSTOR-1225](https://folio-org.atlassian.net/browse/MODINVSTOR-1225))
 * Add Subject source and Subject type to schema ([MODINVSTOR-1205](https://folio-org.atlassian.net/browse/MODINVSTOR-1205))
+* Migrate "publicationPeriod" data to the Dates object and remove it from the Instance schema ([MODINVSTOR-1232](https://folio-org.atlassian.net/browse/MODINVSTOR-1232))
 
 
 ### Bug fixes

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -167,7 +167,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "10.4",
+      "version": "11.0",
       "handlers": [
         {
           "methods": ["GET"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -274,7 +274,7 @@
     },
     {
       "id": "instance-storage-batch",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["POST"],
@@ -285,7 +285,7 @@
     },
     {
       "id": "instance-storage-batch-sync",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["POST"],
@@ -296,7 +296,7 @@
     },
     {
       "id": "instance-storage-batch-sync-unsafe",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["POST"],
@@ -307,7 +307,7 @@
     },
     {
       "id": "instance-storage-bulk",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["POST"],
@@ -668,7 +668,7 @@
     },
     {
       "id": "inventory-reindex-records",
-      "version": "1.0",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["POST"],
@@ -1339,7 +1339,7 @@
     },
     {
       "id": "inventory-view",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -1350,7 +1350,7 @@
     },
     {
       "id": "inventory-view-instance-set",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -1361,7 +1361,7 @@
     },
     {
       "id": "instance-reindex",
-      "version": "0.1",
+      "version": "1.0",
       "handlers": [
         {
           "methods": ["POST"],
@@ -1387,7 +1387,7 @@
     },
     {
       "id": "instance-iteration",
-      "version": "0.1",
+      "version": "1.0",
       "handlers": [
         {
           "methods": ["POST"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -307,7 +307,7 @@
     },
     {
       "id": "instance-storage-bulk",
-      "version": "2.0",
+      "version": "1.0",
       "handlers": [
         {
           "methods": ["POST"],
@@ -668,7 +668,7 @@
     },
     {
       "id": "inventory-reindex-records",
-      "version": "2.0",
+      "version": "1.0",
       "handlers": [
         {
           "methods": ["POST"],
@@ -1361,7 +1361,7 @@
     },
     {
       "id": "instance-reindex",
-      "version": "1.0",
+      "version": "0.1",
       "handlers": [
         {
           "methods": ["POST"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -167,7 +167,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "10.3",
+      "version": "10.4",
       "handlers": [
         {
           "methods": ["GET"],

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>27.2.0-SNAPSHOT</version>
+  <version>28.0.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/ramls/instance-iteration.raml
+++ b/ramls/instance-iteration.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Iterate instances
-version: v0.1
+version: v1.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/instance-set.raml
+++ b/ramls/instance-set.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Instance Set API
-version: v2.0
+version: v3.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://github.com/org/folio/mod-inventory-storage
 

--- a/ramls/instance-storage-batch.raml
+++ b/ramls/instance-storage-batch.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Deprecated Inventory Storage Instance Batch API
-version: v2.0
+version: v3.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/instance-storage.raml
+++ b/ramls/instance-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Instance Storage
-version: v10.0
+version: v11.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/instance-sync-unsafe.raml
+++ b/ramls/instance-sync-unsafe.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Storage Instance Batch Sync Unsafe API
-version: v2.0
+version: v3.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/instance-sync.raml
+++ b/ramls/instance-sync.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Storage Instance Batch Sync API
-version: v2.0
+version: v3.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -286,21 +286,6 @@
       },
       "uniqueItems": true
     },
-    "publicationPeriod": {
-      "type": "object",
-      "description": "Publication period",
-      "properties": {
-        "start": {
-          "type": "integer",
-          "description": "Publication start year"
-        },
-        "end": {
-          "type": "integer",
-          "description": "Publication end year"
-        }
-      },
-      "additionalProperties": false
-    },
     "electronicAccess": {
       "type": "array",
       "description": "List of electronic access items",

--- a/ramls/inventory-view.raml
+++ b/ramls/inventory-view.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Inventory Storage View API
-version: v2.0
+version: v3.0
 protocols: [ HTTP, HTTPS ]
 baseUri: http://github.com/org/folio/mod-inventory-storage
 

--- a/src/main/resources/templates/db_scripts/publication-period/migratePublicationPeriod.sql
+++ b/src/main/resources/templates/db_scripts/publication-period/migratePublicationPeriod.sql
@@ -5,7 +5,7 @@ DECLARE
     pub_period jsonb;
     start_date text;
     end_date text;
-    date_type text;
+    date_type_id text;
     dates jsonb := '{}'::jsonb;
 BEGIN
     pub_period := jsonb_data -> 'publicationPeriod';
@@ -14,27 +14,22 @@ BEGIN
 
     -- Determine Date type
     IF (start_date IS NOT NULL AND end_date IS NOT NULL) THEN
-        date_type := 'Multiple dates';
+        date_type_id := '8fa6d067-41ff-4362-96a0-96b16ddce267';
     ELSIF (start_date IS NOT NULL OR end_date IS NOT NULL) THEN
-        date_type := 'Single known date/probable date';
+        date_type_id := '24a506e8-2a92-4ecc-bd09-ff849321fd5a';
     ELSE
-        date_type := NULL;
+        RETURN jsonb_data;
     END IF;
 
     -- Build the JSONB Dates object
     IF start_date IS NOT NULL THEN
-        dates := jsonb_set(dates, '{date1}', to_jsonb(start_date));
+        dates := jsonb_set(dates, '{date1}', to_jsonb(substring(start_date FROM 1 FOR 4)));
     END IF;
     IF end_date IS NOT NULL THEN
-        dates := jsonb_set(dates, '{date2}', to_jsonb(end_date));
+        dates := jsonb_set(dates, '{date2}', to_jsonb(substring(end_date FROM 1 FOR 4)));
     END IF;
-    IF date_type IS NOT NULL THEN
-        dates := jsonb_set(dates, '{dateTypeId}',
-            COALESCE((SELECT to_jsonb(id)
-                      FROM ${myuniversity}_${mymodule}.instance_date_type
-                      WHERE jsonb ->> 'name' = date_type
-                      LIMIT 1)));
-    END IF;
+    dates := jsonb_set(dates, '{dateTypeId}', to_jsonb(date_type_id));
+
     -- Set the dates into jsonb
     jsonb_data := jsonb_set(jsonb_data, '{dates}', dates);
 

--- a/src/main/resources/templates/db_scripts/publication-period/migratePublicationPeriod.sql
+++ b/src/main/resources/templates/db_scripts/publication-period/migratePublicationPeriod.sql
@@ -1,0 +1,132 @@
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.migrate_publication_period(
+    jsonb_data jsonb
+) RETURNS jsonb AS $$
+DECLARE
+    pub_period jsonb;
+    start_date text;
+    end_date text;
+    date_type text;
+    dates jsonb := '{}'::jsonb;
+BEGIN
+    pub_period := jsonb_data -> 'publicationPeriod';
+    start_date := pub_period ->> 'start';
+    end_date := pub_period ->> 'end';
+
+    -- Determine Date type
+    IF (start_date IS NOT NULL AND end_date IS NOT NULL) THEN
+        date_type := 'Multiple dates';
+    ELSIF (start_date IS NOT NULL OR end_date IS NOT NULL) THEN
+        date_type := 'Single known date/probable date';
+    ELSE
+        date_type := NULL;
+    END IF;
+
+    -- Build the JSONB Dates object
+    IF start_date IS NOT NULL THEN
+        dates := jsonb_set(dates, '{date1}', to_jsonb(start_date));
+    END IF;
+    IF end_date IS NOT NULL THEN
+        dates := jsonb_set(dates, '{date2}', to_jsonb(end_date));
+    END IF;
+    IF date_type IS NOT NULL THEN
+        dates := jsonb_set(dates, '{dateTypeId}',
+            COALESCE((SELECT to_jsonb(id)
+                      FROM ${myuniversity}_${mymodule}.instance_date_type
+                      WHERE jsonb ->> 'name' = date_type
+                      LIMIT 1)));
+    END IF;
+    -- Set the dates into jsonb
+    jsonb_data := jsonb_set(jsonb_data, '{dates}', dates);
+
+    -- Remove publicationPeriod from jsonb
+    jsonb_data := jsonb_data - 'publicationPeriod';
+
+    RETURN jsonb_data;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE PARALLEL SAFE STRICT;
+
+
+-- Migration Script
+DO
+$$
+DECLARE
+    trigger VARCHAR;
+    triggers      VARCHAR[] DEFAULT ARRAY[
+    'audit_instance',
+    'check_subject_references_on_insert_or_update',
+    'instance_check_statistical_code_references_on_insert',
+    'instance_check_statistical_code_references_on_update',
+    'set_id_in_jsonb',
+    'set_instance_md_json_trigger',
+    'set_instance_md_trigger',
+    'set_instance_ol_version_trigger',
+    'set_instance_sourcerecordformat',
+    'set_instance_status_updated_date',
+    'update_instance_references',
+    'updatecompleteupdateddate_instance'];
+    arr          UUID[] DEFAULT ARRAY[
+        '10000000-0000-0000-0000-000000000000',
+        '20000000-0000-0000-0000-000000000000',
+        '30000000-0000-0000-0000-000000000000',
+        '40000000-0000-0000-0000-000000000000',
+        '50000000-0000-0000-0000-000000000000',
+        '60000000-0000-0000-0000-000000000000',
+        '70000000-0000-0000-0000-000000000000',
+        '80000000-0000-0000-0000-000000000000',
+        '90000000-0000-0000-0000-000000000000',
+        'a0000000-0000-0000-0000-000000000000',
+        'b0000000-0000-0000-0000-000000000000',
+        'c0000000-0000-0000-0000-000000000000',
+        'd0000000-0000-0000-0000-000000000000',
+        'e0000000-0000-0000-0000-000000000000',
+        'f0000000-0000-0000-0000-000000000000',
+        'ffffffff-ffff-ffff-ffff-ffffffffffff'
+    ];
+    lower          UUID;
+    cur            UUID;
+    rowcount       BIGINT;
+    need_migration BOOLEAN;
+BEGIN
+    -- STEP 0: Check if migration is required
+    SELECT EXISTS (
+        SELECT 1
+        FROM ${myuniversity}_${mymodule}.instance
+        WHERE jsonb ? 'publicationPeriod'
+        LIMIT 1
+    ) INTO need_migration;
+
+    IF need_migration THEN
+        -- STEP 1: Disable triggers
+        FOREACH trigger IN ARRAY triggers LOOP
+            EXECUTE 'ALTER TABLE ${myuniversity}_${mymodule}.instance DISABLE TRIGGER '
+            || trigger;
+        END LOOP;
+
+        -- STEP 2: Do updates
+        lower := '00000000-0000-0000-0000-000000000000';
+        FOREACH cur IN ARRAY arr LOOP
+            RAISE INFO 'range: % - %', lower, cur;
+            -- Update scripts
+            EXECUTE format($q$
+                UPDATE ${myuniversity}_${mymodule}.instance
+                SET jsonb = ${myuniversity}_${mymodule}.migrate_publication_period(jsonb)
+                WHERE (jsonb -> 'publicationPeriod' IS NOT NULL)
+                AND (id > %L AND id <= %L);
+            $q$, lower, cur);
+
+            GET DIAGNOSTICS rowcount = ROW_COUNT;
+            RAISE INFO 'updated % instances', rowcount;
+
+            lower := cur;
+        END LOOP;
+
+        -- STEP 3: Enable triggers
+        FOREACH trigger IN ARRAY triggers LOOP
+            EXECUTE 'ALTER TABLE ${myuniversity}_${mymodule}.instance ENABLE TRIGGER '
+            || trigger;
+        END LOOP;
+    END IF;
+END;
+$$ LANGUAGE 'plpgsql';
+
+DROP FUNCTION IF EXISTS ${myuniversity}_${mymodule}.migrate_publication_period(jsonb);

--- a/src/main/resources/templates/db_scripts/publication-period/migratePublicationPeriod.sql
+++ b/src/main/resources/templates/db_scripts/publication-period/migratePublicationPeriod.sql
@@ -9,8 +9,8 @@ DECLARE
     dates jsonb := '{}'::jsonb;
 BEGIN
     pub_period := jsonb_data -> 'publicationPeriod';
-    start_date := pub_period ->> 'start';
-    end_date := pub_period ->> 'end';
+    start_date := NULLIF(pub_period ->> 'start', '');
+    end_date := NULLIF(pub_period ->> 'end', '');
 
     -- Determine Date type
     IF (start_date IS NOT NULL AND end_date IS NOT NULL) THEN
@@ -18,20 +18,22 @@ BEGIN
     ELSIF (start_date IS NOT NULL OR end_date IS NOT NULL) THEN
         date_type_id := '24a506e8-2a92-4ecc-bd09-ff849321fd5a';
     ELSE
+        -- Remove publicationPeriod from jsonb
+        jsonb_data := jsonb_data - 'publicationPeriod';
         RETURN jsonb_data;
     END IF;
 
     -- Build the JSONB Dates object
     IF start_date IS NOT NULL THEN
-        dates := jsonb_set(dates, '{date1}', to_jsonb(substring(start_date FROM 1 FOR 4)));
+        dates := jsonb_set(dates, '{date1}', to_jsonb(substring(start_date FROM 1 FOR 4)), true);
     END IF;
     IF end_date IS NOT NULL THEN
-        dates := jsonb_set(dates, '{date2}', to_jsonb(substring(end_date FROM 1 FOR 4)));
+        dates := jsonb_set(dates, '{date2}', to_jsonb(substring(end_date FROM 1 FOR 4)), true);
     END IF;
-    dates := jsonb_set(dates, '{dateTypeId}', to_jsonb(date_type_id));
+    dates := jsonb_set(dates, '{dateTypeId}', to_jsonb(date_type_id), true);
 
     -- Set the dates into jsonb
-    jsonb_data := jsonb_set(jsonb_data, '{dates}', dates);
+    jsonb_data := jsonb_set(jsonb_data, '{dates}', dates, true);
 
     -- Remove publicationPeriod from jsonb
     jsonb_data := jsonb_data - 'publicationPeriod';

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1221,6 +1221,11 @@
     },
     {
       "run": "after",
+      "snippetPath": "publication-period/migratePublicationPeriod.sql",
+      "fromModuleVersion": "27.2.0"
+    },
+    {
+      "run": "after",
       "snippetPath": "subjectIdsReferenceCheckTrigger.sql",
       "fromModuleVersion": "27.2.0"
     }

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1222,7 +1222,7 @@
     {
       "run": "after",
       "snippetPath": "publication-period/migratePublicationPeriod.sql",
-      "fromModuleVersion": "27.2.0"
+      "fromModuleVersion": "28.0.0"
     },
     {
       "run": "after",

--- a/src/test/java/org/folio/rest/api/PublicationPeriodMigrationTest.java
+++ b/src/test/java/org/folio/rest/api/PublicationPeriodMigrationTest.java
@@ -1,0 +1,147 @@
+package org.folio.rest.api;
+
+import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
+import static org.folio.utility.ModuleUtility.getVertx;
+import static org.folio.utility.RestUtility.TENANT_ID;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import lombok.SneakyThrows;
+import org.folio.rest.persist.PostgresClient;
+import org.junit.Before;
+import org.junit.Test;
+
+public class PublicationPeriodMigrationTest extends MigrationTestBase {
+  private static final String MIGRATION_SCRIPT = loadScript("publication-period/migratePublicationPeriod.sql");
+  private static final String TAG_VALUE = "test-tag";
+  private static final String START_DATE = "1877";
+  private static final String END_DATE = "1880";
+  private static final String MULTIPLE_DATE_TYPE_ID = "8fa6d067-41ff-4362-96a0-96b16ddce267";
+  private static final String SINGLE_DATE_TYPE_ID = "24a506e8-2a92-4ecc-bd09-ff849321fd5a";
+  private static final String SELECT_JSONB_BY_ID =
+    "SELECT jsonb FROM %s_mod_inventory_storage.instance WHERE id = '%s';";
+  private static final String UPDATE_JSONB_WITH_PUB_PERIOD =
+    "UPDATE %s_mod_inventory_storage.instance "
+      + "SET jsonb = jsonb_set(jsonb, '{publicationPeriod}', jsonb_build_object('start','%s','end', '%s')) "
+      + "WHERE id = '%s';";
+  private static final String UPDATE_JSONB_WITH_PUB_PERIOD_START_DATE =
+    "UPDATE %s_mod_inventory_storage.instance "
+      + "SET jsonb = jsonb_set(jsonb, '{publicationPeriod}', jsonb_build_object('start','%s')) "
+      + "WHERE id = '%s';";
+
+  @SneakyThrows
+  @Before
+  public void beforeEach() {
+    StorageTestSuite.deleteAll(instancesStorageUrl(""));
+    removeAllEvents();
+  }
+
+  @Test
+  public void canMigratePublicationPeriodToMultipleDates() throws Exception {
+    var instanceId = createInstance();
+
+    // add "publicationPeriod" object to jsonb
+    addPublicationPeriodToJsonb(instanceId, START_DATE, END_DATE);
+
+    //migrate "publicationPeriod" to Dates object
+    executeMultipleSqlStatements(MIGRATION_SCRIPT);
+
+    String query = String.format(SELECT_JSONB_BY_ID, TENANT_ID, instanceId);
+    RowSet<Row> result = runSql(query);
+
+    assertEquals(1, result.rowCount());
+    JsonObject entry = result.iterator().next().toJson();
+    JsonObject dates = entry.getJsonObject("jsonb").getJsonObject("dates");
+    assertNotNull(dates);
+    assertEquals(START_DATE, dates.getString("date1"));
+    assertEquals(END_DATE, dates.getString("date2"));
+    assertEquals(MULTIPLE_DATE_TYPE_ID, dates.getString("dateTypeId"));
+  }
+
+  @Test
+  public void canMigratePublicationPeriodToSingleDates() throws Exception {
+    var instanceId = createInstance();
+
+    // add "publicationPeriod" object to jsonb
+    addPublicationPeriodToJsonb(instanceId, START_DATE, null);
+
+    //migrate "publicationPeriod" to Dates object
+    executeMultipleSqlStatements(MIGRATION_SCRIPT);
+
+    String query = String.format(SELECT_JSONB_BY_ID, TENANT_ID, instanceId);
+    RowSet<Row> result = runSql(query);
+
+    assertEquals(1, result.rowCount());
+    JsonObject entry = result.iterator().next().toJson();
+    JsonObject dates = entry.getJsonObject("jsonb").getJsonObject("dates");
+    assertNotNull(dates);
+    assertEquals(START_DATE, dates.getString("date1"));
+    assertNull(dates.getString("date2"));
+    assertEquals(SINGLE_DATE_TYPE_ID, dates.getString("dateTypeId"));
+  }
+
+  @Test
+  public void canNotMigrateWhenPublicationPeriodIsNull() throws Exception {
+    var instanceId = createInstance();
+
+    //migrate "publicationPeriod" to Dates object
+    executeMultipleSqlStatements(MIGRATION_SCRIPT);
+
+    String query = String.format(SELECT_JSONB_BY_ID, TENANT_ID, instanceId);
+    RowSet<Row> result = runSql(query);
+
+    assertEquals(1, result.rowCount());
+    JsonObject entry = result.iterator().next().toJson();
+    JsonObject dates = entry.getJsonObject("jsonb").getJsonObject("dates");
+    assertNull(dates);
+  }
+
+  private String createInstance() {
+    var instanceId = UUID.randomUUID().toString();
+    JsonObject instanceToCreate = new JsonObject()
+      .put("id", instanceId)
+      .put("title", "Test")
+      .put("source", "FOLIO")
+      .put("identifiers", new JsonArray().add(identifier(UUID_ISBN, "9781473619777")))
+      .put("instanceTypeId", UUID_INSTANCE_TYPE.toString())
+      .put("tags", new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))
+      .put("_version", 1);
+
+    instancesClient.create(instanceToCreate);
+    return instanceId;
+  }
+
+  private void addPublicationPeriodToJsonb(String instanceId, String startDate, String endDate)
+    throws InterruptedException, ExecutionException, TimeoutException {
+    String query;
+    if (endDate != null) {
+      query = String.format(UPDATE_JSONB_WITH_PUB_PERIOD, TENANT_ID, startDate, endDate, instanceId);
+    } else {
+      query = String.format(UPDATE_JSONB_WITH_PUB_PERIOD_START_DATE, TENANT_ID, startDate, instanceId);
+    }
+    runSql(query);
+  }
+
+  private RowSet<Row> runSql(String sql) throws InterruptedException, ExecutionException, TimeoutException {
+    var postgresClient = PostgresClient.getInstance(getVertx());
+    CompletableFuture<RowSet<Row>> future = new CompletableFuture<>();
+
+    postgresClient.execute(sql, handler -> {
+      if (handler.failed()) {
+        future.completeExceptionally(handler.cause());
+      }
+      future.complete(handler.result());
+    });
+    return future.get(TIMEOUT, TimeUnit.SECONDS);
+  }
+}

--- a/src/test/java/org/folio/rest/api/PublicationPeriodMigrationTest.java
+++ b/src/test/java/org/folio/rest/api/PublicationPeriodMigrationTest.java
@@ -12,7 +12,6 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -132,16 +131,11 @@ public class PublicationPeriodMigrationTest extends MigrationTestBase {
     runSql(query);
   }
 
-  private RowSet<Row> runSql(String sql) throws InterruptedException, ExecutionException, TimeoutException {
-    var postgresClient = PostgresClient.getInstance(getVertx());
-    CompletableFuture<RowSet<Row>> future = new CompletableFuture<>();
-
-    postgresClient.execute(sql, handler -> {
-      if (handler.failed()) {
-        future.completeExceptionally(handler.cause());
-      }
-      future.complete(handler.result());
-    });
-    return future.get(TIMEOUT, TimeUnit.SECONDS);
+  private RowSet<Row> runSql(String sql) throws ExecutionException, InterruptedException, TimeoutException {
+    return PostgresClient.getInstance(getVertx())
+      .execute(sql)
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(TIMEOUT, TimeUnit.SECONDS);
   }
 }

--- a/src/test/java/org/folio/rest/api/PublicationPeriodMigrationTest.java
+++ b/src/test/java/org/folio/rest/api/PublicationPeriodMigrationTest.java
@@ -131,7 +131,8 @@ public class PublicationPeriodMigrationTest extends MigrationTestBase {
     runSql(query);
   }
 
-  private RowSet<Row> runSql(String sql) throws ExecutionException, InterruptedException, TimeoutException {
+  @SneakyThrows
+  private RowSet<Row> runSql(String sql) {
     return PostgresClient.getInstance(getVertx())
       .execute(sql)
       .toCompletionStage()

--- a/src/test/java/org/folio/rest/api/PublicationPeriodMigrationTest.java
+++ b/src/test/java/org/folio/rest/api/PublicationPeriodMigrationTest.java
@@ -12,9 +12,7 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
 import java.util.UUID;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import lombok.SneakyThrows;
 import org.folio.rest.persist.PostgresClient;
 import org.junit.Before;
@@ -120,8 +118,7 @@ public class PublicationPeriodMigrationTest extends MigrationTestBase {
     return instanceId;
   }
 
-  private void addPublicationPeriodToJsonb(String instanceId, String startDate, String endDate)
-    throws InterruptedException, ExecutionException, TimeoutException {
+  private void addPublicationPeriodToJsonb(String instanceId, String startDate, String endDate) {
     String query;
     if (endDate != null) {
       query = String.format(UPDATE_JSONB_WITH_PUB_PERIOD, TENANT_ID, startDate, endDate, instanceId);

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -91,7 +91,8 @@ import org.junit.runners.Suite;
   RetainLeadingZeroesMigrationScriptTest.class,
   StatisticalCodeTest.class,
   UpcIsmnMigrationScriptTest.class,
-  InstanceStorageInstancesBulkApiTest.class
+  InstanceStorageInstancesBulkApiTest.class,
+  PublicationPeriodMigrationTest.class
 
   // These fail.
   //ReferenceTablesTest.class,

--- a/src/test/resources/instances/bulk/bulkInstanceRepresentation.json
+++ b/src/test/resources/instances/bulk/bulkInstanceRepresentation.json
@@ -96,10 +96,6 @@
   "publicationRange": [
     "v. 1-   Apr. 1950-"
   ],
-  "publicationPeriod": {
-    "start": 2000,
-    "end": 2001
-  },
   "electronicAccess": [
     {
       "uri": "http://resolver.library.cornell.edu/cgi-bin/EADresolver?id=RMA01776",

--- a/src/test/resources/instances/bulk/expectedInstance.json
+++ b/src/test/resources/instances/bulk/expectedInstance.json
@@ -96,10 +96,6 @@
   "publicationRange": [
     "v. 1-   Apr. 1950-"
   ],
-  "publicationPeriod": {
-    "start": 2000,
-    "end": 2001
-  },
   "electronicAccess": [
     {
       "uri": "http://resolver.library.cornell.edu/cgi-bin/EADresolver?id=RMA01776",


### PR DESCRIPTION
### Purpose
[MODINVSTOR-1232](https://folio-org.atlassian.net/browse/MODINVSTOR-1232) Currently in the Instance schema, there is a field for publication date. However, this data originates from an uncontrolled string in variable fields of the MARC record. The dates in the 008 are more consistently formatted, and are more useful for certain materials like serials. Previously, we implemented sortable properties (publicationPeriod.start/publicationPeriod.end) that are parsed from the publication date field. We need to break this relationship, and instead make the source of that data the 07-14 from the 008. We need to determine how to migrate data from these MARC fields as well as existing publication date field for FOLIO source records.

### Approach
Create migration script that will migrate instances:
1. Move value from  publicationPeriod.start to Date 1 and publicationPeriod.end to Date 2  and populate date type based on conditions:
        - If single date: Date type = Single known date/probable date
        - If multiple dates: Date type = Multiple dates

2. Remove publicationPeriod field from instance schema.
### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.
