### PR TITLE
[MODINVSTOR-1427] Fixed instance creation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 * Fix error serialization when writing to files uploaded to S3 ([MODINVSTOR-1389](https://folio-org.atlassian.net/browse/MODINVSTOR-1389))
 * Fix changes propagation to shadow instances after shared instance update ([MODINVSTOR-1393](https://folio-org.atlassian.net/browse/MODINVSTOR-1393))
 * Fix metadata not filled for records created via `POST /instance-storage/batch/synchronous`([MODINVSTOR-1382](https://folio-org.atlassian.net/browse/MODINVSTOR-1382))
+* Fixed random "`Cannot set holdings_record.instanceid = [...] because it does not exist in instance.id.`" errors when opening orders ([MODINVSTOR-1427](https://folio-org.atlassian.net/browse/MODINVSTOR-1427))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/src/main/java/org/folio/services/instance/InstanceService.java
+++ b/src/main/java/org/folio/services/instance/InstanceService.java
@@ -140,7 +140,8 @@ public class InstanceService {
                 return Future.succeededFuture(respond400WithTextPlain(response.getEntity()));
               }
             })
-        ).onSuccess(postResponse::complete)
+        )
+        .onSuccess(postResponse::complete)
         .onFailure(throwable -> {
           if (throwable instanceof PgException pgException) {
             postResponse.complete(respond400WithTextPlain(pgException.getDetail()));

--- a/src/main/java/org/folio/services/instance/InstanceService.java
+++ b/src/main/java/org/folio/services/instance/InstanceService.java
@@ -141,14 +141,14 @@ public class InstanceService {
               }
             })
         )
-        .onSuccess(postResponse::complete)
-        .onFailure(throwable -> {
-          if (throwable instanceof PgException pgException) {
-            postResponse.complete(respond400WithTextPlain(pgException.getDetail()));
-          } else {
-            postResponse.complete(respond400WithTextPlain(throwable.getMessage()));
-          }
-        });
+          .onSuccess(postResponse::complete)
+          .onFailure(throwable -> {
+            if (throwable instanceof PgException pgException) {
+              postResponse.complete(respond400WithTextPlain(pgException.getDetail()));
+            } else {
+              postResponse.complete(respond400WithTextPlain(throwable.getMessage()));
+            }
+          });
 
         return postResponse.future()
             // Return the response without waiting for a domain event publish

--- a/src/main/java/org/folio/services/instance/InstanceService.java
+++ b/src/main/java/org/folio/services/instance/InstanceService.java
@@ -140,15 +140,14 @@ public class InstanceService {
                 return Future.succeededFuture(respond400WithTextPlain(response.getEntity()));
               }
             })
-            .onSuccess(postResponse::complete)
-            .onFailure(throwable -> {
-              if (throwable instanceof PgException pgException) {
-                postResponse.complete(respond400WithTextPlain(pgException.getDetail()));
-              } else {
-                postResponse.complete(respond400WithTextPlain(throwable.getMessage()));
-              }
-            })
-        );
+        ).onSuccess(postResponse::complete)
+        .onFailure(throwable -> {
+          if (throwable instanceof PgException pgException) {
+            postResponse.complete(respond400WithTextPlain(pgException.getDetail()));
+          } else {
+            postResponse.complete(respond400WithTextPlain(throwable.getMessage()));
+          }
+        });
 
         return postResponse.future()
             // Return the response without waiting for a domain event publish


### PR DESCRIPTION
### Purpose
[MODINVSTOR-1427](https://folio-org.atlassian.net/browse/MODINVSTOR-1427) - Random error when opening orders

### Approach
When an instance is created, the result was returned before the transaction was released. As a consequence, creating holdings afterwards referencing the instance was failing because of the foreign key on the instance id. This only happened, seemingly at random, on fast computers. The error was sometimes happening 10 times while processing mod-orders integration tests, when orders were opened and holdings were created after the instance.

This fix simply moves `onSuccess` and `onFailure` after the transaction block.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINVSTOR-1299](https://folio-org.atlassian.net/browse/MODINVSTOR-1299) - [PR](https://github.com/folio-org/mod-inventory-storage/pull/1127)
