### PR TITLE
MODINVSTOR-1272: Upgrade localstack from 0.11.3 to s3-latest (=3.8.0)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@
 * Provides `inventory-view-instance-set 3.0`
 * Provides `instance-iteration 1.0`
 
+### Tech Dept
+* Upgrade localstack from 0.11.3 to s3-latest (=3.8.0) ([MODINVSTOR-1272](https://folio-org.atlassian.net/browse/MODINVSTOR-1272))
+
 ## v27.2.0 2024-09-24
 ### Breaking changes
 * Required sourceId field in holdings record ([MODINVSTOR-1161](https://folio-org.atlassian.net/browse/MODINVSTOR-1161))

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,6 @@
     <rest-assured.version>5.5.0</rest-assured.version>
     <awaitility.version>4.2.2</awaitility.version>
     <assertj.version>3.26.3</assertj.version>
-    <localstack.version>1.20.2</localstack.version>
 
     <maven-compiler-plugin.version>3.13.0</maven-compiler-plugin.version>
     <build-helper-maven-plugin.version>3.6.0</build-helper-maven-plugin.version>
@@ -237,7 +236,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>localstack</artifactId>
-      <version>${localstack.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/test/java/org/folio/rest/api/InstanceStorageInstancesBulkApiTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageInstancesBulkApiTest.java
@@ -79,7 +79,7 @@ public class InstanceStorageInstancesBulkApiTest extends TestBaseWithInventoryUt
 
   @BeforeClass
   public static void setUpClass() {
-    localStackContainer = new LocalStackContainer(DockerImageName.parse("localstack/localstack:0.11.3"))
+    localStackContainer = new LocalStackContainer(DockerImageName.parse("localstack/localstack:s3-latest"))
       .withServices(S3);
 
     localStackContainer.start();


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODINVSTOR-1272

0.11.3 has been released 2020-06-28:
https://github.com/localstack/localstack/releases/tag/v0.11.3 0.11.3 has an image size of 454 MB:
https://hub.docker.com/r/localstack/localstack/tags?name=0.11.3

s3-latest has been released 2024-10-03 and has an image size of 108 MB: https://hub.docker.com/r/localstack/localstack/tags?name=0.11.3

This reduces the image size from 454 MB to 108 MB.

For the s3 only image there's no version tag, only the -latest tag.

### Purpose
Upgrade 4 year old localstack.
Reduce localstack image size.

### Approach
Upgrade localstack from 0.11.3 to s3-latest (=3.8.0)

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.