### PR TITLE
feat(holding-validation) Holdings record statistical codes validation enhancement

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -16,6 +16,7 @@
 * Create index for "deleted" field to improve performance of mod-oai-pmh views ([MODOAIPMH-614](https://folio-org.atlassian.net/browse/MODOAIPMH-614))
 * Execute migration script to add "deleted" field to instance.jsonb if it's missing ([MODINVSTOR-1425](https://folio-org.atlassian.net/browse/MODINVSTOR-1425))
 * New enum property `defaultCheckInActionForUseAtLocation` for reading room circulation ([MODINVSTOR-1376](https://folio-org.atlassian.net/browse/MODINVSTOR-1376))
+* Holdings record statistical codes validation enhancement ([MODINVSTOR-1185](https://folio-org.atlassian.net/browse/MODINVSTOR-1185))
 
 ### Bug fixes
 * Fix ordering of electronic access items for inventory-hierarchy, oai-pmh-view ([MODINVSTOR-1224](https://folio-org.atlassian.net/browse/MODINVSTOR-1224))

--- a/src/main/java/org/folio/persist/AbstractRepository.java
+++ b/src/main/java/org/folio/persist/AbstractRepository.java
@@ -4,6 +4,7 @@ import static io.vertx.core.Future.succeededFuture;
 
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.Tuple;
@@ -36,6 +37,10 @@ public abstract class AbstractRepository<T> {
 
   public Future<String> save(String id, T entity) {
     return postgresClientFuturized.save(tableName, id, entity);
+  }
+
+  public void save(String id, T entity, Handler<AsyncResult<T>> replyHandler) {
+    postgresClientFuturized.save(tableName, id, entity, replyHandler);
   }
 
   public Future<List<T>> get(Criterion criterion) {

--- a/src/main/java/org/folio/rest/persist/PostgresClientFuturized.java
+++ b/src/main/java/org/folio/rest/persist/PostgresClientFuturized.java
@@ -4,7 +4,9 @@ import static io.vertx.core.Future.succeededFuture;
 import static io.vertx.core.Promise.promise;
 import static org.folio.rest.persist.PostgresClient.convertToPsqlStandard;
 
+import io.vertx.core.AsyncResult;
 import io.vertx.core.Future;
+import io.vertx.core.Handler;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonArray;
 import io.vertx.sqlclient.Row;
@@ -26,6 +28,10 @@ public class PostgresClientFuturized {
 
   public <T> Future<String> save(String table, String id, T entity) {
     return postgresClient.save(table, id, entity);
+  }
+
+  public <T> void save(String table, String id, T entity, Handler<AsyncResult<T>> replyHandler) {
+    postgresClient.saveAndReturnUpdatedEntity(table, id, entity, replyHandler);
   }
 
   public <T> Future<List<T>> get(String tableName, Class<T> type, Criterion criterion) {

--- a/src/main/java/org/folio/services/holding/HoldingsService.java
+++ b/src/main/java/org/folio/services/holding/HoldingsService.java
@@ -207,9 +207,9 @@ public class HoldingsService {
           respond422method(responseClass), respond400, respond500));
       }
       if (pgException.isInvalidTextRepresentation()) {
-        handler.handle(PgUtil.response(cause.getMessage(), respond400, respond500));
+        handler.handle(PgUtil.response(pgException.getMessage(), respond400, respond500));
       }
-      handler.handle(PgUtil.response(cause.getMessage(), respond500, respond500));
+      handler.handle(PgUtil.response(pgException.getMessage(), respond500, respond500));
     } catch (Exception e) {
       log.error(e.getMessage(), e);
       handler.handle(Future.failedFuture(e));

--- a/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -67,6 +67,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   protected static final String PERMANENT_LOCATION_ID_KEY = "permanentLocationId";
   protected static final String TEMPORARY_LOCATION_ID_KEY = "temporaryLocationId";
   protected static final String EFFECTIVE_LOCATION_ID_KEY = "effectiveLocationId";
+  protected static final String STATISTICAL_CODE_IDS_KEY = "statisticalCodeIds";
   // These UUIDs were taken from reference-data folder.
   // When the vertical gets started the data from the reference-data folder are loaded to the DB.
   // see org.folio.rest.impl.TenantRefAPI.refPaths


### PR DESCRIPTION
### Purpose
[MODINVSTOR-1185](https://folio-org.atlassian.net/browse/MODINVSTOR-1185) Holdings record statistical codes validation enhancement. 
A Holding Create request with an invalid `statisticalCodeIds` value returns a `500 Internal Server Error` with the message: `ERROR: invalid input syntax for type uuid: "incorrect value" (22P02)`. The returned status and message are incorrect. 
The expected response is `HTTP 400 Bad Request` with the message: `invalid input syntax for type uuid: "incorrect value"`.

### Approach
Updated failure response handler for Holding Create API when handling invalid fields.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Screenshots
Before:
  <kbd>
  <img src="https://github.com/user-attachments/assets/a12736ca-e16a-4626-8df4-2d1ef824f134" width="550" height="350" alt="key" style="vertical-align: middle;"></kbd>

After:
  <kbd>
  <img src="https://github.com/user-attachments/assets/b4fea265-adde-4cc8-b8f4-79dcb8462121" width="550" height="350" alt="key" style="vertical-align: middle;"></kbd>

