### PR TITLE
MODINVSTOR-1393 - Suppress shared FOLIO Instance from discovery in Central tenant does not always propagate to record in Member tenant

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,7 @@
 ### Bug fixes
 * Fix ordering of electronic access items for inventory-hierarchy, oai-pmh-view ([MODINVSTOR-1224](https://folio-org.atlassian.net/browse/MODINVSTOR-1224))
 * Fix error serialization when writing to files uploaded to S3 ([MODINVSTOR-1389](https://folio-org.atlassian.net/browse/MODINVSTOR-1389))
+* Fix changes propagation to shadow instances after shared instance update ([MODINVSTOR-1393](https://folio-org.atlassian.net/browse/MODINVSTOR-1393))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))


### PR DESCRIPTION
## Purpose
to fix issue where changes are intermittently not propagated to shadow instances on member tenants after a shared instance update

## Approach
* create a copy of the instance to prevent side effects between member tenants during instance version population


## Learning
[MODINVSTOR-1393](https://issues.folio.org/browse/MODINVSTOR-1393)