### PR TITLE
fix(iteration-job-runner) Fix inconsistent "messagesPublished" updates caused by asynchronous execution in IterationJobRunner.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,7 @@
 * Fixed random "`Cannot set holdings_record.instanceid = [...] because it does not exist in instance.id.`" errors when opening orders ([MODINVSTOR-1427](https://folio-org.atlassian.net/browse/MODINVSTOR-1427))
 * Fix an iteration job is never finished after a cancellation request ([MODINVSTOR-1434](https://folio-org.atlassian.net/browse/MODINVSTOR-1434))
 * Fix updateIdentifierTypeCanceledLCCN migration script ([MODINVSTOR-1361](https://folio-org.atlassian.net/browse/MODINVSTOR-1361))
+* Fix inconsistent "messagesPublished" updates caused by asynchronous execution in IterationJobRunner. ([MODINVSTOR-1450](https://folio-org.atlassian.net/browse/MODINVSTOR-1450))
 
 ### Tech Dept
 * Stabilize `canRequestOaiPmhViewWithOrderedElectronicAccess` test by refining item lookup logic ([MODINVSTOR-1406](https://folio-org.atlassian.net/browse/MODINVSTOR-1406))

--- a/src/main/java/org/folio/persist/IterationJobRepository.java
+++ b/src/main/java/org/folio/persist/IterationJobRepository.java
@@ -4,9 +4,9 @@ import static org.folio.rest.jaxrs.model.IterationJob.JobStatus.COMPLETED;
 import static org.folio.rest.persist.PgUtil.postgresClient;
 
 import io.vertx.core.Context;
+import io.vertx.core.Future;
 import java.util.Map;
 import java.util.function.UnaryOperator;
-import io.vertx.core.Future;
 import org.folio.rest.jaxrs.model.IterationJob;
 
 public class IterationJobRepository extends AbstractRepository<IterationJob> {

--- a/src/main/java/org/folio/persist/IterationJobRepository.java
+++ b/src/main/java/org/folio/persist/IterationJobRepository.java
@@ -1,9 +1,12 @@
 package org.folio.persist;
 
+import static org.folio.rest.jaxrs.model.IterationJob.JobStatus.COMPLETED;
 import static org.folio.rest.persist.PgUtil.postgresClient;
 
 import io.vertx.core.Context;
 import java.util.Map;
+import java.util.function.UnaryOperator;
+import io.vertx.core.Future;
 import org.folio.rest.jaxrs.model.IterationJob;
 
 public class IterationJobRepository extends AbstractRepository<IterationJob> {
@@ -12,5 +15,16 @@ public class IterationJobRepository extends AbstractRepository<IterationJob> {
 
   public IterationJobRepository(Context context, Map<String, String> okapiHeaders) {
     super(postgresClient(context, okapiHeaders), TABLE_NAME, IterationJob.class);
+  }
+
+  public Future<IterationJob> fetchAndUpdateIterationJob(String id, UnaryOperator<IterationJob> builder) {
+    return postgresClient.withTrans(conn -> conn.getByIdForUpdate(TABLE_NAME, id, IterationJob.class)
+      .compose(response -> {
+        if (COMPLETED.equals(response.getJobStatus())) {
+          return Future.succeededFuture(response);
+        }
+        return conn.update(TABLE_NAME, builder.apply(response), id)
+          .map(builder.apply(response));
+      }));
   }
 }

--- a/src/main/java/org/folio/services/iteration/IterationJobRunner.java
+++ b/src/main/java/org/folio/services/iteration/IterationJobRunner.java
@@ -134,7 +134,7 @@ public class IterationJobRunner {
     }
 
     return jobRepository
-      .fetchAndUpdate(context.getJobId(), job -> job.withMessagesPublished(records.intValue()))
+      .fetchAndUpdateIterationJob(context.getJobId(), job -> job.withMessagesPublished(records.intValue()))
       .map(job -> {
         if (job.getJobStatus() == CANCELLATION_PENDING) {
           throw new IllegalStateException("The job has been cancelled");

--- a/src/test/java/org/folio/persist/IterationJobRepositoryTest.java
+++ b/src/test/java/org/folio/persist/IterationJobRepositoryTest.java
@@ -1,0 +1,147 @@
+package org.folio.persist;
+
+import static org.folio.okapi.common.XOkapiHeaders.TENANT;
+import static org.folio.rest.jaxrs.model.IterationJob.JobStatus.COMPLETED;
+import static org.folio.rest.jaxrs.model.IterationJob.JobStatus.IN_PROGRESS;
+import static org.folio.utility.ModuleUtility.getVertx;
+import static org.folio.utility.RestUtility.TENANT_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.ext.unit.junit.VertxUnitRunner;
+import java.util.Map;
+import java.util.function.Function;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.folio.rest.api.TestBase;
+import org.folio.rest.jaxrs.model.IterationJob;
+import org.folio.rest.persist.Conn;
+import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(VertxUnitRunner.class)
+public class IterationJobRepositoryTest extends TestBase {
+
+  private static final String JOB_ID = "test-job-id";
+
+  private PostgresClient postgresClient;
+  private IterationJobRepository repository;
+  private Conn conn;
+
+  @Before
+  public void setUp() {
+    postgresClient = mock(PostgresClient.class);
+    conn = mock(Conn.class);
+    try (var pgUtilMock = mockStatic(PgUtil.class)) {
+      pgUtilMock.when(() -> PgUtil.postgresClient(any(), any())).thenReturn(postgresClient);
+      repository = spy(new IterationJobRepository(getContext(), okapiHeaders()));
+    }
+  }
+
+  @Test
+  public void fetchAndUpdateIterationJob_ShouldReturnJob_WhenStatusIsCompleted() {
+    // Arrange
+    when(conn.getByIdForUpdate(anyString(), anyString(), eq(IterationJob.class)))
+      .thenReturn(Future.succeededFuture(new IterationJob().withId(JOB_ID).withJobStatus(COMPLETED)));
+    when(postgresClient.withTrans(any()))
+      .thenAnswer(invocation -> {
+        Function<Conn, Future<IterationJob>> function = invocation.getArgument(0);
+        return function.apply(conn);
+      });
+
+    // Act
+    var result = repository.fetchAndUpdateIterationJob(JOB_ID, job -> job);
+
+    // Assert
+    assertTrue(result.succeeded());
+    assertEquals(COMPLETED, result.result().getJobStatus());
+    verify(conn, never()).update(anyString(), any(), anyString());
+  }
+
+  @Test
+  public void fetchAndUpdateIterationJob_ShouldUpdateJob_WhenStatusIsNotCompleted() {
+    // Arrange
+    var updatedJob = new IterationJob().withId(JOB_ID)
+      .withJobStatus(IN_PROGRESS)
+      .withMessagesPublished(100);
+    when(conn.getByIdForUpdate(anyString(), anyString(), eq(IterationJob.class)))
+      .thenReturn(Future.succeededFuture(updatedJob));
+    when(conn.update(anyString(), any(), anyString()))
+      .thenReturn(Future.succeededFuture(null));
+    when(postgresClient.withTrans(any()))
+      .thenAnswer(invocation -> {
+        Function<Conn, Future<IterationJob>> function = invocation.getArgument(0);
+        return function.apply(conn);
+      });
+
+    // Act
+    var result = repository.fetchAndUpdateIterationJob(JOB_ID, job -> job);
+
+    // Assert
+    assertTrue(result.succeeded());
+    assertEquals(IN_PROGRESS, result.result().getJobStatus());
+    assertEquals(100, result.result().getMessagesPublished());
+    verify(conn).update(anyString(), eq(updatedJob), eq(JOB_ID));
+  }
+
+  @Test
+  public void fetchAndUpdateIterationJob_ShouldFail_WhenFetchFails() {
+    // Arrange
+    when(conn.getByIdForUpdate(anyString(), anyString(), eq(IterationJob.class)))
+      .thenReturn(Future.failedFuture(new RuntimeException("Fetch failed")));
+    when(postgresClient.withTrans(any()))
+      .thenAnswer(invocation -> {
+        Function<Conn, Future<IterationJob>> function = invocation.getArgument(0);
+        return function.apply(conn);
+      });
+
+    // Act
+    var result = repository.fetchAndUpdateIterationJob(JOB_ID, job -> job);
+
+    // Assert
+    assertTrue(result.failed());
+    assertEquals("Fetch failed", result.cause().getMessage());
+  }
+
+  @Test
+  public void fetchAndUpdateIterationJob_ShouldFail_WhenUpdateFails() {
+    // Arrange
+    when(conn.getByIdForUpdate(anyString(), anyString(), eq(IterationJob.class)))
+      .thenReturn(Future.succeededFuture(new IterationJob().withId(JOB_ID).withJobStatus(IN_PROGRESS)));
+    when(conn.update(anyString(), any(), anyString()))
+      .thenReturn(Future.failedFuture(new RuntimeException("Update failed")));
+    when(postgresClient.withTrans(any()))
+      .thenAnswer(invocation -> {
+        Function<Conn, Future<IterationJob>> function = invocation.getArgument(0);
+        return function.apply(conn);
+      });
+
+    // Act
+    var result = repository.fetchAndUpdateIterationJob(JOB_ID, job -> job);
+
+    // Assert
+    assertTrue(result.failed());
+    assertEquals("Update failed", result.cause().getMessage());
+  }
+
+  private static Map<String, String> okapiHeaders() {
+    return new CaseInsensitiveMap<>(Map.of(TENANT.toLowerCase(), TENANT_ID));
+  }
+
+  private static Context getContext() {
+    return getVertx().getOrCreateContext();
+  }
+}

--- a/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -21,6 +21,7 @@ import java.util.concurrent.TimeoutException;
 import lombok.SneakyThrows;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.folio.persist.IterationJobRepositoryTest;
 import org.folio.postgres.testing.PostgresTesterContainer;
 import org.folio.rest.persist.PostgresClient;
 import org.folio.rest.support.HttpClient;
@@ -59,6 +60,7 @@ import org.junit.runners.Suite;
   ItemShelvingOrderMigrationServiceApiTest.class,
   ItemStorageTest.class,
   IterationJobRunnerTest.class,
+  IterationJobRepositoryTest.class,
   LegacyItemEffectiveLocationMigrationScriptTest.class,
   NotificationSendingErrorRepositoryTest.class,
   OaiPmhViewTest.class,


### PR DESCRIPTION
### Purpose
[MODINVSTOR-1450](https://folio-org.atlassian.net/browse/MODINVSTOR-1450) Fix inconsistent "messagesPublished" updates caused by asynchronous execution in IterationJobRunner.

Due to asynchronous execution, there is an issue where the `messagesPublished` field may be overwritten with an outdated value. This can occur when the job status has already been marked as `COMPLETED` and the corresponding `messagesPublished` value has been stored, but the `logJobDetails` method finishes execution afterward and writes an outdated value to the same field.

### Approach
If the job status is marked as `COMPLETED`, no further updates to the `messagesPublished` field are applied.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Screenshots (if applicable)
Logs from the test that identified the issue::
https://jenkins-aws.indexdata.com/job/folio-org/job/mod-inventory-storage/job/MODINVSTOR-987/13/consoleFull
<img width="799" height="57" alt="image" src="https://github.com/user-attachments/assets/7f845a01-6417-4b8b-90c7-16a65069166f" />
<img width="1148" height="253" alt="image" src="https://github.com/user-attachments/assets/753a6327-8e71-4ffe-90ae-a08a1b3e0237" />


