### PR TITLE
build: add folio-module-descriptor-validator plugin and fix the permission names

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,15 @@
-## v27.2.0 In progress
+## v28.0.0 In progress
+### New APIs versions
+* Requires `holdings-storage 8.0`
+* Requires `instance-storage 11.0`
+* Requires `instance-storage-batch-sync 3.0`
+* Requires `bound-with-parts-storage 2.0`
+* Requires `async-migration 1.0`
 
+### Features
+* Add module descriptor validator plugin and fix the permission names ([MODINVSTOR-1247](https://folio-org.atlassian.net/browse/MODINVSTOR-1247))
+
+## v27.2.0 2024-10-08
 ### Breaking changes
 * Required sourceId field in holdings record ([MODINVSTOR-1161](https://folio-org.atlassian.net/browse/MODINVSTOR-1161))
 
@@ -28,7 +38,6 @@
 * Add new date type fields to Instance schema ([MODINVSTOR-1188](https://folio-org.atlassian.net/browse/MODINVSTOR-1188))
 * Implement endpoint for bulk instances upsert from external file ([MODINVSTOR-1225](https://folio-org.atlassian.net/browse/MODINVSTOR-1225))
 * Add Subject source and Subject type to schema ([MODINVSTOR-1205](https://folio-org.atlassian.net/browse/MODINVSTOR-1205))
-* Add module descriptor validator plugin and fix the permission names ([MODINVSTOR-1247](https://folio-org.atlassian.net/browse/MODINVSTOR-1247))
 
 ### Bug fixes
 * Unintended update of instance records \_version (optimistic locking) whenever any of its holdings or items are created, updated or deleted. ([MODINVSTOR-1186](https://folio-org.atlassian.net/browse/MODINVSTOR-1186))

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,7 +28,7 @@
 * Add new date type fields to Instance schema ([MODINVSTOR-1188](https://folio-org.atlassian.net/browse/MODINVSTOR-1188))
 * Implement endpoint for bulk instances upsert from external file ([MODINVSTOR-1225](https://folio-org.atlassian.net/browse/MODINVSTOR-1225))
 * Add Subject source and Subject type to schema ([MODINVSTOR-1205](https://folio-org.atlassian.net/browse/MODINVSTOR-1205))
-
+* Add module descriptor validator plugin and fix the permission names ([MODINVSTOR-1247](https://folio-org.atlassian.net/browse/MODINVSTOR-1247))
 
 ### Bug fixes
 * Unintended update of instance records \_version (optimistic locking) whenever any of its holdings or items are created, updated or deleted. ([MODINVSTOR-1186](https://folio-org.atlassian.net/browse/MODINVSTOR-1186))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -104,7 +104,7 @@
         },{
           "methods": ["POST"],
           "pathPattern": "/holdings-storage/holdings/retrieve",
-          "permissionsRequired": ["inventory-storage.holdings.collection.get"]
+          "permissionsRequired": ["inventory-storage.holdings.collection.post"]
         }, {
           "methods": ["GET"],
           "pathPattern": "/holdings-storage/holdings/{id}",
@@ -176,7 +176,7 @@
         },{
           "methods": ["POST"],
           "pathPattern": "/instance-storage/instances/retrieve",
-          "permissionsRequired": ["inventory-storage.instances.collection.get"]
+          "permissionsRequired": ["inventory-storage.instances.collection.post"]
         },
         {
           "methods": ["GET"],
@@ -290,7 +290,7 @@
         {
           "methods": ["POST"],
           "pathPattern": "/instance-storage/batch/synchronous",
-          "permissionsRequired": ["inventory-storage.instances.batch.post"]
+          "permissionsRequired": ["inventory-storage.instances.batch.execute"]
         }
       ]
     },
@@ -1266,9 +1266,7 @@
           "methods": ["PUT"],
           "pathPattern": "/inventory-storage/bound-withs",
           "permissionsRequired": [
-            "inventory-storage.bound-with-parts.collection.get",
-            "inventory-storage.bound-with-parts.item.post",
-            "inventory-storage.bound-with-parts.item.delete"
+            "inventory-storage.bound-with-parts.collection.put"
           ]
         }
       ]
@@ -1428,7 +1426,7 @@
         {
           "methods": ["GET"],
           "pathPattern": "/inventory-storage/migrations/jobs",
-          "permissionsRequired": ["inventory-storage.migration.job.item.get"]
+          "permissionsRequired": ["inventory-storage.migration.job.collection.get"]
         },
         {
           "methods": ["DELETE"],
@@ -1526,6 +1524,11 @@
       "description": "get holdings collection from storage"
     },
     {
+      "permissionName": "inventory-storage.holdings.collection.post",
+      "displayName": "inventory storage - retrieve holdings collection",
+      "description": "retrieve holdings collection from storage"
+    },
+    {
       "permissionName": "inventory-storage.holdings.collection.delete",
       "displayName": "inventory storage - delete entire holdings collection",
       "description": "delete entire holdings collection from storage"
@@ -1566,6 +1569,11 @@
       "description": "get instance collection from storage"
     },
     {
+      "permissionName": "inventory-storage.instances.collection.post",
+      "displayName": "inventory storage - retrieve instance collection",
+      "description": "retrieve instance collection from storage"
+    },
+    {
       "permissionName": "inventory-storage.instances.collection.delete",
       "displayName": "inventory storage - delete entire instance collection",
       "description": "delete entire instance collection from storage"
@@ -1599,6 +1607,11 @@
       "permissionName": "inventory-storage.instances.batch.post",
       "displayName": "inventory storage - create or update a number of instances",
       "description": "create or update a number of instances in storage"
+    },
+    {
+      "permissionName": "inventory-storage.instances.batch.execute",
+      "displayName": "inventory storage - create or update a collection of instances in a single synchronous request",
+      "description": "create or update a collection of instances in a single synchronous request"
     },
     {
       "permissionName": "inventory-storage.instances.batch-unsafe.post",
@@ -2542,6 +2555,11 @@
       "description":    "add a holdings record to a bound-with by associating it with the bound-with item"
     },
     {
+      "permissionName": "inventory-storage.bound-with-parts.collection.put",
+      "displayName":    "inventory storage - modify a bound-withs",
+      "description":    "replace a holdings-records of a bound-withs or move it to a different bound-withs"
+    },
+    {
       "permissionName": "inventory-storage.bound-with-parts.item.put",
       "displayName":    "inventory storage - modify a bound-with part",
       "description":    "replace a holdings-record of a bound-with or move it to a different bound-with"
@@ -2607,6 +2625,11 @@
       "description": "get migration job by id"
     },
     {
+      "permissionName": "inventory-storage.migration.job.collection.get",
+      "displayName": "inventory storage - get migration jobs",
+      "description": "get migration jobs"
+    },
+    {
       "permissionName": "inventory-storage.migration.item.get",
       "displayName": "inventory storage - get list of available migrations",
       "description": "get list of available migrations"
@@ -2647,6 +2670,7 @@
         "inventory-storage.items.batch.post",
         "inventory-storage.items.batch-unsafe.post",
         "inventory-storage.holdings.collection.get",
+        "inventory-storage.holdings.collection.post",
         "inventory-storage.holdings.item.get",
         "inventory-storage.holdings.item.post",
         "inventory-storage.holdings.item.put",
@@ -2655,6 +2679,7 @@
         "inventory-storage.holdings.batch.post",
         "inventory-storage.holdings.batch-unsafe.post",
         "inventory-storage.instances.collection.get",
+        "inventory-storage.instances.collection.post",
         "inventory-storage.instances.item.get",
         "inventory-storage.instances.item.post",
         "inventory-storage.instances.item.put",
@@ -2666,6 +2691,7 @@
         "inventory-storage.instances.source-record.marc-json.delete",
         "inventory-storage.instances.collection.delete",
         "inventory-storage.instances.batch.post",
+        "inventory-storage.instances.batch.execute",
         "inventory-storage.instances.batch-unsafe.post",
         "inventory-storage.instances.bulk.post",
         "inventory-storage.loan-types.collection.get",
@@ -2853,6 +2879,7 @@
         "inventory-storage.bound-with-parts.collection.get",
         "inventory-storage.bound-with-parts.item.get",
         "inventory-storage.bound-with-parts.item.post",
+        "inventory-storage.bound-with-parts.collection.put",
         "inventory-storage.bound-with-parts.item.put",
         "inventory-storage.bound-with-parts.item.delete",
         "inventory-storage.inventory-hierarchy.updated-instances-ids.collection.get",
@@ -2870,6 +2897,7 @@
         "inventory-storage.migration.job.item.delete",
         "inventory-storage.migration.job.post",
         "inventory-storage.migration.job.item.get",
+        "inventory-storage.migration.job.collection.get",
         "inventory-storage.migration.item.get",
         "inventory-storage.reindex-records.publish.post",
         "inventory-storage.instance-date-types.collection.get",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -95,7 +95,7 @@
     },
     {
       "id": "holdings-storage",
-      "version": "7.0",
+      "version": "8.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -167,7 +167,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "10.3",
+      "version": "11.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -285,7 +285,7 @@
     },
     {
       "id": "instance-storage-batch-sync",
-      "version": "2.0",
+      "version": "3.0",
       "handlers": [
         {
           "methods": ["POST"],
@@ -1240,7 +1240,7 @@
     },
     {
       "id": "bound-with-parts-storage",
-      "version": "1.1",
+      "version": "2.0",
       "handlers": [
         {
           "methods": ["GET"],
@@ -1406,7 +1406,7 @@
     },
     {
       "id": "async-migration",
-      "version": "0.1",
+      "version": "1.0",
       "handlers": [
         {
           "methods": ["POST"],

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -176,7 +176,7 @@
         },{
           "methods": ["POST"],
           "pathPattern": "/instance-storage/instances/retrieve",
-          "permissionsRequired": ["inventory-storage.instances.collection.post"]
+          "permissionsRequired": ["inventory-storage.instances.retrieve.collection.post"]
         },
         {
           "methods": ["GET"],
@@ -1569,7 +1569,7 @@
       "description": "get instance collection from storage"
     },
     {
-      "permissionName": "inventory-storage.instances.collection.post",
+      "permissionName": "inventory-storage.instances.retrieve.collection.post",
       "displayName": "inventory storage - retrieve instance collection",
       "description": "retrieve instance collection from storage"
     },
@@ -2679,7 +2679,7 @@
         "inventory-storage.holdings.batch.post",
         "inventory-storage.holdings.batch-unsafe.post",
         "inventory-storage.instances.collection.get",
-        "inventory-storage.instances.collection.post",
+        "inventory-storage.instances.retrieve.collection.post",
         "inventory-storage.instances.item.get",
         "inventory-storage.instances.item.post",
         "inventory-storage.instances.item.put",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -104,7 +104,7 @@
         },{
           "methods": ["POST"],
           "pathPattern": "/holdings-storage/holdings/retrieve",
-          "permissionsRequired": ["inventory-storage.holdings.collection.post"]
+          "permissionsRequired": ["inventory-storage.holdings.retrieve.collection.post"]
         }, {
           "methods": ["GET"],
           "pathPattern": "/holdings-storage/holdings/{id}",
@@ -290,7 +290,7 @@
         {
           "methods": ["POST"],
           "pathPattern": "/instance-storage/batch/synchronous",
-          "permissionsRequired": ["inventory-storage.instances.batch.execute"]
+          "permissionsRequired": ["inventory-storage.instances.batch.synchronous.post"]
         }
       ]
     },
@@ -1266,7 +1266,7 @@
           "methods": ["PUT"],
           "pathPattern": "/inventory-storage/bound-withs",
           "permissionsRequired": [
-            "inventory-storage.bound-with-parts.collection.put"
+            "inventory-storage.bound-withs.collection.put"
           ]
         }
       ]
@@ -1524,7 +1524,7 @@
       "description": "get holdings collection from storage"
     },
     {
-      "permissionName": "inventory-storage.holdings.collection.post",
+      "permissionName": "inventory-storage.holdings.retrieve.collection.post",
       "displayName": "inventory storage - retrieve holdings collection",
       "description": "retrieve holdings collection from storage"
     },
@@ -1609,7 +1609,7 @@
       "description": "create or update a number of instances in storage"
     },
     {
-      "permissionName": "inventory-storage.instances.batch.execute",
+      "permissionName": "inventory-storage.instances.batch.synchronous.post",
       "displayName": "inventory storage - create or update a collection of instances in a single synchronous request",
       "description": "create or update a collection of instances in a single synchronous request"
     },
@@ -2555,7 +2555,7 @@
       "description":    "add a holdings record to a bound-with by associating it with the bound-with item"
     },
     {
-      "permissionName": "inventory-storage.bound-with-parts.collection.put",
+      "permissionName": "inventory-storage.bound-withs.collection.put",
       "displayName":    "inventory storage - modify a bound-withs",
       "description":    "replace a holdings-records of a bound-withs or move it to a different bound-withs"
     },
@@ -2670,7 +2670,7 @@
         "inventory-storage.items.batch.post",
         "inventory-storage.items.batch-unsafe.post",
         "inventory-storage.holdings.collection.get",
-        "inventory-storage.holdings.collection.post",
+        "inventory-storage.holdings.retrieve.collection.post",
         "inventory-storage.holdings.item.get",
         "inventory-storage.holdings.item.post",
         "inventory-storage.holdings.item.put",
@@ -2691,7 +2691,7 @@
         "inventory-storage.instances.source-record.marc-json.delete",
         "inventory-storage.instances.collection.delete",
         "inventory-storage.instances.batch.post",
-        "inventory-storage.instances.batch.execute",
+        "inventory-storage.instances.batch.synchronous.post",
         "inventory-storage.instances.batch-unsafe.post",
         "inventory-storage.instances.bulk.post",
         "inventory-storage.loan-types.collection.get",
@@ -2879,7 +2879,7 @@
         "inventory-storage.bound-with-parts.collection.get",
         "inventory-storage.bound-with-parts.item.get",
         "inventory-storage.bound-with-parts.item.post",
-        "inventory-storage.bound-with-parts.collection.put",
+        "inventory-storage.bound-withs.collection.put",
         "inventory-storage.bound-with-parts.item.put",
         "inventory-storage.bound-with-parts.item.delete",
         "inventory-storage.inventory-hierarchy.updated-instances-ids.collection.get",

--- a/pom.xml
+++ b/pom.xml
@@ -51,6 +51,7 @@
     <checkstyle.version>10.18.1</checkstyle.version>
     <maven-failsafe-plugin.version>3.5.0</maven-failsafe-plugin.version>
     <versions-maven-plugin.version>2.17.1</versions-maven-plugin.version>
+    <folio-module-descriptor-validator.version>1.0.0</folio-module-descriptor-validator.version>
   </properties>
 
   <dependencyManagement>
@@ -638,6 +639,19 @@
         </configuration>
       </plugin>
 
+      <plugin>
+        <groupId>org.folio</groupId>
+        <artifactId>folio-module-descriptor-validator</artifactId>
+        <version>${folio-module-descriptor-validator.version}</version>
+        <inherited>false</inherited>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
   <artifactId>mod-inventory-storage</artifactId>
   <groupId>org.folio</groupId>
-  <version>27.2.0-SNAPSHOT</version>
+  <version>28.0.0-SNAPSHOT</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
### Purpose
To support automatic capabilities creation and keep FOLIO permission usage consistent, it is suggested that all module descriptors be reviewed and inconsistencies in permission namings and usage be fixed.

### Approach
Add module descriptor validator plugin and fix the issue with permission names

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.
