### PR TITLE
feat(inventory-reindex-records): Make reindex kafka producer maxRequestSize configurable

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -125,6 +125,8 @@ These are the defined topic properties for `message retention` and `maximum mess
 
 in case, any of these topic properties are changed for `reindex-records` the topic needs to be recreated and module needs to be reinstalled.
 
+Changing maximum message size for kafka producer:
+* `KAFKA_REINDEX_PRODUCER_MAX_REQUEST_SIZE_BYTES` Default value - `10485760` (10 MB)
 
 # Building
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -2919,6 +2919,7 @@
       { "name": "KAFKA_REINDEX_RECORDS_TOPIC_NUM_PARTITIONS", "value": "16"},
       { "name": "KAFKA_REINDEX_RECORDS_TOPIC_MESSAGE_RETENTION", "value": "86400000"},
       { "name": "KAFKA_REINDEX_RECORDS_TOPIC_MAX_MESSAGE_SIZE", "value": "1048576"},
+      { "name": "KAFKA_REINDEX_PRODUCER_MAX_REQUEST_SIZE_BYTES", "value": "10485760"},
       { "name": "S3_URL", "value": "http://127.0.0.1:9000/" },
       { "name": "S3_REGION", "value": "" },
       { "name": "S3_BUCKET", "value": "marc-migrations" },

--- a/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
@@ -52,16 +52,21 @@ public class CommonDomainEventPublisher<T> {
 
   public CommonDomainEventPublisher(Context vertxContext, Map<String, String> okapiHeaders,
                                     String kafkaTopic) {
+    this(vertxContext, okapiHeaders, kafkaTopic, 0);
+  }
 
-    this(okapiHeaders, kafkaTopic, createProducerManager(vertxContext),
+  public CommonDomainEventPublisher(Context vertxContext, Map<String, String> okapiHeaders,
+                                    String kafkaTopic, int maxRequestSize) {
+
+    this(okapiHeaders, kafkaTopic, createProducerManager(vertxContext, maxRequestSize),
       new LogToDbFailureHandler(vertxContext, okapiHeaders));
   }
 
-  private static KafkaProducerManager createProducerManager(Context vertxContext) {
+  private static KafkaProducerManager createProducerManager(Context vertxContext, int maxRequestSize) {
     var kafkaConfig = KafkaConfig.builder()
       .kafkaPort(KafkaEnvironmentProperties.port())
       .kafkaHost(KafkaEnvironmentProperties.host())
-      .maxRequestSize(10485760) // 10MB
+      .maxRequestSize(maxRequestSize)
       .build();
 
     return new SimpleKafkaProducerManager(vertxContext.owner(), kafkaConfig);

--- a/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/CommonDomainEventPublisher.java
@@ -61,6 +61,7 @@ public class CommonDomainEventPublisher<T> {
     var kafkaConfig = KafkaConfig.builder()
       .kafkaPort(KafkaEnvironmentProperties.port())
       .kafkaHost(KafkaEnvironmentProperties.host())
+      .maxRequestSize(10485760) // 10MB
       .build();
 
     return new SimpleKafkaProducerManager(vertxContext.owner(), kafkaConfig);

--- a/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/InstanceDomainEventPublisher.java
@@ -19,6 +19,8 @@ import org.folio.rest.jaxrs.model.Instance;
 import org.folio.rest.jaxrs.model.PublishReindexRecords;
 
 public class InstanceDomainEventPublisher extends AbstractDomainEventPublisher<Instance, Instance> {
+
+  private static final String MAX_REQUEST_SIZE = "KAFKA_REINDEX_PRODUCER_MAX_REQUEST_SIZE_BYTES";
   private static final Logger log = getLogger(InstanceDomainEventPublisher.class);
   
   private final CommonDomainEventPublisher<Map<String, Object>> instanceReindexPublisher;
@@ -28,7 +30,7 @@ public class InstanceDomainEventPublisher extends AbstractDomainEventPublisher<I
       new CommonDomainEventPublisher<>(context, okapiHeaders,
         INSTANCE.fullTopicName(tenantId(okapiHeaders))));
     instanceReindexPublisher = new CommonDomainEventPublisher<>(context, okapiHeaders,
-      REINDEX_RECORDS.fullTopicName(tenantId(okapiHeaders)));
+      REINDEX_RECORDS.fullTopicName(tenantId(okapiHeaders)), getProducerMaxRequestSize());
   }
 
   public Future<Void> publishReindexInstances(String key, List<Map<String, Object>> instances) {
@@ -67,5 +69,12 @@ public class InstanceDomainEventPublisher extends AbstractDomainEventPublisher<I
   @Override
   protected String getId(Instance instance) {
     return instance.getId();
+  }
+
+  private int getProducerMaxRequestSize() {
+    return Integer.parseInt(StringUtils.firstNonBlank(
+      System.getenv(MAX_REQUEST_SIZE),
+      System.getProperty(MAX_REQUEST_SIZE),
+      "10485760")); // 10MB
   }
 }


### PR DESCRIPTION
### Purpose
Make reindex kafka producer maxRequestSize configurable

### Approach
- Parse env or use default for kafka config in reindex publisher

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINVSTOR-1265](https://folio-org.atlassian.net/browse/MODINVSTOR-1265)
