### PR TITLE
[MODINVSTOR-1264] Add codes to Subject sources

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,7 @@
 * Add new date type fields to Instance schema ([MODINVSTOR-1188](https://folio-org.atlassian.net/browse/MODINVSTOR-1188))
 * Implement endpoint for bulk instances upsert from external file ([MODINVSTOR-1225](https://folio-org.atlassian.net/browse/MODINVSTOR-1225))
 * Add Subject source and Subject type to schema ([MODINVSTOR-1205](https://folio-org.atlassian.net/browse/MODINVSTOR-1205))
+* Add codes to Subject sources ([MODINVSTOR-1264](https://folio-org.atlassian.net/browse/MODINVSTOR-1264))
 
 
 ### Bug fixes

--- a/ramls/subject-source.json
+++ b/ramls/subject-source.json
@@ -7,7 +7,11 @@
       "type": "string"
     },
     "name": {
-      "description": "label for the subject source",
+      "description": "label for the subject source name",
+      "type": "string"
+    },
+    "code": {
+      "description": "label for the subject source code",
       "type": "string"
     },
     "source": {

--- a/reference-data/subject-sources/CanadianSubjectHeadings.json
+++ b/reference-data/subject-sources/CanadianSubjectHeadings.json
@@ -1,0 +1,5 @@
+{
+  "id": "e894d0dc-621d-4b1d-98f6-6f7120eb0d45",
+  "name": "Canadian Subject Headings",
+  "source": "folio"
+}

--- a/reference-data/subject-sources/CanadianSubjectHeadings.json
+++ b/reference-data/subject-sources/CanadianSubjectHeadings.json
@@ -1,5 +1,6 @@
 {
   "id": "e894d0dc-621d-4b1d-98f6-6f7120eb0d45",
   "name": "Canadian Subject Headings",
+  "code" : "cash",
   "source": "folio"
 }

--- a/reference-data/subject-sources/LibraryofCongressChildrensandYoungAdultsSubjectHeadings.json
+++ b/reference-data/subject-sources/LibraryofCongressChildrensandYoungAdultsSubjectHeadings.json
@@ -1,0 +1,5 @@
+{
+  "id": "e894d0dc-621d-4b1d-98f6-6f7120eb0d41",
+  "name": "Library of Congress Children's and Young Adults' Subject Headings",
+  "source": "folio"
+}

--- a/reference-data/subject-sources/LibraryofCongressChildrensandYoungAdultsSubjectHeadings.json
+++ b/reference-data/subject-sources/LibraryofCongressChildrensandYoungAdultsSubjectHeadings.json
@@ -1,5 +1,6 @@
 {
   "id": "e894d0dc-621d-4b1d-98f6-6f7120eb0d41",
   "name": "Library of Congress Children's and Young Adults' Subject Headings",
+  "code" : "cyac",
   "source": "folio"
 }

--- a/reference-data/subject-sources/LibraryofCongressSubjectHeadings.json
+++ b/reference-data/subject-sources/LibraryofCongressSubjectHeadings.json
@@ -1,5 +1,6 @@
 {
   "id": "e894d0dc-621d-4b1d-98f6-6f7120eb0d40",
   "name": "Library of Congress Subject Headings",
+  "code" : "lcsh",
   "source": "folio"
 }

--- a/reference-data/subject-sources/LibraryofCongressSubjectHeadings.json
+++ b/reference-data/subject-sources/LibraryofCongressSubjectHeadings.json
@@ -1,0 +1,5 @@
+{
+  "id": "e894d0dc-621d-4b1d-98f6-6f7120eb0d40",
+  "name": "Library of Congress Subject Headings",
+  "source": "folio"
+}

--- a/reference-data/subject-sources/MedicalSubjectHeadings.json
+++ b/reference-data/subject-sources/MedicalSubjectHeadings.json
@@ -1,0 +1,5 @@
+{
+  "id": "e894d0dc-621d-4b1d-98f6-6f7120eb0d42",
+  "name": "Medical Subject Headings",
+  "source": "folio"
+}

--- a/reference-data/subject-sources/MedicalSubjectHeadings.json
+++ b/reference-data/subject-sources/MedicalSubjectHeadings.json
@@ -1,5 +1,6 @@
 {
   "id": "e894d0dc-621d-4b1d-98f6-6f7120eb0d42",
   "name": "Medical Subject Headings",
+  "code" : "mesh",
   "source": "folio"
 }

--- a/reference-data/subject-sources/NationalAgriculturalLibrarysubjectauthorityfile.json
+++ b/reference-data/subject-sources/NationalAgriculturalLibrarysubjectauthorityfile.json
@@ -1,0 +1,5 @@
+{
+  "id": "e894d0dc-621d-4b1d-98f6-6f7120eb0d43",
+  "name": "National Agricultural Library subject authority file",
+  "source": "folio"
+}

--- a/reference-data/subject-sources/Repertoiredevedettes-matiere.json
+++ b/reference-data/subject-sources/Repertoiredevedettes-matiere.json
@@ -1,5 +1,6 @@
 {
   "id": "e894d0dc-621d-4b1d-98f6-6f7120eb0d46",
   "name": "Répertoire de vedettes-matière",
+  "code" : "rvm",
   "source": "folio"
 }

--- a/reference-data/subject-sources/Repertoiredevedettes-matiere.json
+++ b/reference-data/subject-sources/Repertoiredevedettes-matiere.json
@@ -1,0 +1,5 @@
+{
+  "id": "e894d0dc-621d-4b1d-98f6-6f7120eb0d46",
+  "name": "Répertoire de vedettes-matière",
+  "source": "folio"
+}

--- a/reference-data/subject-sources/Sourcenotspecified.json
+++ b/reference-data/subject-sources/Sourcenotspecified.json
@@ -1,0 +1,5 @@
+{
+  "id": "e894d0dc-621d-4b1d-98f6-6f7120eb0d44",
+  "name": "Source not specified",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Chronologicalterm.json
+++ b/reference-data/subject-types/Chronologicalterm.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff5b6",
+  "name": "Chronological term",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Corporatename.json
+++ b/reference-data/subject-types/Corporatename.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff5b2",
+  "name": "Corporate name",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Curriculumobjective.json
+++ b/reference-data/subject-types/Curriculumobjective.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff514",
+  "name": "Curriculum objective",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Facetedtopicalterms.json
+++ b/reference-data/subject-types/Facetedtopicalterms.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff510",
+  "name": "Faceted topical terms",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Function.json
+++ b/reference-data/subject-types/Function.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff513",
+  "name": "Function",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Genreform.json
+++ b/reference-data/subject-types/Genreform.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff511",
+  "name": "Genre/form",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Geographicname.json
+++ b/reference-data/subject-types/Geographicname.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff5b8",
+  "name": "Geographic name",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Hierarchicalplacename.json
+++ b/reference-data/subject-types/Hierarchicalplacename.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff515",
+  "name": "Hierarchical place name",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Meetingname.json
+++ b/reference-data/subject-types/Meetingname.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff5b3",
+  "name": "Meeting name",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Namedevent.json
+++ b/reference-data/subject-types/Namedevent.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff5b5",
+  "name": "Named event",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Occupation.json
+++ b/reference-data/subject-types/Occupation.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff512",
+  "name": "Occupation",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Personalname.json
+++ b/reference-data/subject-types/Personalname.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff5b1",
+  "name": "Personal name",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Topicalterm.json
+++ b/reference-data/subject-types/Topicalterm.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff5b7",
+  "name": "Topical term",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Typeofentityunspecified.json
+++ b/reference-data/subject-types/Typeofentityunspecified.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff516",
+  "name": "Type of entity unspecified",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Uncontrolled.json
+++ b/reference-data/subject-types/Uncontrolled.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff5b9",
+  "name": "Uncontrolled",
+  "source": "folio"
+}

--- a/reference-data/subject-types/Uniformtitle.json
+++ b/reference-data/subject-types/Uniformtitle.json
@@ -1,0 +1,5 @@
+{
+  "id": "d6488f88-1e74-40ce-81b5-b19a928ff5b4",
+  "name": "Uniform title",
+  "source": "folio"
+}

--- a/src/main/resources/templates/db_scripts/addSubjectSources.sql
+++ b/src/main/resources/templates/db_scripts/addSubjectSources.sql
@@ -1,38 +1,33 @@
 INSERT INTO ${myuniversity}_${mymodule}.subject_source (id, jsonb)
 VALUES ('e894d0dc-621d-4b1d-98f6-6f7120eb0d40',
-        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d40', 'name', 'Library of Congress Subject Headings',  'source', 'folio'))
+        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d40', 'name', 'Library of Congress Subject Headings', 'code', 'lcsh', 'source', 'folio'))
 ON CONFLICT DO NOTHING;
 
 INSERT INTO ${myuniversity}_${mymodule}.subject_source (id, jsonb)
 VALUES ('e894d0dc-621d-4b1d-98f6-6f7120eb0d41',
-        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d41', 'name', 'Library of Congress Children''s and Young Adults'' Subject Headings',  'source', 'folio'))
+        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d41', 'name', 'Library of Congress Children''s and Young Adults'' Subject Headings', 'code', 'cyac', 'source', 'folio'))
 ON CONFLICT DO NOTHING;
 INSERT INTO ${myuniversity}_${mymodule}.subject_source (id, jsonb)
 VALUES ('e894d0dc-621d-4b1d-98f6-6f7120eb0d42',
-        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d42', 'name', 'Medical Subject Headings',  'source', 'folio'))
+        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d42', 'name', 'Medical Subject Headings', 'code', 'mesh', 'source', 'folio'))
 ON CONFLICT DO NOTHING;
 
 INSERT INTO ${myuniversity}_${mymodule}.subject_source (id, jsonb)
 VALUES ('e894d0dc-621d-4b1d-98f6-6f7120eb0d43',
-        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d43', 'name', 'National Agricultural Library subject authority file',  'source', 'folio'))
+        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d43', 'name', 'National Agricultural Library subject authority file', 'code', 'nalnaf', 'source', 'folio'))
 ON CONFLICT DO NOTHING;
 
 INSERT INTO ${myuniversity}_${mymodule}.subject_source (id, jsonb)
 VALUES ('e894d0dc-621d-4b1d-98f6-6f7120eb0d44',
-        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d44', 'name', 'Source not specified',  'source', 'folio'))
+        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d44', 'name', 'Source not specified', 'source', 'folio'))
 ON CONFLICT DO NOTHING;
 
 INSERT INTO ${myuniversity}_${mymodule}.subject_source (id, jsonb)
 VALUES ('e894d0dc-621d-4b1d-98f6-6f7120eb0d45',
-        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d45', 'name', 'Canadian Subject Headings',  'source', 'folio'))
+        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d45', 'name', 'Canadian Subject Headings', 'code', 'cash',  'source', 'folio'))
 ON CONFLICT DO NOTHING;
 
 INSERT INTO ${myuniversity}_${mymodule}.subject_source (id, jsonb)
 VALUES ('e894d0dc-621d-4b1d-98f6-6f7120eb0d46',
-        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d46', 'name', 'Répertoire de vedettes-matière',  'source', 'folio'))
-ON CONFLICT DO NOTHING;
-
-INSERT INTO ${myuniversity}_${mymodule}.subject_source (id, jsonb)
-VALUES ('e894d0dc-621d-4b1d-98f6-6f7120eb0d47',
-        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d47', 'name', 'Source specified in subfield $2',  'source', 'folio'))
+        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d46', 'name', 'Répertoire de vedettes-matière', 'code', 'rvm',  'source', 'folio'))
 ON CONFLICT DO NOTHING;

--- a/src/main/resources/templates/db_scripts/addSubjectSources.sql
+++ b/src/main/resources/templates/db_scripts/addSubjectSources.sql
@@ -14,7 +14,7 @@ ON CONFLICT DO NOTHING;
 
 INSERT INTO ${myuniversity}_${mymodule}.subject_source (id, jsonb)
 VALUES ('e894d0dc-621d-4b1d-98f6-6f7120eb0d43',
-        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d43', 'name', 'National Agricultural Library subject authority file', 'code', 'nalnaf', 'source', 'folio'))
+        json_build_object('id','e894d0dc-621d-4b1d-98f6-6f7120eb0d43', 'name', 'National Agricultural Library subject authority file', 'source', 'folio'))
 ON CONFLICT DO NOTHING;
 
 INSERT INTO ${myuniversity}_${mymodule}.subject_source (id, jsonb)

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -914,6 +914,10 @@
         {
           "fieldName": "name",
           "tOps": "ADD"
+        },
+        {
+          "fieldName": "code",
+          "tOps": "ADD"
         }
       ]
     }

--- a/src/test/java/org/folio/rest/api/SubjectSourceTest.java
+++ b/src/test/java/org/folio/rest/api/SubjectSourceTest.java
@@ -68,7 +68,8 @@ public class SubjectSourceTest extends TestBase {
     subjectSourceClient.create(subjectSource);
 
     CompletableFuture<Response> postCompleted = new CompletableFuture<>();
-    getClient().post(subjectSourcesUrl(""), subjectSource.put("name", "Test2"), TENANT_ID, ResponseHandler.json(postCompleted));
+    getClient().post(subjectSourcesUrl(""), subjectSource.put("name", "Test2"),
+      TENANT_ID, ResponseHandler.json(postCompleted));
 
     Response response = postCompleted.get(TIMEOUT, TimeUnit.SECONDS);
     assertThat(response.getStatusCode(), is(422));

--- a/src/test/java/org/folio/rest/impl/SubjectSourcesIT.java
+++ b/src/test/java/org/folio/rest/impl/SubjectSourcesIT.java
@@ -36,6 +36,7 @@ public class SubjectSourcesIT extends BaseReferenceDataIntegrationTest<SubjectSo
     return new SubjectSource()
       .withId(UUID.randomUUID().toString())
       .withName("test_name")
+      .withCode("test_code")
       .withSource(SubjectSource.Source.LOCAL);
   }
 
@@ -46,7 +47,7 @@ public class SubjectSourcesIT extends BaseReferenceDataIntegrationTest<SubjectSo
 
   @Override
   protected List<Function<SubjectSource, Object>> recordFieldExtractors() {
-    return List.of(SubjectSource::getName, SubjectSource::getSource);
+    return List.of(SubjectSource::getName, SubjectSource::getCode, SubjectSource::getSource);
   }
 
   @Override
@@ -66,6 +67,6 @@ public class SubjectSourcesIT extends BaseReferenceDataIntegrationTest<SubjectSo
 
   @Override
   protected List<String> queries() {
-    return List.of("name==test_name");
+    return List.of("name==test_name", "code==test_code");
   }
 }


### PR DESCRIPTION
### Purpose
Add codes to Subject sources
### Approach

- Extend schema of Subject source to contain code (code should be unique)
- Remove reference data “specified in subfiled $2”
- Add codes to existing as ref data Subject sources (find corresponding values in [Subject Heading and Term Source Codes: Source Codes for Vocabularies, Rules, and Schemes (Network Development and MARC Standards Office, Library of Congress)](https://www.loc.gov/standards/sourcelist/subject.html) )

### Jira 
https://folio-org.atlassian.net/browse/MODINVSTOR-1264
