### PR TITLE
MODINVSTOR-1390 Add instance property sourceUri

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,12 +4,14 @@
 
 ### New APIs versions
 * Provides `item-storage 10.2`
+* Provides `instance-storage 11.2`
 
 ### Features
 * Make max.request.size configurable for reindex holdings/items producers ([MODINVSTOR-1372](https://folio-org.atlassian.net/browse/MODINVSTOR-1372))
 * Create index for discoverySuppress and source fields to improve performance of queries which include mentioned fields ([MODINVSTOR-1377](https://folio-org.atlassian.net/browse/MODINVSTOR-1377))
 * Introduce new post retrieve api to fetch inventory item ([MODINVSTOR-1381](https://folio-org.atlassian.net/browse/MODINVSTOR-1381))
 * Optimize reindex instances database fetch query ([MODINVSTOR-1395](https://folio-org.atlassian.net/browse/MODINVSTOR-1395))
+* Add instance property `sourceUri` ([MODINVNSTOR-1390](https://folio-org.atlassian.net/browse/MODINVSTOR-1395))
 
 ### Bug fixes
 * Fix ordering of electronic access items for inventory-hierarchy, oai-pmh-view ([MODINVSTOR-1224](https://folio-org.atlassian.net/browse/MODINVSTOR-1224))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -171,7 +171,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "11.1",
+      "version": "11.2",
       "handlers": [
         {
           "methods": ["GET"],

--- a/ramls/instance.json
+++ b/ramls/instance.json
@@ -20,6 +20,10 @@
       "type": "string",
       "description" : "A unique instance identifier matching a client-side bibliographic record identification scheme, in particular for a scenario where multiple separate catalogs with no shared record identifiers contribute to the same Instance in Inventory. A match key is typically generated from select, normalized pieces of metadata in bibliographic records"
     },
+    "sourceUri": {
+      "type": "string",
+      "description": "A remote URI uniquely identifying the source of the instance"
+    },
     "source": {
       "type": "string",
       "description": "The metadata source and its format of the underlying record to the instance record. (e.g. FOLIO if it's a record created in Inventory; MARC if it's a MARC record created in MARCcat or EPKB if it's a record coming from eHoldings; CONSORTIUM-MARC or CONSORTIUM-FOLIO for sharing Instances)."

--- a/src/main/resources/templates/db_scripts/schema.json
+++ b/src/main/resources/templates/db_scripts/schema.json
@@ -412,6 +412,10 @@
           "removeAccents": true
         },
         {
+          "fieldName": "sourceUri",
+          "tOps": "ADD"
+        },
+        {
           "fieldName": "statisticalCodeIds",
           "tOps": "ADD",
           "caseSensitive": false,


### PR DESCRIPTION
### Purpose
Full description of purpose(s) in [UXPROD-5135](https://folio-org.atlassian.net/browse/UXPROD-5135)

### Approach
Add optional property to the instance schema. A corresponding change will need to be applied to mod-inventory for the property to be available through the UI. 

### Changes Checklist
- [x] **API Changes**:  Instance schema changed.
- [x] **Database Schema Changes**:  The database schema has a new index created. 
- [x] **Interface Version Changes**: Instance API version 11.1 -> 11.2
- [x] **Interface Dependencies**: NA
- [x] **Permissions**: NA
- [x] **Logging**: NA
- [x] **Unit Testing**: NA
- [x] **Integration Testing**:NA.
- [x] **Manual Testing**: Tested in local dev and on shared Nation Library Sweden / Index Data development environment 
- [X] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
UXPROD-3135, MODINVSTOR-1390


