### PR TITLE
MODINVSTOR-1354 Optimize check for existing shadow Instance before creating it

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,7 @@
 * Implement Kafka Event Publishing for Call-Number Type CRUD Operations ([MODINVSTOR-1275](https://folio-org.atlassian.net/browse/MODINVSTOR-1275))
 * Extend domain events with eventId and eventTs ([MODINVSTOR-1322](https://folio-org.atlassian.net/browse/MODINVSTOR-1322))
 * Revert the publication period migration changes ([MODINVSTOR-1280](https://folio-org.atlassian.net/browse/MODINVSTOR-1280))
+* Optimize check for existing shadow Instance before creating it ([MODINVSTOR-1354](https://folio-org.atlassian.net/browse/MODINVSTOR-1354))
 
 ### Bug fixes
 * Add item barcode right truncation search index ([MODINVSTOR-1292](https://folio-org.atlassian.net/browse/MODINVSTOR-1292))

--- a/src/main/java/org/folio/persist/AbstractRepository.java
+++ b/src/main/java/org/folio/persist/AbstractRepository.java
@@ -15,6 +15,8 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+
+import io.vertx.sqlclient.Tuple;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.PostgresClientFuturized;
@@ -68,6 +70,13 @@ public abstract class AbstractRepository<T> {
       .collect(Collectors.toSet());
 
     return getById(ids);
+  }
+
+  public Future<Boolean> exists(String id) {
+    return postgresClient.execute(
+        "select 1 from " + postgresClient.getSchemaName() + "." + tableName + " where id = $1 limit 1",
+        Tuple.of(id))
+      .map(ar -> ar != null && ar.rowCount() == 1);
   }
 
   public Future<RowSet<Row>> update(AsyncResult<SQLConnection> connection, String id, T entity) {

--- a/src/main/java/org/folio/persist/AbstractRepository.java
+++ b/src/main/java/org/folio/persist/AbstractRepository.java
@@ -9,14 +9,13 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.Tuple;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-
-import io.vertx.sqlclient.Tuple;
 import org.folio.rest.persist.Criteria.Criterion;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.persist.PostgresClientFuturized;

--- a/src/main/java/org/folio/services/consortium/ConsortiumServiceImpl.java
+++ b/src/main/java/org/folio/services/consortium/ConsortiumServiceImpl.java
@@ -42,7 +42,7 @@ public class ConsortiumServiceImpl implements ConsortiumService {
                                                       Map<String, String> headers) {
     LOGGER.info("createShadowInstance:: instance with id: {} is not found in local tenant."
           + " Trying to create a shadow instance", instanceId);
-  SharingInstance sharingInstance = new SharingInstance();
+    SharingInstance sharingInstance = new SharingInstance();
     String centralTenantId = consortiumData.centralTenantId();
     sharingInstance.setSourceTenantId(centralTenantId);
     sharingInstance.setInstanceIdentifier(UUID.fromString(instanceId));

--- a/src/main/java/org/folio/services/consortium/ConsortiumServiceImpl.java
+++ b/src/main/java/org/folio/services/consortium/ConsortiumServiceImpl.java
@@ -40,7 +40,9 @@ public class ConsortiumServiceImpl implements ConsortiumService {
   @Override
   public Future<SharingInstance> createShadowInstance(String instanceId, ConsortiumData consortiumData,
                                                       Map<String, String> headers) {
-    SharingInstance sharingInstance = new SharingInstance();
+    LOGGER.info("createShadowInstance:: instance with id: {} is not found in local tenant."
+          + " Trying to create a shadow instance", instanceId);
+  SharingInstance sharingInstance = new SharingInstance();
     String centralTenantId = consortiumData.centralTenantId();
     sharingInstance.setSourceTenantId(centralTenantId);
     sharingInstance.setInstanceIdentifier(UUID.fromString(instanceId));

--- a/src/main/java/org/folio/services/holding/HoldingsService.java
+++ b/src/main/java/org/folio/services/holding/HoldingsService.java
@@ -304,7 +304,7 @@ public class HoldingsService {
 
   private Future<SharingInstance> createShadowInstanceIfNeeded(String instanceId, ConsortiumData consortiumData) {
     return instanceRepository.exists(instanceId)
-      .compose(exists -> exists? Future.succeededFuture():
+      .compose(exists -> exists ? Future.succeededFuture() :
         consortiumService.createShadowInstance(instanceId, consortiumData, okapiHeaders)
       );
   }

--- a/src/main/java/org/folio/services/holding/HoldingsService.java
+++ b/src/main/java/org/folio/services/holding/HoldingsService.java
@@ -303,15 +303,10 @@ public class HoldingsService {
   }
 
   private Future<SharingInstance> createShadowInstanceIfNeeded(String instanceId, ConsortiumData consortiumData) {
-    return instanceRepository.getById(instanceId)
-      .compose(instance -> {
-        if (instance != null) {
-          return Future.succeededFuture();
-        }
-        log.info("createShadowInstanceIfNeeded:: instance with id: {} is not found in local tenant."
-          + " Trying to create a shadow instance", instanceId);
-        return consortiumService.createShadowInstance(instanceId, consortiumData, okapiHeaders);
-      });
+    return instanceRepository.exists(instanceId)
+      .compose(exists -> exists? Future.succeededFuture():
+        consortiumService.createShadowInstance(instanceId, consortiumData, okapiHeaders)
+      );
   }
 
   private boolean holdingsRecordFound(HoldingsRecord holdingsRecord) {


### PR DESCRIPTION
[MODINVSTOR-1354](https://folio-org.atlassian.net/browse/MODINVSTOR-1354)
In ECS when Holdings is created on a member tenant associated with a shared Instance that exists on a central tenant, a shadow copy of the Instance should be created on the member to link the Holdings, unless it already exists. To check if the Instance exists it is unnecessary to retrieve the whole object, the operation could be optimized by merely checking that object with such id exists.