### PR TITLE
feat(storage): Prevent update of instance/item/holdings in case there're no changes

### DIFF
--- a/src/main/java/org/folio/utils/ComparisonUtils.java
+++ b/src/main/java/org/folio/utils/ComparisonUtils.java
@@ -1,0 +1,24 @@
+package org.folio.utils;
+
+import static org.folio.rest.persist.PostgresClient.pojo2JsonObject;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Objects;
+
+public final class ComparisonUtils {
+
+  private static final String METADATA_FIELD = "metadata";
+
+  private ComparisonUtils() {
+    throw new UnsupportedOperationException("Utility class");
+  }
+
+  public static boolean equalsIgnoringMetadata(Object o1, Object o2) throws JsonProcessingException {
+    var o1json = pojo2JsonObject(o1);
+    var o2json = pojo2JsonObject(o2);
+    o1json.remove(METADATA_FIELD);
+    o2json.remove(METADATA_FIELD);
+
+    return Objects.equals(o1json, o2json);
+  }
+}

--- a/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -928,6 +928,21 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  public void shouldNotUpdateHoldingsIfNoChanges() {
+    var holdingId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID).toString();
+    var holding = getById(holdingId).getJson();
+
+    assertThat(update(holding).getStatusCode(), is(204));
+
+    var updatedHolding = getById(holdingId).getJson();
+    //assert that there was no update in database
+    assertThat(updatedHolding.getString("_version"), is("1"));
+    var kafkaEvents = KAFKA_CONSUMER.getMessagesForHoldings(holdingId);
+    //assert that there's only CREATE kafka message, no updates
+    assertThat(kafkaEvents.size(), is(1));
+  }
+
+  @Test
   public void updatingHoldingsWithSourceIdShouldUpdate()
     throws InterruptedException, ExecutionException, TimeoutException {
     UUID instanceId = UUID.randomUUID();

--- a/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -553,6 +553,23 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  @SneakyThrows
+  public void shouldNotUpdateInstanceIfNoChanges() {
+    var id = UUID.randomUUID();
+    createInstance(nod(id));
+    var instance = getById(id).getJson();
+
+    assertThat(update(instance).getStatusCode(), is(204));
+
+    var updatedInstance = getById(id).getJson();
+    //assert that there was no update in database
+    assertThat(updatedInstance.getString("_version"), is("1"));
+    var kafkaEvents = KAFKA_CONSUMER.getMessagesForInstance(id.toString());
+    //assert that there's only CREATE kafka message, no updates
+    assertThat(kafkaEvents.size(), is(1));
+  }
+
+  @Test
   public void cannotProvideAdditionalPropertiesInInstance()
     throws InterruptedException, TimeoutException, ExecutionException {
 

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -519,6 +519,22 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  public void shouldNotUpdateItemIfNoChanges() {
+    var itemId = UUID.randomUUID();
+    var holdingId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
+    var item = createItem(nod(itemId, holdingId));
+
+    assertThat(update(item).getStatusCode(), is(204));
+
+    var updatedItem = getById(itemId).getJson();
+    //assert that there was no update in database
+    assertThat(updatedItem.getString("_version"), is("1"));
+    var kafkaEvents = KAFKA_CONSUMER.getMessagesForItem(itemId.toString());
+    //assert that there's only CREATE kafka message, no updates
+    assertThat(kafkaEvents.size(), is(1));
+  }
+
+  @Test
   public void canCreateAnItemWithoutProvidingId() throws InterruptedException, ExecutionException, TimeoutException {
     UUID holdingsRecordId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
 

--- a/src/test/java/org/folio/utils/ComparisonUtilsTest.java
+++ b/src/test/java/org/folio/utils/ComparisonUtilsTest.java
@@ -1,0 +1,33 @@
+package org.folio.utils;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ComparisonUtilsTest {
+
+  @Test
+  void testEqualsIgnoringMetadata_true() throws JsonProcessingException {
+    var obj1 = testMap(1, 1);
+    var obj2 = testMap(1, 2);
+
+    assertTrue(ComparisonUtils.equalsIgnoringMetadata(obj1, obj2));
+  }
+
+  @Test
+  void testEqualsIgnoringMetadata_false() throws JsonProcessingException {
+    var obj1 = testMap(1, 1);
+    var obj2 = testMap(2, 2);
+
+    assertFalse(ComparisonUtils.equalsIgnoringMetadata(obj1, obj2));
+  }
+
+  private Map<String, Object> testMap(int fieldValue, int metadataValue) {
+    return Map.of("field1", "value1",
+    "field2", fieldValue,
+    "metadata", Map.of("createdBy", metadataValue));
+  }
+}


### PR DESCRIPTION
### Purpose
Prevent update of instance/item/holdings in case there're no changes

### Approach
- Prevent entity update in database
- Do not send a Kafka event

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINVSTOR-1363](https://folio-org.atlassian.net/browse/MODINVSTOR-1363)
