### PR TITLE
MODINVSTOR-1377 - mod-oai-pmh - new indexes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,7 +8,7 @@
 
 ### Features
 * Make max.request.size configurable for reindex holdings/items producers ([MODINVSTOR-1372](https://folio-org.atlassian.net/browse/MODINVSTOR-1372))
-* mod-oai-pmh - new indexes ([MODINVSTOR-1377](https://folio-org.atlassian.net/browse/MODINVSTOR-1377))
+* Create index for discoverySuppress and source fields to improve performance of queries which include mentioned fields ([MODINVSTOR-1377](https://folio-org.atlassian.net/browse/MODINVSTOR-1377))
 
 ### Bug fixes
 * Fix ordering of electronic access items for inventory-hierarchy, oai-pmh-view ([MODINVSTOR-1224](https://folio-org.atlassian.net/browse/MODINVSTOR-1224))

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 ### Features
 * Make max.request.size configurable for reindex holdings/items producers ([MODINVSTOR-1372](https://folio-org.atlassian.net/browse/MODINVSTOR-1372))
+* mod-oai-pmh - new indexes ([MODINVSTOR-1377](https://folio-org.atlassian.net/browse/MODINVSTOR-1377))
 
 ### Bug fixes
 * Fix ordering of electronic access items for inventory-hierarchy, oai-pmh-view ([MODINVSTOR-1224](https://folio-org.atlassian.net/browse/MODINVSTOR-1224))

--- a/src/main/resources/templates/db_scripts/oaipmh/createDiscoverySuppressSourceIndex.sql
+++ b/src/main/resources/templates/db_scripts/oaipmh/createDiscoverySuppressSourceIndex.sql
@@ -1,2 +1,2 @@
-CREATE INDEX instance_discoverysuppress_source_idx
+CREATE INDEX IF NOT EXISTS instance_discoverysuppress_source_idx
 ON ${myuniversity}_${mymodule}.instance (((jsonb ->> 'discoverySuppress'::text)), ((jsonb ->> 'source'::text)));

--- a/src/main/resources/templates/db_scripts/oaipmh/createDiscoverySuppressSourceIndex.sql
+++ b/src/main/resources/templates/db_scripts/oaipmh/createDiscoverySuppressSourceIndex.sql
@@ -1,0 +1,2 @@
+CREATE INDEX instance_discoverysuppress_source_idx
+ON ${myuniversity}_${mymodule}.instance (((jsonb ->> 'discoverySuppress'::text)), ((jsonb ->> 'source'::text)));

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -1258,6 +1258,11 @@
       "run": "after",
       "snippetPath": "statistical-code/create-populate-triggers.sql",
       "fromModuleVersion": "29.1.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "oaipmh/createDiscoverySuppressSourceIndex.sql",
+      "fromModuleVersion": "29.1.0"
     }
   ]
 }


### PR DESCRIPTION
## Purpose
[MODINVSTOR-1377](https://folio-org.atlassian.net/browse/MODINVSTOR-1377) - mod-oai-pmh - new indexes

## Approach
The instance_discoverysuppress_source_idx should be applied to both fields: discoverySuppress and source. This allows significantly improve the mentioned query performance.

### TODOS and Open Questions

### Learning
