### PR TITLE
MODINVSTOR-1270. Add required module permissions

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -562,11 +562,13 @@
         }, {
           "methods": ["POST"],
           "pathPattern": "/subject-types",
-          "permissionsRequired": ["inventory-storage.subject-types.item.post"]
+          "permissionsRequired": ["inventory-storage.subject-types.item.post"],
+          "modulePermissions": ["user-tenants.collection.get"]
         }, {
           "methods": ["PUT"],
           "pathPattern": "/subject-types/{id}",
-          "permissionsRequired": ["inventory-storage.subject-types.item.put"]
+          "permissionsRequired": ["inventory-storage.subject-types.item.put"],
+          "modulePermissions": ["user-tenants.collection.get"]
         }, {
           "methods": ["DELETE"],
           "pathPattern": "/subject-types/{id}",
@@ -589,11 +591,13 @@
         }, {
           "methods": ["POST"],
           "pathPattern": "/subject-sources",
-          "permissionsRequired": ["inventory-storage.subject-sources.item.post"]
+          "permissionsRequired": ["inventory-storage.subject-sources.item.post"],
+          "modulePermissions": ["user-tenants.collection.get"]
         }, {
           "methods": ["PUT"],
           "pathPattern": "/subject-sources/{id}",
-          "permissionsRequired": ["inventory-storage.subject-sources.item.put"]
+          "permissionsRequired": ["inventory-storage.subject-sources.item.put"],
+          "modulePermissions": ["user-tenants.collection.get"]
         }, {
           "methods": ["DELETE"],
           "pathPattern": "/subject-sources/{id}",


### PR DESCRIPTION
### Purpose
https://folio-org.atlassian.net/browse/MODINVSTOR-1270

### Approach
During implementing https://github.com/folio-org/mod-inventory-storage/pull/1098 new validation is added that fetches /user-tenant endpoint.
Need to add appropriate module permissions