### PR TITLE
feat(remove-instance-shadow-copies): Create script to remove Instance shadow copies without shared record in ecs sprint testing environment

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -29,6 +29,7 @@
 * Implement endpoint for bulk instances upsert from external file ([MODINVSTOR-1225](https://folio-org.atlassian.net/browse/MODINVSTOR-1225))
 * Add Subject source and Subject type to schema ([MODINVSTOR-1205](https://folio-org.atlassian.net/browse/MODINVSTOR-1205))
 * Add codes to Subject sources ([MODINVSTOR-1264](https://folio-org.atlassian.net/browse/MODINVSTOR-1264))
+* Create script to remove instance shadow copies without shared record in ecs sprint testing environment ([MODINVSTOR-1263](https://folio-org.atlassian.net/browse/MODINVSTOR-1263))
 
 
 ### Bug fixes

--- a/src/main/resources/templates/db_scripts/removeInstanceShadowCopiesWithoutSharedRecord.sql
+++ b/src/main/resources/templates/db_scripts/removeInstanceShadowCopiesWithoutSharedRecord.sql
@@ -1,0 +1,94 @@
+DO
+$$
+DECLARE
+    trigger VARCHAR;
+    triggers      VARCHAR[] DEFAULT ARRAY[
+    'audit_instance',
+    'check_subject_references_on_insert_or_update',
+    'instance_check_statistical_code_references_on_insert',
+    'instance_check_statistical_code_references_on_update',
+    'set_id_in_jsonb',
+    'set_instance_md_json_trigger',
+    'set_instance_md_trigger',
+    'set_instance_ol_version_trigger',
+    'set_instance_sourcerecordformat',
+    'set_instance_status_updated_date',
+    'update_instance_references',
+    'updatecompleteupdateddate_instance'];
+    arr          UUID[] DEFAULT ARRAY[
+        '10000000-0000-0000-0000-000000000000',
+        '20000000-0000-0000-0000-000000000000',
+        '30000000-0000-0000-0000-000000000000',
+        '40000000-0000-0000-0000-000000000000',
+        '50000000-0000-0000-0000-000000000000',
+        '60000000-0000-0000-0000-000000000000',
+        '70000000-0000-0000-0000-000000000000',
+        '80000000-0000-0000-0000-000000000000',
+        '90000000-0000-0000-0000-000000000000',
+        'a0000000-0000-0000-0000-000000000000',
+        'b0000000-0000-0000-0000-000000000000',
+        'c0000000-0000-0000-0000-000000000000',
+        'd0000000-0000-0000-0000-000000000000',
+        'e0000000-0000-0000-0000-000000000000',
+        'f0000000-0000-0000-0000-000000000000',
+        'ffffffff-ffff-ffff-ffff-ffffffffffff'
+    ];
+    lower          UUID;
+    cur            UUID;
+    rowcount       BIGINT;
+    need_deletion BOOLEAN;
+BEGIN
+    -- STEP 0: Check if deletion is required
+    SELECT EXISTS (
+        SELECT 1
+        FROM ${myuniversity}_${mymodule}.instance shared_instance
+        WHERE shared_instance.jsonb ? 'source'
+          AND (shared_instance.jsonb ->> 'source') ILIKE 'CONSORTIUM-%%'
+          AND NOT EXISTS (
+              SELECT 1
+              FROM ${central}_${mymodule}.instance local_instance
+              WHERE local_instance.id = shared_instance.id
+              LIMIT 1
+          )
+          LIMIT 1
+    ) INTO need_deletion;
+
+    IF need_deletion THEN
+        -- STEP 1: Disable triggers
+        FOREACH trigger IN ARRAY triggers LOOP
+            EXECUTE 'ALTER TABLE ${myuniversity}_${mymodule}.instance DISABLE TRIGGER '
+            || trigger;
+        END LOOP;
+
+        -- STEP 2: Do deletions
+        lower := '00000000-0000-0000-0000-000000000000';
+        FOREACH cur IN ARRAY arr LOOP
+            RAISE INFO 'range: % - %', lower, cur;
+            -- Delete scripts
+            EXECUTE format($q$
+                DELETE FROM ${myuniversity}_${mymodule}.instance shared_instance
+                WHERE shared_instance.jsonb ? 'source'
+                  AND (shared_instance.jsonb ->> 'source') ILIKE 'CONSORTIUM-%%'
+                  AND NOT EXISTS (
+                      SELECT 1
+                      FROM  ${central}_${mymodule}.instance local_instance
+                      WHERE local_instance.id = shared_instance.id
+                      LIMIT 1
+                  )
+                  AND (id > %L AND id <= %L);
+            $q$, lower, cur);
+
+            GET DIAGNOSTICS rowcount = ROW_COUNT;
+            RAISE INFO 'deleted % instances', rowcount;
+
+            lower := cur;
+        END LOOP;
+
+        -- STEP 3: Enable triggers
+        FOREACH trigger IN ARRAY triggers LOOP
+            EXECUTE 'ALTER TABLE ${myuniversity}_${mymodule}.instance ENABLE TRIGGER '
+            || trigger;
+        END LOOP;
+    END IF;
+END;
+$$ LANGUAGE 'plpgsql';

--- a/src/main/resources/templates/db_scripts/removeInstanceShadowCopiesWithoutSharedRecord.sql
+++ b/src/main/resources/templates/db_scripts/removeInstanceShadowCopiesWithoutSharedRecord.sql
@@ -41,13 +41,13 @@ BEGIN
     -- STEP 0: Check if deletion is required
     SELECT EXISTS (
         SELECT 1
-        FROM ${myuniversity}_${mymodule}.instance shared_instance
-        WHERE shared_instance.jsonb ? 'source'
-          AND (shared_instance.jsonb ->> 'source') ILIKE 'CONSORTIUM-%%'
+        FROM ${myuniversity}_${mymodule}.instance member_instance
+        WHERE member_instance.jsonb ? 'source'
+          AND (member_instance.jsonb ->> 'source') ILIKE 'CONSORTIUM-%%'
           AND NOT EXISTS (
               SELECT 1
-              FROM ${central}_${mymodule}.instance local_instance
-              WHERE local_instance.id = shared_instance.id
+              FROM ${central}_${mymodule}.instance central_instance
+              WHERE central_instance.id = member_instance.id
               LIMIT 1
           )
           LIMIT 1
@@ -66,13 +66,13 @@ BEGIN
             RAISE INFO 'range: % - %', lower, cur;
             -- Delete scripts
             EXECUTE format($q$
-                DELETE FROM ${myuniversity}_${mymodule}.instance shared_instance
-                WHERE shared_instance.jsonb ? 'source'
-                  AND (shared_instance.jsonb ->> 'source') ILIKE 'CONSORTIUM-%%'
+                DELETE FROM ${myuniversity}_${mymodule}.instance member_instance
+                WHERE member_instance.jsonb ? 'source'
+                  AND (member_instance.jsonb ->> 'source') ILIKE 'CONSORTIUM-%%'
                   AND NOT EXISTS (
                       SELECT 1
-                      FROM  ${central}_${mymodule}.instance local_instance
-                      WHERE local_instance.id = shared_instance.id
+                      FROM  ${central}_${mymodule}.instance central_instance
+                      WHERE central_instance.id = member_instance.id
                       LIMIT 1
                   )
                   AND (id > %L AND id <= %L);

--- a/src/test/java/org/folio/rest/api/RemoveInstanceShadowCopiesWithoutSharedRecordTest.java
+++ b/src/test/java/org/folio/rest/api/RemoveInstanceShadowCopiesWithoutSharedRecordTest.java
@@ -1,0 +1,140 @@
+package org.folio.rest.api;
+
+import static org.folio.utility.ModuleUtility.getVertx;
+import static org.folio.utility.ModuleUtility.prepareTenant;
+import static org.folio.utility.ModuleUtility.removeTenant;
+import static org.folio.utility.RestUtility.CONSORTIUM_CENTRAL_TENANT;
+import static org.folio.utility.RestUtility.CONSORTIUM_MEMBER_TENANT;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowSet;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import lombok.SneakyThrows;
+import org.folio.rest.persist.PostgresClient;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+public class RemoveInstanceShadowCopiesWithoutSharedRecordTest extends MigrationTestBase {
+
+  private static final String TAG_VALUE = "test-tag";
+  private static final String FOLIO_SOURCE = "FOLIO";
+  private static final String CONSORTIUM_FOLIO_SOURCE = "CONSORTIUM-FOLIO";
+  private static final String CONSORTIUM_MARC_SOURCE = "CONSORTIUM-MARC";
+  private static final String SELECT_INSTANCE_COUNT_QUERY = "SELECT COUNT(*) FROM %s_mod_inventory_storage.instance";
+  private static final String SELECT_JSONB_QUERY = "SELECT jsonb FROM %s_mod_inventory_storage.instance";
+  private static final String SQL_SCRIPT = loadScript(
+    "removeInstanceShadowCopiesWithoutSharedRecord.sql",
+    RemoveInstanceShadowCopiesWithoutSharedRecordTest::replacePlaceholders);
+
+  @SneakyThrows
+  @BeforeClass
+  public static void beforeClass() {
+    prepareTenant(CONSORTIUM_MEMBER_TENANT, false);
+    prepareTenant(CONSORTIUM_CENTRAL_TENANT, false);
+  }
+
+  @SneakyThrows
+  @AfterClass
+  public static void afterClass() {
+    removeTenant(CONSORTIUM_MEMBER_TENANT);
+    removeTenant(CONSORTIUM_CENTRAL_TENANT);
+  }
+
+  @Before
+  public void beforeEach() {
+    clearData(CONSORTIUM_MEMBER_TENANT);
+    clearData(CONSORTIUM_CENTRAL_TENANT);
+    removeAllEvents();
+  }
+
+  @Test
+  public void shouldRemoveInstanceShadowCopiesWithoutSharedRecord() throws Exception {
+    //instance shadow copies without shared record
+    createInstance(UUID.randomUUID().toString(), CONSORTIUM_FOLIO_SOURCE, CONSORTIUM_MEMBER_TENANT);
+    createInstance(UUID.randomUUID().toString(), CONSORTIUM_MARC_SOURCE, CONSORTIUM_MEMBER_TENANT);
+
+    // check the number of instances in the table before executing the script.
+    String instanceCountQuery = String.format(SELECT_INSTANCE_COUNT_QUERY, CONSORTIUM_MEMBER_TENANT);
+    RowSet<Row> queryResult = runSql(instanceCountQuery);
+    assertEquals(2L, queryResult.iterator().next().getLong("count").longValue());
+
+    executeMultipleSqlStatements(SQL_SCRIPT);
+
+    String query = String.format(SELECT_INSTANCE_COUNT_QUERY, CONSORTIUM_MEMBER_TENANT);
+    RowSet<Row> result = runSql(query);
+
+    assertEquals(0, result.iterator().next().getLong("count").longValue());
+  }
+
+  @Test
+  public void shouldNotRemoveInstanceShadowCopiesWithSharedRecord() throws Exception {
+    var instanceId = UUID.randomUUID().toString();
+    createInstance(instanceId, CONSORTIUM_FOLIO_SOURCE, CONSORTIUM_MEMBER_TENANT);
+    createInstance(instanceId, FOLIO_SOURCE, CONSORTIUM_CENTRAL_TENANT);
+
+    executeMultipleSqlStatements(SQL_SCRIPT);
+
+    String query = String.format(SELECT_JSONB_QUERY, CONSORTIUM_MEMBER_TENANT);
+    RowSet<Row> result = runSql(query);
+
+    assertEquals(1, result.rowCount());
+    JsonObject jsonb = result.iterator().next().getJsonObject("jsonb");
+    assertNotNull(jsonb);
+    assertEquals(instanceId, jsonb.getString("id"));
+    assertEquals(CONSORTIUM_FOLIO_SOURCE, jsonb.getString("source"));
+  }
+
+  @Test
+  public void shouldNotRemoveInstanceShadowCopiesWithoutConsortiumSourcePrefix() throws Exception {
+    var instanceId = UUID.randomUUID().toString();
+    createInstance(instanceId, FOLIO_SOURCE, CONSORTIUM_MEMBER_TENANT);
+
+    executeMultipleSqlStatements(SQL_SCRIPT);
+
+    String query = String.format(SELECT_JSONB_QUERY, CONSORTIUM_MEMBER_TENANT);
+    RowSet<Row> result = runSql(query);
+
+    assertEquals(1, result.rowCount());
+    JsonObject jsonb = result.iterator().next().getJsonObject("jsonb");
+    assertNotNull(jsonb);
+    assertEquals(instanceId, jsonb.getString("id"));
+    assertEquals(FOLIO_SOURCE, jsonb.getString("source"));
+  }
+
+  @SneakyThrows
+  private RowSet<Row> runSql(String sql) {
+    return PostgresClient.getInstance(getVertx(), CONSORTIUM_MEMBER_TENANT)
+      .execute(sql)
+      .toCompletionStage()
+      .toCompletableFuture()
+      .get(TIMEOUT, TimeUnit.SECONDS);
+  }
+
+  private void createInstance(String instanceId, String source, String tenant) {
+    JsonObject instanceToCreate = new JsonObject()
+      .put("id", instanceId)
+      .put("title", "Test")
+      .put("source", source)
+      .put("identifiers", new JsonArray().add(identifier(UUID_ISBN, "9781473619777")))
+      .put("instanceTypeId", UUID_INSTANCE_TYPE.toString())
+      .put("tags", new JsonObject().put("tagList", new JsonArray().add(TAG_VALUE)))
+      .put("_version", 1);
+
+    instancesClient.create(instanceToCreate, tenant);
+  }
+
+  private static String replacePlaceholders(String resource) {
+    return resource
+      .replace("${central}_${mymodule}",
+        String.format("%s_mod_inventory_storage", CONSORTIUM_CENTRAL_TENANT))
+      .replace("${myuniversity}_${mymodule}",
+        String.format("%s_mod_inventory_storage", CONSORTIUM_MEMBER_TENANT));
+  }
+}

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -91,7 +91,8 @@ import org.junit.runners.Suite;
   RetainLeadingZeroesMigrationScriptTest.class,
   StatisticalCodeTest.class,
   UpcIsmnMigrationScriptTest.class,
-  InstanceStorageInstancesBulkApiTest.class
+  InstanceStorageInstancesBulkApiTest.class,
+  RemoveInstanceShadowCopiesWithoutSharedRecordTest.class
 
   // These fail.
   //ReferenceTablesTest.class,


### PR DESCRIPTION
### Purpose
[MODINVSTOR-1263](https://folio-org.atlassian.net/browse/MODINVSTOR-1263) There are data issues in the ECS sprint testing environment where shadow copies exist but no record exists on the central tenant. Potentially this is an issue with how the data was loaded, or some inconsistency where records were deleted on the central tenant but it was not synchronized to the member tenants. 

### Approach
Create script to delete from member tenant instances that has source=”CONSORTIUM-*” but don’t have same instance in central tenant.
Use `${central}` placeholder for central tenant name in the sql script.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.
