### PR TITLE
HOTFIX: MODINVSTOR-1299 update rollback mechanism for instances when linking/unlinking with subjects is failed.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@
 * Requires `API_NAME vX.Y`
 
 ### Features
+* update rollback mechanism for instances when linking/unlinking with subjects is failed. ([MODINVSTOR-1299](https://folio-org.atlassian.net/browse/MODINVSTOR-1299))
 * Unable to delete local Subject types/sources when they are linked to an Instance ([MODINVSTOR-1284](https://folio-org.atlassian.net/browse/MODINVSTOR-1284))
 * Modify endpoint for bulk instances upsert with publish events flag ([MODINVSTOR-1283](https://folio-org.atlassian.net/browse/MODINVSTOR-1283))
 * Change Kafka event publishing keys for holdings and items ([MODINVSTOR-1281](https://folio-org.atlassian.net/browse/MODINVSTOR-1281))

--- a/src/main/java/org/folio/persist/InstanceRepository.java
+++ b/src/main/java/org/folio/persist/InstanceRepository.java
@@ -91,12 +91,8 @@ public class InstanceRepository extends AbstractRepository<Instance> {
   }
 
   public Future<Response> createInstance(Conn conn, Instance instance) {
-    try {
-      return conn.save(INSTANCE_TABLE, instance.getId(), instance)
-        .map(id -> respond201WithApplicationJson(instance.withId(id), headersFor201()));
-    } catch (PgException e) {
-      return Future.failedFuture(new BadRequestException(e.getDetail()));
-    }
+    return conn.save(INSTANCE_TABLE, instance.getId(), instance)
+      .map(id -> respond201WithApplicationJson(instance.withId(id), headersFor201()));
   }
 
   public Future<RowSet<Row>> batchLinkSubjectType(Conn conn, List<Pair<String, String>> typePairs) {

--- a/src/main/java/org/folio/persist/InstanceRepository.java
+++ b/src/main/java/org/folio/persist/InstanceRepository.java
@@ -3,6 +3,8 @@ package org.folio.persist;
 import static org.folio.rest.impl.BoundWithPartApi.BOUND_WITH_TABLE;
 import static org.folio.rest.impl.HoldingsStorageApi.HOLDINGS_RECORD_TABLE;
 import static org.folio.rest.impl.ItemStorageApi.ITEM_TABLE;
+import static org.folio.rest.jaxrs.resource.InstanceStorage.PostInstanceStorageInstancesResponse.headersFor201;
+import static org.folio.rest.jaxrs.resource.InstanceStorage.PostInstanceStorageInstancesResponse.respond201WithApplicationJson;
 import static org.folio.rest.persist.PgUtil.postgresClient;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -88,8 +90,13 @@ public class InstanceRepository extends AbstractRepository<Instance> {
     }
   }
 
-  public Future<String> createInstance(Conn conn, Instance instance) {
-    return conn.save(INSTANCE_TABLE, instance.getId(), instance);
+  public Future<Response> createInstance(Conn conn, Instance instance) {
+    try {
+      return conn.save(INSTANCE_TABLE, instance.getId(), instance)
+        .map(id -> respond201WithApplicationJson(instance.withId(id), headersFor201()));
+    } catch (PgException e) {
+      return Future.failedFuture(new BadRequestException(e.getDetail()));
+    }
   }
 
   public Future<RowSet<Row>> batchLinkSubjectType(Conn conn, List<Pair<String, String>> typePairs) {

--- a/src/main/java/org/folio/persist/InstanceRepository.java
+++ b/src/main/java/org/folio/persist/InstanceRepository.java
@@ -88,6 +88,10 @@ public class InstanceRepository extends AbstractRepository<Instance> {
     }
   }
 
+  public Future<String> createInstance(Conn conn, Instance instance) {
+    return conn.save(INSTANCE_TABLE, instance.getId(), instance);
+  }
+
   public Future<RowSet<Row>> batchLinkSubjectType(Conn conn, List<Pair<String, String>> typePairs) {
     try {
       String sql = """

--- a/src/main/java/org/folio/services/ResponseHandlerUtil.java
+++ b/src/main/java/org/folio/services/ResponseHandlerUtil.java
@@ -6,6 +6,7 @@ import org.folio.rest.jaxrs.model.Errors;
 public final class ResponseHandlerUtil {
   private static final String HRID_ERROR_MESSAGE = "lower(f_unaccent(jsonb ->> 'hrid'::text))";
   private static final String HRID = "HRID";
+  private static final String TABLE_NAME = "instance";
 
   private ResponseHandlerUtil() {
   }
@@ -25,13 +26,10 @@ public final class ResponseHandlerUtil {
   }
 
   private static String getErrorMessage(Object responseEntity) {
-    var errorMessage = responseEntity.toString();
     if (responseEntity instanceof Errors errors) {
-      errorMessage = errors.getErrors().get(0).getMessage();
-    } else if (responseEntity instanceof String message) {
-      errorMessage = message;
+      return errors.getErrors().get(0).getMessage();
     }
-    return errorMessage;
+    return responseEntity.toString();
   }
 
   private static Response createResponse(Response response) {
@@ -51,5 +49,40 @@ public final class ResponseHandlerUtil {
     return Response.fromResponse(response)
       .entity(entity)
       .build();
+  }
+
+  // todo: use helper methods from PgUtil class when they become public
+  public static Response handleHridErrorInInstance(Response response) {
+    var statusCode = response.getStatus();
+
+    if (statusCode == 201) {
+      return response;
+    }
+
+    var errorMessage = getErrorMessage(response.getEntity());
+    if (errorMessage.contains(HRID_ERROR_MESSAGE)) {
+      return createResponse(response, errorMessage);
+    }
+    return response;
+  }
+
+  private static Response createResponse(Response response, String errorMessage) {
+    var transformedMessage = transformHridErrorMessage(errorMessage);
+    return Response.fromResponse(response)
+      .entity(transformedMessage)
+      .build();
+  }
+
+  private static String transformHridErrorMessage(String errorMessage) {
+    var hridValue = extractHridValue(errorMessage);
+    return hridValue != null
+      ? String.format("%s value already exists in table %s: %s", HRID, TABLE_NAME, hridValue)
+      : errorMessage;
+  }
+
+  private static String extractHridValue(String errorMessage) {
+    var startIndex = errorMessage.indexOf("=(") + 2;
+    var endIndex = errorMessage.indexOf(")", startIndex);
+    return (startIndex > 1 && endIndex > startIndex) ? errorMessage.substring(startIndex, endIndex) : null;
   }
 }

--- a/src/main/java/org/folio/services/ResponseHandlerUtil.java
+++ b/src/main/java/org/folio/services/ResponseHandlerUtil.java
@@ -79,7 +79,8 @@ public final class ResponseHandlerUtil {
   private static Response createMatchKeyResponse(Response response) {
     var entity = response.getEntity().toString();
     var matchKeyValue = extractValue(entity);
-    var remappedMessage = String.format("%s value already exists in table instance: %s", MATCH_KEY_ERROR_MESSAGE, matchKeyValue);
+    var remappedMessage = String.format("%s value already exists in table instance: %s",
+      MATCH_KEY_ERROR_MESSAGE, matchKeyValue);
     return Response.fromResponse(response)
       .entity(remappedMessage)
       .build();

--- a/src/main/java/org/folio/services/ResponseHandlerUtil.java
+++ b/src/main/java/org/folio/services/ResponseHandlerUtil.java
@@ -41,6 +41,13 @@ public final class ResponseHandlerUtil {
     }
   }
 
+  private static Response createResponse(Response response, String errorMessage) {
+    var transformedMessage = transformHridErrorMessage(errorMessage);
+    return Response.fromResponse(response)
+      .entity(transformedMessage)
+      .build();
+  }
+
   public static Response failedValidationResponse(Response response) {
     var entity = (Errors) response.getEntity();
     var errors = entity.getErrors();
@@ -64,13 +71,6 @@ public final class ResponseHandlerUtil {
       return createResponse(response, errorMessage);
     }
     return response;
-  }
-
-  private static Response createResponse(Response response, String errorMessage) {
-    var transformedMessage = transformHridErrorMessage(errorMessage);
-    return Response.fromResponse(response)
-      .entity(transformedMessage)
-      .build();
   }
 
   private static String transformHridErrorMessage(String errorMessage) {

--- a/src/main/java/org/folio/services/instance/InstanceService.java
+++ b/src/main/java/org/folio/services/instance/InstanceService.java
@@ -1,14 +1,16 @@
 package org.folio.services.instance;
 
 import static io.vertx.core.Promise.promise;
+import static javax.ws.rs.core.Response.noContent;
 import static org.folio.okapi.common.XOkapiHeaders.TENANT;
 import static org.folio.persist.InstanceRepository.INSTANCE_TABLE;
 import static org.folio.rest.impl.StorageHelper.MAX_ENTITIES;
 import static org.folio.rest.jaxrs.resource.InstanceStorage.DeleteInstanceStorageInstancesByInstanceIdResponse;
 import static org.folio.rest.jaxrs.resource.InstanceStorage.DeleteInstanceStorageInstancesResponse;
 import static org.folio.rest.jaxrs.resource.InstanceStorage.GetInstanceStorageInstancesByInstanceIdResponse;
+import static org.folio.rest.jaxrs.resource.InstanceStorage.PostInstanceStorageInstancesResponse.headersFor201;
+import static org.folio.rest.jaxrs.resource.InstanceStorage.PostInstanceStorageInstancesResponse.respond201WithApplicationJson;
 import static org.folio.rest.jaxrs.resource.InstanceStorageBatchSynchronous.PostInstanceStorageBatchSynchronousResponse;
-import static org.folio.rest.persist.PgUtil.post;
 import static org.folio.rest.persist.PgUtil.postSync;
 import static org.folio.rest.persist.PgUtil.postgresClient;
 import static org.folio.rest.persist.PgUtil.put;
@@ -114,25 +116,24 @@ public class InstanceService {
     return hridManager.populateHrid(entity)
       .compose(NotesValidators::refuseLongNotes)
       .compose(instance -> {
-        final Promise<Response> postResponse = promise(); // promise for the entire process
+        final Promise<Response> postResponse = promise();
 
-        // execute post and linking logic within same transaction
-        return postgresClient.withTrans(conn -> {
+        postgresClient.withTrans(conn ->
+          instanceRepository.createInstance(conn, instance)
+            .onFailure(postResponse::fail)
+            .compose(instanceId -> batchLinkSubjects(conn, instanceId, instance.getSubjects())
+              .map(v -> instanceId))
+            .map(instanceId -> respond201WithApplicationJson(instance.withId(instanceId), headersFor201()))
+        ).onSuccess(postResponse::complete);
 
-          Promise<Response> postPromise = postInstance(instance);
-
-          // Chain the batchLinkSubjects operation after postPromise completes
-          return postPromise.future()
-            .compose(response -> batchLinkSubjects(conn, instance.getId(), instance.getSubjects())
-              .map(v -> response)
-            );
-        }).onComplete(transactionResult -> {
-          if (transactionResult.succeeded()) {
-            postResponse.complete(transactionResult.result());
-          } else {
-            postResponse.fail(transactionResult.cause());
-          }
-        }).onSuccess(domainEventPublisher.publishCreated());
+        return postResponse.future()
+            // Return the response without waiting for a domain event publish
+            // to complete. Units of work performed by this service is the same
+            // but the ordering of the units of work provides a benefit to the
+            // api client invoking this endpoint. The response is returned
+            // a little earlier so the api client can continue its processing
+            // while the domain event publish is satisfied.
+            .onSuccess(domainEventPublisher.publishCreated());
       })
       .map(ResponseHandlerUtil::handleHridError);
   }
@@ -196,24 +197,6 @@ public class InstanceService {
         })
           .onSuccess(domainEventPublisher.publishUpdated(oldInstance));
       });
-  }
-
-  /**
-   * creates instance with separate promise, to use withing single transaction
-   * alongside with linking subject sources/types.
-   * */
-  private Promise<Response> postInstance(Instance instance) {
-    Promise<Response> promise = Promise.promise(); // Promise for the `post` operation
-    post(INSTANCE_TABLE, instance, okapiHeaders, vertxContext,
-      InstanceStorage.PostInstanceStorageInstancesResponse.class,
-      reply -> {
-        if (reply.succeeded()) {
-          promise.complete(reply.result()); // Mark `postPromise` as successful
-        } else {
-          promise.fail(reply.cause()); // Mark `postPromise` as failed
-        }
-      });
-    return promise;
   }
 
   private Promise<Response> postSyncInstance(List<Instance> instances, boolean upsert, boolean optimisticLocking) {
@@ -339,7 +322,7 @@ public class InstanceService {
       .compose(notUsed -> relationshipRepository.deleteAll())
       .compose(notUsed -> instanceRepository.deleteAll())
       .onSuccess(notUsed -> domainEventPublisher.publishAllRemoved())
-      .map(Response.noContent().build());
+      .map(noContent().build());
   }
 
   /**
@@ -356,7 +339,7 @@ public class InstanceService {
         rowSet.iterator().forEachRemaining(row ->
           domainEventPublisher.publishRemoved(row.getString(0), row.getString(1))
         );
-        return Response.noContent().build();
+        return noContent().build();
       });
   }
 
@@ -380,7 +363,7 @@ public class InstanceService {
           domainEventPublisher.publishRemoved(row.getString(0), row.getString(1))
         )
       ))
-      .map(Response.noContent().build());
+      .map(noContent().build());
   }
 
   public Future<Void> publishReindexInstanceRecords(String rangeId, String fromId, String toId) {

--- a/src/test/java/org/folio/rest/api/AsyncMigrationTest.java
+++ b/src/test/java/org/folio/rest/api/AsyncMigrationTest.java
@@ -130,7 +130,7 @@ public class AsyncMigrationTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void canMigrateInstanceSubjectsAndSeries() {
-    var numberOfRecords = 3;
+    var numberOfRecords = 10;
 
     IntStream.range(0, numberOfRecords).parallel().forEach(v ->
       instancesClient.create(new JsonObject()
@@ -167,7 +167,7 @@ public class AsyncMigrationTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void canMigrateInstancePublicationPeriod() {
-    var numberOfRecords = 4;
+    var numberOfRecords = 10;
 
     IntStream.range(0, numberOfRecords).parallel().forEach(v ->
       instancesClient.create(new JsonObject()
@@ -182,7 +182,7 @@ public class AsyncMigrationTest extends TestBaseWithInventoryUtil {
     // check jsonb contains 'publicationPeriod' data
     RowSet<Row> selectResult = runSql(String.format(SELECT_JSONB, TENANT_ID));
 
-    assertEquals(4, selectResult.rowCount());
+    assertEquals(10, selectResult.rowCount());
     JsonObject jsonbData = selectResult.iterator().next().toJson().getJsonObject("jsonb");
     assertNull(jsonbData.getJsonObject("dates"));
     assertNotNull(jsonbData.getJsonObject("publicationPeriod"));
@@ -209,7 +209,7 @@ public class AsyncMigrationTest extends TestBaseWithInventoryUtil {
     var selectQuery = String.format(SELECT_JSONB, TENANT_ID);
     RowSet<Row> result = runSql(selectQuery);
 
-    assertEquals(4, result.rowCount());
+    assertEquals(10, result.rowCount());
     JsonObject entry = result.iterator().next().toJson();
     JsonObject jsonb = entry.getJsonObject("jsonb");
     JsonObject dates = jsonb.getJsonObject("dates");

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -1946,9 +1946,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(updatedInstanceWithOthStatus.getString(STATUS_UPDATED_DATE_PROPERTY), hasIsoFormat());
 
     assertThat(updatedInstanceWithCatStatus
-      .getInstant(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(2)));
+      .getInstant(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(3)));
     assertThat(updatedInstanceWithOthStatus
-      .getInstant(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(1)));
+      .getInstant(STATUS_UPDATED_DATE_PROPERTY), withinSecondsBeforeNow(seconds(2)));
   }
 
   /**
@@ -2226,8 +2226,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final Response response = createCompleted.get(10, SECONDS);
 
     assertThat(response.getStatusCode(), is(400));
-    assertTrue(response.getBody()
-      .contains("Key (lower(f_unaccent(jsonb ->> 'hrid'::text)))=(in00000000001) already exists."));
+    assertThat(response.getBody(),
+      is("HRID value already exists in table instance: in00000000001"));
 
     log.info("Finished cannotCreateInstanceWithDuplicateHRID");
   }
@@ -2343,7 +2343,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(response.getStatusCode(), is(400));
     assertTrue(response.getBody()
-      .contains("Key (lower(f_unaccent(jsonb ->> 'hrid'::text)))=(in00000001000) already exists."));
+      .contains("HRID value already exists in table instance: in00000001000"));
   }
 
   @Test
@@ -3094,7 +3094,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     getClient().post(instancesStorageUrl(""), instanceToCreate,
       TENANT_ID, json(createCompleted));
 
-    Response response = createCompleted.get(2, SECONDS);
+    Response response = createCompleted.get(5, SECONDS);
 
     assertThat(format("Create instance failed: %s", response.getBody()),
       response.getStatusCode(), is(201));

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -47,7 +47,6 @@ import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInA
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.joda.time.Seconds.seconds;
 import static org.junit.Assert.fail;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -2708,8 +2707,9 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final Response response = createCompleted.get(10, SECONDS);
 
     assertThat(response.getStatusCode(), is(400));
-    assertTrue(response.getBody()
-      .contains("Key (lower(f_unaccent(jsonb ->> 'matchKey'::text)))=(match_key) already exists."));
+    assertThat(response.getBody(),
+      is("lower(f_unaccent(jsonb ->> 'matchKey'::text)) value already " +
+        "exists in table instance: match_key"));
 
     log.info("Finished cannotCreateInstanceWithDuplicateMatchKey");
   }

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -2708,8 +2708,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     assertThat(response.getStatusCode(), is(400));
     assertThat(response.getBody(),
-      is("lower(f_unaccent(jsonb ->> 'matchKey'::text)) value already " +
-        "exists in table instance: match_key"));
+      is("lower(f_unaccent(jsonb ->> 'matchKey'::text)) value already "
+        + "exists in table instance: match_key"));
 
     log.info("Finished cannotCreateInstanceWithDuplicateMatchKey");
   }

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -2226,7 +2226,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final Response response = createCompleted.get(10, SECONDS);
 
     assertThat(response.getStatusCode(), is(400));
-    assertTrue(response.getBody().contains("Key (lower(f_unaccent(jsonb ->> 'hrid'::text)))=(in00000000001) already exists."));
+    assertTrue(response.getBody()
+      .contains("Key (lower(f_unaccent(jsonb ->> 'hrid'::text)))=(in00000000001) already exists."));
 
     log.info("Finished cannotCreateInstanceWithDuplicateHRID");
   }
@@ -2341,7 +2342,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final Response response = createCompleted.get(TIMEOUT, TimeUnit.SECONDS);
 
     assertThat(response.getStatusCode(), is(400));
-    assertTrue(response.getBody().contains("Key (lower(f_unaccent(jsonb ->> 'hrid'::text)))=(in00000001000) already exists."));
+    assertTrue(response.getBody()
+      .contains("Key (lower(f_unaccent(jsonb ->> 'hrid'::text)))=(in00000001000) already exists."));
   }
 
   @Test
@@ -2706,7 +2708,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final Response response = createCompleted.get(10, SECONDS);
 
     assertThat(response.getStatusCode(), is(400));
-    assertTrue(response.getBody().contains("Key (lower(f_unaccent(jsonb ->> 'matchKey'::text)))=(match_key) already exists."));
+    assertTrue(response.getBody()
+      .contains("Key (lower(f_unaccent(jsonb ->> 'matchKey'::text)))=(match_key) already exists."));
 
     log.info("Finished cannotCreateInstanceWithDuplicateMatchKey");
   }

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -2342,8 +2342,8 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final Response response = createCompleted.get(TIMEOUT, TimeUnit.SECONDS);
 
     assertThat(response.getStatusCode(), is(400));
-    assertTrue(response.getBody()
-      .contains("HRID value already exists in table instance: in00000001000"));
+    assertThat(response.getBody(), is(
+      "HRID value already exists in table instance: in00000001000"));
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -47,6 +47,7 @@ import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInA
 import static org.hamcrest.core.IsNull.notNullValue;
 import static org.joda.time.Seconds.seconds;
 import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -171,7 +172,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     // This calls get() to ensure blocking until all futures are complete.
     final Async async = context.async();
-    List<CompletableFuture<Response>> cfs = new ArrayList<CompletableFuture<Response>>();
+    List<CompletableFuture<Response>> cfs = new ArrayList<>();
     natureOfContentIdsToRemoveAfterTest.forEach(id -> cfs.add(getClient()
       .delete(natureOfContentTermsUrl("/" + id), TENANT_ID)));
     CompletableFuture.allOf(cfs.toArray(new CompletableFuture[cfs.size()]))
@@ -2225,8 +2226,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final Response response = createCompleted.get(10, SECONDS);
 
     assertThat(response.getStatusCode(), is(400));
-    assertThat(response.getBody(),
-      is("HRID value already exists in table instance: in00000000001"));
+    assertTrue(response.getBody().contains("Key (lower(f_unaccent(jsonb ->> 'hrid'::text)))=(in00000000001) already exists."));
 
     log.info("Finished cannotCreateInstanceWithDuplicateHRID");
   }
@@ -2341,9 +2341,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final Response response = createCompleted.get(TIMEOUT, TimeUnit.SECONDS);
 
     assertThat(response.getStatusCode(), is(400));
-
-    assertThat(response.getBody(), is(
-      "HRID value already exists in table instance: in00000001000"));
+    assertTrue(response.getBody().contains("Key (lower(f_unaccent(jsonb ->> 'hrid'::text)))=(in00000001000) already exists."));
   }
 
   @Test
@@ -2708,9 +2706,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     final Response response = createCompleted.get(10, SECONDS);
 
     assertThat(response.getStatusCode(), is(400));
-    assertThat(response.getBody(),
-      is("lower(f_unaccent(jsonb ->> 'matchKey'::text)) value already "
-        + "exists in table instance: match_key"));
+    assertTrue(response.getBody().contains("Key (lower(f_unaccent(jsonb ->> 'matchKey'::text)))=(match_key) already exists."));
 
     log.info("Finished cannotCreateInstanceWithDuplicateMatchKey");
   }


### PR DESCRIPTION
### Purpose
[MODINVSTOR-1299](https://folio-org.atlassian.net/browse/MODINVSTOR-1299) update rollback mechanism for instances when linking/unlinking with subjects is failed.
hotfix pr to resolve the issue with failing hourly builts 

> Tenant operation failed for module mod-inventory-storage-28.1.0-SNAPSHOT.1060: GET http://10.36.1.221:9151/instance-storage/instances/e6bc03c6-c137-4221-b679-a7c5c31f986c returned status 404: null POST http://10.36.1.221:9151/instance-storage/instances returned status 500: Timeout for DB_HOST:DB_PORT=10.36.1.221:5432

### Approach
* use atomic transactions
* update tests

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.