### PR TITLE
feat(patch-items-endpoint) Create a new API to support the update of items' order.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,7 +3,7 @@
 * Constraint item call number type ID to refer to a known type ([MODINVSTOR-987](https://folio-org.atlassian.net/browse/MODINVSTOR-987))
 
 ### New APIs versions
-* Provides `item-storage 11.0`
+* Provides `item-storage 11.1`
 * Provides `item-storage-batch-sync 2.0`
 * Provides `item-storage-batch-sync-unsafe 2.0`
 * Provides `item-storage-dereferenced 1.2`
@@ -35,6 +35,7 @@
 * Add new `isShadow` property to location schema ([MODINVNSTOR-1436](https://folio-org.atlassian.net/browse/MODINVSTOR-1436))
 * Implement async migration that will populate the item's order field ([MODINVNSTOR-1442](https://folio-org.atlassian.net/browse/MODINVSTOR-1442))
 * Add new `isShadow` property to location units (institution, campus, library) schemas ([MODINVNSTOR-1455](https://folio-org.atlassian.net/browse/MODINVSTOR-1455))
+* Create a new API to support the update of items' order ([MODINVSTOR-1441](https://folio-org.atlassian.net/browse/MODINVSTOR-1441))
 
 ### Bug fixes
 * Fix ordering of electronic access items for inventory-hierarchy, oai-pmh-view ([MODINVSTOR-1224](https://folio-org.atlassian.net/browse/MODINVSTOR-1224))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -24,7 +24,7 @@
     },
     {
       "id": "item-storage",
-      "version": "11.0",
+      "version": "11.1",
       "handlers": [
         {
           "methods": ["GET"],
@@ -43,6 +43,10 @@
           "pathPattern": "/item-storage/items",
           "permissionsRequired": ["inventory-storage.items.item.post"]
         }, {
+          "methods": ["PATCH"],
+          "pathPattern": "/item-storage/items",
+          "permissionsRequired": ["inventory-storage.items.collection.patch"]
+        },{
           "methods": ["PUT"],
           "pathPattern": "/item-storage/items/{id}",
           "permissionsRequired": ["inventory-storage.items.item.put"]
@@ -1479,6 +1483,11 @@
       "description": "create individual item in storage"
     },
     {
+      "permissionName": "inventory-storage.items.collection.patch",
+      "displayName": "inventory storage - update items collection",
+      "description": "update items in storage"
+    },
+    {
       "permissionName": "inventory-storage.items.item.put",
       "displayName": "inventory storage - modify item",
       "description": "modify item in storage"
@@ -2615,6 +2624,7 @@
         "inventory-storage.items.retrieve.collection.post",
         "inventory-storage.items.item.get",
         "inventory-storage.items.item.post",
+        "inventory-storage.items.collection.patch",
         "inventory-storage.items.item.put",
         "inventory-storage.items.item.delete",
         "inventory-storage.items.collection.delete",

--- a/ramls/examples/items_patch.json
+++ b/ramls/examples/items_patch.json
@@ -1,0 +1,21 @@
+{
+  "items": [
+    {
+      "id": "f2901bcc-6290-417a-843b-a6d97ee9a418",
+      "_version": 1,
+      "order": 2
+    },
+    {
+      "id": "0b96a642-5e7f-452d-9cae-9cee66c9a892",
+      "_version": 1,
+      "barcode": "645398607547",
+      "status": {
+        "name": "Available"
+      },
+      "materialTypeId": "1a54b431-2e4f-452d-9cae-9cee66c9a892",
+      "permanentLoanTypeId": "2b94c631-fca9-4892-a730-03ee529ffe27",
+      "temporaryLoanTypeId": "e8b311a6-3b21-43f2-a269-dd9310cb2d0e",
+      "temporaryLocationId": "0df935eb-f3f4-4741-9ac6-33c500174b96"
+    }
+  ]
+}

--- a/ramls/item-storage.raml
+++ b/ramls/item-storage.raml
@@ -11,6 +11,7 @@ documentation:
 types:
   item: !include item-storage/item.json
   items: !include item-storage/items.json
+  itemsPatch: !include itemspatch.json
   errors: !include raml-util/schemas/errors.schema
   retrieveDto: !include retrieveEntitiesDto.json
 
@@ -39,6 +40,42 @@ resourceTypes:
           ]
     post:
       is: [validate]
+    patch:
+      is: [validate]
+      body:
+        application/json:
+          type: itemsPatch
+          example:
+            strict: false
+            value: examples/items_patch.json
+      responses:
+        204:
+          description: "Items successfully updated"
+        400:
+          description: "Bad request: malformed request body"
+          body:
+            text/plain:
+              example: "Bad request: malformed request body"
+        404:
+          description: "There is no source record for that item ID"
+          body:
+            text/plain:
+              example: "There is no source record for that item ID"
+        409:
+          description: "Optimistic locking version conflict"
+          body:
+            text/plain:
+              example: "Optimistic locking version conflict"
+        413:
+          description: "Payload Too Large"
+          body:
+            text/plain:
+              example: "Payload Too Large"
+        500:
+          description: "Internal server error"
+          body:
+            text/plain:
+              example: "Internal server error"
     delete:
       is: [searchable: { description: "CQL to select items to delete, use cql.allRecords=1 to delete all", example: "barcode==\"123-0*\"" } ]
       responses:

--- a/ramls/item-storage/itemPatch.json
+++ b/ramls/item-storage/itemPatch.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "An item record",
+  "javaType": "org.folio.rest.jaxrs.model.ItemPatch",
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "Unique identifier for the item record",
+      "$ref": "../uuid.json"
+    },
+    "_version": {
+      "description": "Version of the item record",
+      "type": "integer"
+    }
+  },
+  "additionalProperties": true,
+  "required": [
+    "id",
+    "_version"
+  ]
+}

--- a/ramls/itemspatch.json
+++ b/ramls/itemspatch.json
@@ -1,0 +1,20 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A collection of item records",
+  "type": "object",
+  "properties": {
+    "items": {
+      "description": "List of item records",
+      "id": "items",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "item-storage/itemPatch.json"
+      }
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "items"
+  ]
+}

--- a/src/main/java/org/folio/persist/HoldingsRepository.java
+++ b/src/main/java/org/folio/persist/HoldingsRepository.java
@@ -97,4 +97,22 @@ public class HoldingsRepository extends AbstractRepository<HoldingsRecord> {
       return resultList;
     });
   }
+
+  public Future<RowSet<Row>> getHoldingsByIds(List<String> holdingsIds) {
+    if (holdingsIds.isEmpty()) {
+      return Future.succeededFuture();
+    }
+
+    var holdingsIdsArray = String.join("','", holdingsIds);
+    var sql = """
+      SELECT id::text, jsonb::text
+      FROM %s
+      WHERE id = ANY(ARRAY['%s']::uuid[])
+      """.formatted(
+      getFullTableName(HOLDINGS_RECORD_TABLE),
+      holdingsIdsArray
+    );
+
+    return postgresClient.execute(sql);
+  }
 }

--- a/src/main/java/org/folio/persist/ItemRepository.java
+++ b/src/main/java/org/folio/persist/ItemRepository.java
@@ -2,23 +2,46 @@ package org.folio.persist;
 
 import static org.folio.rest.impl.HoldingsStorageApi.HOLDINGS_RECORD_TABLE;
 import static org.folio.rest.impl.ItemStorageApi.ITEM_TABLE;
+import static org.folio.rest.impl.StorageHelper.MAX_ENTITIES;
+import static org.folio.rest.jaxrs.resource.ItemStorage.PatchItemStorageItemsResponse.respond204;
+import static org.folio.rest.jaxrs.resource.ItemStorage.PatchItemStorageItemsResponse.respond413WithTextPlain;
 import static org.folio.rest.persist.PgUtil.postgresClient;
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+import io.vertx.pgclient.PgConnection;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.Tuple;
+import java.lang.reflect.Method;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import javax.ws.rs.core.Response;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.folio.cql2pgjson.CQL2PgJSON;
+import org.folio.rest.exceptions.ValidationException;
+import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.jaxrs.model.ItemPatch;
+import org.folio.rest.jaxrs.resource.ItemStorage;
+import org.folio.rest.jaxrs.resource.support.ResponseDelegate;
 import org.folio.rest.persist.Conn;
 import org.folio.rest.persist.Criteria.Criteria;
 import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.PgUtil;
 import org.folio.rest.persist.cql.CQLWrapper;
+import org.folio.rest.tools.utils.OptimisticLockingUtil;
 
 public class ItemRepository extends AbstractRepository<Item> {
+
+  private static final Logger logger = LogManager.getLogger(ItemRepository.class);
+  private static final String EXPECTED_A_MAXIMUM_RECORDS_TO_PREVENT_OUT_OF_MEMORY =
+    "Expected a maximum of %s records to prevent out of memory but got %s";
+  private static final String RESPOND_500_WITH_TEXT_PLAIN = "respond500WithTextPlain";
+
   public ItemRepository(Context context, Map<String, String> okapiHeaders) {
     super(postgresClient(context, okapiHeaders), ITEM_TABLE, Item.class);
   }
@@ -60,5 +83,45 @@ public class ItemRepository extends AbstractRepository<Item> {
       }
       return resultList;
     });
+  }
+
+  public Future<Response> updateItems(PgConnection conn, List<ItemPatch> items) {
+    try {
+      if (items.size() > MAX_ENTITIES) {
+        var message = EXPECTED_A_MAXIMUM_RECORDS_TO_PREVENT_OUT_OF_MEMORY.formatted(MAX_ENTITIES, items.size());
+        return Future.succeededFuture(respond413WithTextPlain(message));
+      }
+      OptimisticLockingUtil.unsetVersionIfMinusOne(items);
+
+      var tuples = items.stream()
+        .map(item -> Tuple.of(JsonObject.mapFrom(item), item.getId()))
+        .toList();
+      var sql = "UPDATE %s SET jsonb = jsonb || $1 WHERE id = $2"
+        .formatted(getFullTableName(ITEM_TABLE));
+
+      return conn.preparedQuery(sql).executeBatch(tuples)
+        .map((Response) respond204())
+        .recover(throwable ->
+          respondFailure(ITEM_TABLE, throwable, ItemStorage.PatchItemStorageItemsResponse.class)
+            .compose(response -> {
+              if (response.getEntity() instanceof Errors errors) {
+                return Future.failedFuture(new ValidationException(errors));
+              }
+              return Future.failedFuture(throwable);
+            }));
+    } catch (Exception e) {
+      logger.error("Failed to update items batch", e);
+      return Future.failedFuture(e);
+    }
+  }
+
+  private Future<Response> respondFailure(String table, Throwable throwable,
+                                          Class<? extends ResponseDelegate> responseClass) {
+    try {
+      Method respond500 = responseClass.getMethod(RESPOND_500_WITH_TEXT_PLAIN, Object.class);
+      return PgUtil.response(table, "", throwable, responseClass, respond500, respond500);
+    } catch (Exception e) {
+      return Future.failedFuture(e.getMessage());
+    }
   }
 }

--- a/src/main/java/org/folio/rest/impl/ItemStorageApi.java
+++ b/src/main/java/org/folio/rest/impl/ItemStorageApi.java
@@ -11,6 +11,7 @@ import java.util.Map;
 import javax.ws.rs.core.Response;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.jaxrs.model.ItemsPatch;
 import org.folio.rest.jaxrs.model.RetrieveDto;
 import org.folio.rest.jaxrs.resource.ItemStorage;
 import org.folio.rest.persist.PgUtil;
@@ -58,6 +59,14 @@ public class ItemStorageApi implements ItemStorage {
     new ItemService(vertxContext, okapiHeaders).createItem(entity)
       .onSuccess(response -> asyncResultHandler.handle(succeededFuture(response)))
       .onFailure(handleFailure(asyncResultHandler));
+  }
+
+  @Override
+  public void patchItemStorageItems(ItemsPatch entity, RoutingContext routingContext, Map<String, String> okapiHeaders,
+                                    Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    new ItemService(vertxContext, okapiHeaders).updateItems(entity.getItems())
+      .onFailure(handleFailure(asyncResultHandler))
+      .onComplete(asyncResultHandler);
   }
 
   @Validate

--- a/src/main/java/org/folio/services/domainevent/AbstractDomainEventPublisher.java
+++ b/src/main/java/org/folio/services/domainevent/AbstractDomainEventPublisher.java
@@ -104,6 +104,20 @@ abstract class AbstractDomainEventPublisher<D, E> {
     };
   }
 
+  public Handler<Response> publishUpdated(BatchOperationContext<D> batchOperation) {
+    return response -> {
+      if (!isUpdateSuccessResponse(response)) {
+        log.warn("Records update failed, skipping event publishing");
+        return;
+      }
+      log.info("Records updated {}", batchOperation.existingRecords().size());
+
+      if (batchOperation.publishEvents()) {
+        publishUpdated(batchOperation.existingRecords());
+      }
+    };
+  }
+
   protected Future<Void> publishUpdated(Collection<D> oldRecords) {
     if (oldRecords.isEmpty()) {
       log.info("No records were updated, skipping event sending");

--- a/src/main/java/org/folio/services/item/ItemService.java
+++ b/src/main/java/org/folio/services/item/ItemService.java
@@ -464,7 +464,7 @@ public class ItemService {
 
           // Set new holdings if it's the same as current
           var newHoldingsId = patchData.getNewItem().getHoldingsRecordId();
-          if (newHoldingsId.equals(currentHoldingsId)) {
+          if (newHoldingsId == null || newHoldingsId.equals(currentHoldingsId)) {
             patchData.setNewHoldings(patchData.getOldHoldings());
           }
         }

--- a/src/main/java/org/folio/services/item/ItemService.java
+++ b/src/main/java/org/folio/services/item/ItemService.java
@@ -29,8 +29,8 @@ import static org.folio.validator.HridValidators.refuseWhenHridChanged;
 import static org.folio.validator.NotesValidators.refuseLongNotes;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import io.vertx.core.CompositeFuture;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Promise;
@@ -38,23 +38,24 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowSet;
 import io.vertx.sqlclient.Tuple;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import java.util.function.Function;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.ws.rs.core.Response;
 import org.apache.commons.collections4.CollectionUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.Logger;
 import org.folio.dbschema.ObjectMapperTool;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.persist.HoldingsRepository;
 import org.folio.persist.ItemRepository;
+import org.folio.rest.exceptions.NotFoundException;
 import org.folio.rest.jaxrs.model.CirculationNote;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
@@ -69,7 +70,6 @@ import org.folio.rest.support.HridManager;
 import org.folio.rest.tools.client.exceptions.ResponseException;
 import org.folio.services.ItemEffectiveValuesService;
 import org.folio.services.ResponseHandlerUtil;
-import org.folio.services.batch.BatchOperationContext;
 import org.folio.services.domainevent.ItemDomainEventPublisher;
 import org.folio.validator.CommonValidators;
 import org.folio.validator.NotesValidators;
@@ -85,7 +85,6 @@ public class ItemService {
   private static final String INSTANCE_ID_WITH_ITEM_JSON = """
     {"instanceId": "%s",%s
     """;
-  private static final String ITEMS_NOT_FOUND = "Unable to update items. The following item IDs were not found: %s";
 
   private final HridManager hridManager;
   private final ItemEffectiveValuesService effectiveValuesService;
@@ -128,7 +127,7 @@ public class ItemService {
   }
 
   public Future<Response> createItems(List<Item> items, boolean upsert, boolean optimisticLocking) {
-    final Date itemStatusDate = new java.util.Date();
+    final var itemStatusDate = new Date();
     items.stream()
       .filter(item -> item.getStatus().getDate() == null)
       .forEach(item -> item.getStatus().setDate(itemStatusDate));
@@ -151,35 +150,55 @@ public class ItemService {
         ItemStorage.PatchItemStorageItemsResponse.respond400WithTextPlain("Expected at least one item to update"));
     }
 
-    List<Item> itemList;
+    List<PatchData> patchDataList;
+    var itemList = new ArrayList<Item>(items.size());
     try {
-      itemList = OBJECT_MAPPER.convertValue(items, new TypeReference<>() {});
+      patchDataList = items.stream()
+        .map(itemPatch -> {
+          var patchData = new PatchData();
+          patchData.setPatchRequest(itemPatch);
+          patchData.setNewItem(OBJECT_MAPPER.convertValue(itemPatch, Item.class));
+          itemList.add(patchData.getNewItem());  // Add to itemList during mapping
+          return patchData;
+        })
+        .toList();
     } catch (IllegalArgumentException e) {
       log.error("updateItems:: Failed to convert items", e);
       return Future.succeededFuture(ItemStorage.PatchItemStorageItemsResponse.respond400WithTextPlain(
         "Invalid item format: " + e.getMessage()));
     }
 
-    itemList.forEach(item -> validateUuidFormat(item.getStatisticalCodeIds())
-      .compose(v -> refuseLongNotes(item))
-      .compose(v -> StringUtils.isNotEmpty(item.getHoldingsRecordId())
-        ? getItemAndHolding(item.getId(), item.getHoldingsRecordId())
-        : Future.succeededFuture()));
-
-    return buildBatchOperationContext(true, itemList, itemRepository, Item::getId, true)
-      .compose(batchOperation -> {
-        if (CollectionUtils.isNotEmpty(batchOperation.recordsToBeCreated())) {
-          return buildItemsNotFoundResponse(batchOperation);
+    return ItemUtils.validateRequiredFields(items)
+      .compose(v -> validateUuidFormatForList(itemList, Item::getStatisticalCodeIds))
+      .compose(v -> NotesValidators.refuseItemLongNotes(itemList))
+      .compose(v -> populateCirculationNoteId(itemList))
+      .compose(v -> validateMultiplePatchItemsAndHoldings(patchDataList))
+      .compose(this::filterUnchangedPatchData)
+      .compose(patchDataToUpdate -> {
+        if (patchDataToUpdate.isEmpty()) {
+          return Future.succeededFuture(ItemStorage.PatchItemStorageItemsResponse.respond204());
         }
         return postgresClient.withTransaction(conn ->
-            itemRepository.updateItems(conn, items))
-          .onSuccess(domainEventService.publishUpdated(batchOperation));
+            itemRepository.updateItems(conn, items)
+              .<Response>compose(updatedItems -> {
+                for (var updatedItem : updatedItems) {
+                  for (var patchData : patchDataToUpdate) {
+                    if (updatedItem.getId().equals(patchData.getPatchRequest().getId())) {
+                      domainEventService.publishUpdated(
+                        updatedItem, patchData.getOldItem(), patchData.getNewHoldings(), patchData.getOldHoldings());
+                      break;
+                    }
+                  }
+                }
+                return Future.succeededFuture(ItemStorage.PatchItemStorageItemsResponse.respond204());
+              }))
+          .recover(ItemUtils::handleUpdateItemsError);
       });
   }
 
   public Future<Response> updateItem(String itemId, Item newItem) {
     newItem.setId(itemId);
-    PutData putData = new PutData();
+    var putData = new PutData();
     return validateUuidFormat(newItem.getStatisticalCodeIds())
       .compose(v -> refuseLongNotes(newItem))
       .compose(this::populateCirculationNoteId)
@@ -285,20 +304,20 @@ public class ItemService {
   }
 
   private static Response putFailure(Throwable e) {
-    String msg = PgExceptionUtil.badRequestMessage(e);
+    var msg = PgExceptionUtil.badRequestMessage(e);
     if (msg == null) {
       msg = e.getMessage();
     }
     if (PgExceptionUtil.isVersionConflict(e)) {
       return PutItemStorageItemsByItemIdResponse.respond409WithTextPlain(msg);
     }
-    Matcher matcher = KEY_NOT_PRESENT_PATTERN.matcher(msg);
+    var matcher = KEY_NOT_PRESENT_PATTERN.matcher(msg);
     if (matcher.find()) {
-      String field = matcher.group(1);
-      String value = matcher.group(2);
-      String refTable = matcher.group(3);
+      var field = matcher.group(1);
+      var value = matcher.group(2);
+      var refTable = matcher.group(3);
       msg = "Cannot set item " + field + " = " + value
-            + " because it does not exist in " + refTable + ".id.";
+        + " because it does not exist in " + refTable + ".id.";
     } else {
       matcher = KEY_ALREADY_EXISTS_PATTERN.matcher(msg);
       if (matcher.find()) {
@@ -309,7 +328,7 @@ public class ItemService {
   }
 
   public void populateItemFromHoldings(Item item, HoldingsRecord holdingsRecord,
-                                                 org.folio.services.ItemEffectiveValuesService effectiveValuesService) {
+                                       org.folio.services.ItemEffectiveValuesService effectiveValuesService) {
     effectiveValuesService.populateEffectiveValues(item, holdingsRecord);
     if (isItemFieldsAffected(holdingsRecord, item)) {
       populateMetadata(item, holdingsRecord.getMetadata());
@@ -318,13 +337,13 @@ public class ItemService {
 
   private static boolean isItemFieldsAffected(HoldingsRecord holdingsRecord, Item item) {
     return isBlank(item.getItemLevelCallNumber()) && isNotBlank(holdingsRecord.getCallNumber())
-           || isBlank(item.getItemLevelCallNumberPrefix()) && isNotBlank(holdingsRecord.getCallNumberPrefix())
-           || isBlank(item.getItemLevelCallNumberSuffix()) && isNotBlank(holdingsRecord.getCallNumberSuffix())
-           || isBlank(item.getItemLevelCallNumberTypeId()) && isNotBlank(holdingsRecord.getCallNumberTypeId())
-           || isNull(item.getPermanentLocationId())
-              && isNull(item.getTemporaryLocationId())
-              && (!isNull(holdingsRecord.getTemporaryLocationId())
-                  || !isNull(holdingsRecord.getPermanentLocationId()));
+      || isBlank(item.getItemLevelCallNumberPrefix()) && isNotBlank(holdingsRecord.getCallNumberPrefix())
+      || isBlank(item.getItemLevelCallNumberSuffix()) && isNotBlank(holdingsRecord.getCallNumberSuffix())
+      || isBlank(item.getItemLevelCallNumberTypeId()) && isNotBlank(holdingsRecord.getCallNumberTypeId())
+      || isNull(item.getPermanentLocationId())
+      && isNull(item.getTemporaryLocationId())
+      && (!isNull(holdingsRecord.getTemporaryLocationId())
+      || !isNull(holdingsRecord.getPermanentLocationId()));
   }
 
   private Future<RowSet<Row>> updateEffectiveCallNumbersAndLocation(
@@ -353,11 +372,11 @@ public class ItemService {
   }
 
   private Future<PutData> getItemAndHolding(String itemId, String holdingsId) {
-    String sql = "SELECT item.jsonb::text, holdings_record.jsonb::text "
-                 + "FROM " + itemRepository.getFullTableName(ITEM_TABLE) + " "
-                 + "LEFT JOIN " + itemRepository.getFullTableName(HOLDINGS_RECORD_TABLE)
-                 + "  ON holdings_record.id = $2 "
-                 + "WHERE item.id = $1";
+    var sql = "SELECT item.jsonb::text, holdings_record.jsonb::text "
+      + "FROM " + itemRepository.getFullTableName(ITEM_TABLE) + " "
+      + "LEFT JOIN " + itemRepository.getFullTableName(HOLDINGS_RECORD_TABLE)
+      + "  ON holdings_record.id = $2 "
+      + "WHERE item.id = $1";
     return postgresClient.execute(sql, Tuple.of(itemId, holdingsId))
       .compose(rowSet -> {
         if (rowSet.size() == 0) {
@@ -370,7 +389,7 @@ public class ItemService {
             PutItemStorageItemsByItemIdResponse.respond400WithTextPlain(
               "holdingsRecordId not found: " + holdingsId)));
         }
-        PutData putData = new PutData();
+        var putData = new PutData();
         putData.oldItem = readValue(row.getString(0), Item.class);
         putData.newHoldings = readValue(row.getString(1), HoldingsRecord.class);
         return Future.succeededFuture(putData);
@@ -388,8 +407,8 @@ public class ItemService {
     } catch (Exception e) {
       return Future.failedFuture(e);
     }
-    String tableName = itemRepository.getFullTableName(ITEM_TABLE);
-    Tuple tuple = Tuple.of(itemJson, item.getId());
+    var tableName = itemRepository.getFullTableName(ITEM_TABLE);
+    var tuple = Tuple.of(itemJson, item.getId());
 
     return postgresClient.execute("UPDATE " + tableName + " SET jsonb=$1 WHERE id=$2 RETURNING jsonb::text", tuple)
       .compose(rowSet -> {
@@ -400,6 +419,145 @@ public class ItemService {
         return Future.succeededFuture(readValue(rowSet.iterator().next().getString(0), Item.class));
       })
       .recover(e -> Future.failedFuture(new ResponseException(putFailure(e))));
+  }
+
+  private Future<List<PatchData>> validateMultiplePatchItemsAndHoldings(List<PatchData> patchDataList) {
+    if (patchDataList.isEmpty()) {
+      return Future.succeededFuture(List.of());
+    }
+
+    var itemIds = patchDataList.stream()
+      .map(patchData -> patchData.getNewItem().getId())
+      .toList();
+
+    return itemRepository.getItemsWithCurrentHoldings(itemIds)
+      .compose(itemsRowSet -> {
+        populateOldItemsAndCurrentHoldings(itemsRowSet, patchDataList);
+        return ensureHoldingsAreLoaded(patchDataList)
+          .compose(this::validateAndPopulatePatchData);
+      });
+  }
+
+  private void populateOldItemsAndCurrentHoldings(RowSet<Row> itemsRowSet, List<PatchData> patchDataList) {
+    var holdingsCache = new HashMap<String, HoldingsRecord>();
+    var foundItemIds = new ArrayList<String>();
+    var patchDataMap = patchDataList.stream()
+      .<HashMap<String, PatchData>>collect(HashMap::new, (map, patchData) ->
+        map.put(patchData.getNewItem().getId(), patchData), HashMap::putAll);
+
+    // Populate old items and current holdings from database results
+    for (var row : itemsRowSet) {
+      var itemId = row.getString(0);
+      var itemJson = row.getString(1);
+      var currentHoldingsJson = row.getString(2);
+      var currentHoldingsId = row.getString(3);
+
+      var patchData = patchDataMap.get(itemId);
+      if (patchData != null) {
+        patchData.setOldItem(readValue(itemJson, Item.class));
+
+        // Cache current holdings if present
+        if (currentHoldingsJson != null) {
+          holdingsCache.putIfAbsent(currentHoldingsId,
+            readValue(currentHoldingsJson, HoldingsRecord.class));
+          patchData.setOldHoldings(holdingsCache.get(currentHoldingsId));
+
+          // Set new holdings if it's the same as current
+          var newHoldingsId = patchData.getNewItem().getHoldingsRecordId();
+          if (newHoldingsId.equals(currentHoldingsId)) {
+            patchData.setNewHoldings(patchData.getOldHoldings());
+          }
+        }
+
+        foundItemIds.add(itemId);
+      }
+    }
+
+    // Validate all items were found and provide specific missing item IDs
+    if (foundItemIds.size() != patchDataList.size()) {
+      var requestedItemIds = patchDataList.stream()
+        .map(patchData -> patchData.getNewItem().getId())
+        .toList();
+      var missingItemIds = requestedItemIds.stream()
+        .filter(id -> !foundItemIds.contains(id))
+        .toList();
+
+      var errorMessage = missingItemIds.size() == 1
+        ? "Item not found in database: " + missingItemIds.get(0)
+        : "Items not found in database: " + String.join(", ", missingItemIds);
+
+      throw new NotFoundException(errorMessage);
+    }
+  }
+
+  private Future<List<PatchData>> ensureHoldingsAreLoaded(List<PatchData> patchDataList) {
+    var missingHoldingsIds = patchDataList.stream()
+      .filter(patchData -> patchData.getNewHoldings() == null)
+      .map(patchData -> patchData.getNewItem().getHoldingsRecordId())
+      .distinct()
+      .toList();
+
+    if (missingHoldingsIds.isEmpty()) {
+      return Future.succeededFuture(patchDataList);
+    }
+
+    return holdingsRepository.getHoldingsByIds(missingHoldingsIds)
+      .compose(holdingsRowSet -> {
+        var holdingsMap = new HashMap<String, HoldingsRecord>();
+        for (var row : holdingsRowSet) {
+          var holdingsId = row.getString(0);
+          var holdingsJson = row.getString(1);
+          holdingsMap.put(holdingsId, readValue(holdingsJson, HoldingsRecord.class));
+        }
+
+        // Set missing holdings
+        for (var patchData : patchDataList) {
+          if (patchData.getNewHoldings() == null) {
+            var newHoldingsId = patchData.getNewItem().getHoldingsRecordId();
+            patchData.setNewHoldings(holdingsMap.get(newHoldingsId));
+            if (patchData.getNewHoldings() == null) {
+              return Future.failedFuture(new NotFoundException("Holdings not found: " + newHoldingsId));
+            }
+          }
+        }
+
+        return Future.succeededFuture(patchDataList);
+      });
+  }
+
+  private Future<List<PatchData>> validateAndPopulatePatchData(List<PatchData> patchDataList) {
+    var validationFutures = patchDataList.stream()
+      .map(this::validateAndPopulateSinglePatchData)
+      .toList();
+
+    return Future.all(validationFutures)
+      .map(CompositeFuture::list);
+  }
+
+  private Future<PatchData> validateAndPopulateSinglePatchData(PatchData patchData) {
+    var newItem = patchData.getNewItem();
+    var patchRequest = patchData.getPatchRequest();
+
+    var hridPresentInPatch = patchRequest.getAdditionalProperties() != null
+      && patchRequest.getAdditionalProperties().containsKey("hrid");
+
+    var validationFuture = hridPresentInPatch
+      ? refuseWhenHridChanged(patchData.getOldItem(), newItem).mapEmpty()
+      : Future.succeededFuture();
+
+    return validationFuture.compose(v -> {
+      boolean holdingsChanged = !Objects.equals(
+        patchData.getOldItem().getHoldingsRecordId(),
+        newItem.getHoldingsRecordId()
+      );
+
+      if (holdingsChanged) {
+        effectiveValuesService.populateEffectiveValues(newItem, patchData.getNewHoldings());
+        ItemUtils.transferEffectiveValuesToPatch(newItem, patchData.getPatchRequest());
+      }
+
+      return Future.succeededFuture(patchData);
+    });
   }
 
   private void populateMetadata(Item item, Metadata metadata) {
@@ -415,11 +573,6 @@ public class ItemService {
     item.setMetadata(updatedMetadata);
   }
 
-  private Future<List<Item>> populateCirculationNoteId(List<Item> items) {
-    items.forEach(this::populateCirculationNoteId);
-    return Future.succeededFuture(items);
-  }
-
   private Future<Item> populateCirculationNoteId(Item item) {
     if (Objects.nonNull(item.getCirculationNotes())) {
       for (CirculationNote circulationNote : item.getCirculationNotes()) {
@@ -431,14 +584,23 @@ public class ItemService {
     return Future.succeededFuture(item);
   }
 
-  private Future<Response> buildItemsNotFoundResponse(BatchOperationContext<Item> batchOperation) {
-    var idsNotFound = batchOperation.recordsToBeCreated().stream()
-      .map(Item::getId)
-      .toList();
-    var message = ITEMS_NOT_FOUND.formatted(idsNotFound);
-    log.warn("updateItems:: {}", message);
-    return Future.succeededFuture(
-      ItemStorage.PatchItemStorageItemsResponse.respond404WithTextPlain(message));
+  private Future<List<Item>> populateCirculationNoteId(List<Item> items) {
+    items.forEach(this::populateCirculationNoteId);
+    return Future.succeededFuture(items);
+  }
+
+  private Future<List<PatchData>> filterUnchangedPatchData(List<PatchData> patchDataList) {
+    return Future.succeededFuture(patchDataList.stream()
+      .filter(patchData -> {
+        try {
+          return patchData.hasChanges();
+        } catch (Exception e) {
+          log.warn("Error checking patch changes for item {}, including in update: {}",
+            patchData.getNewItem().getId(), e.getMessage());
+          return true;
+        }
+      })
+      .toList());
   }
 
   private static final class PutData {

--- a/src/main/java/org/folio/services/item/ItemUtils.java
+++ b/src/main/java/org/folio/services/item/ItemUtils.java
@@ -1,0 +1,127 @@
+package org.folio.services.item;
+
+import static org.apache.commons.lang3.StringUtils.isBlank;
+import static org.apache.logging.log4j.LogManager.getLogger;
+import static org.folio.rest.impl.ItemStorageApi.ITEM_TABLE;
+
+import io.vertx.core.Future;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.core.Response;
+import org.apache.logging.log4j.Logger;
+import org.folio.rest.exceptions.ValidationException;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.jaxrs.model.ItemPatch;
+import org.folio.rest.jaxrs.resource.ItemStorage;
+import org.folio.rest.persist.PgUtil;
+
+public final class ItemUtils {
+
+  private static final Logger log = getLogger(ItemUtils.class);
+
+  private ItemUtils() {
+    throw new UnsupportedOperationException("Utility class");
+  }
+
+  public static Future<Void> validateRequiredFields(List<ItemPatch> items) {
+    var errors = new ArrayList<Error>();
+
+    for (var itemPatch : items) {
+      var additionalProperties = itemPatch.getAdditionalProperties();
+      if (additionalProperties == null) {
+        continue; // No additional properties to validate
+      }
+
+      var missingFields = new ArrayList<String>();
+
+      if (additionalProperties.containsKey("materialTypeId")
+          && isNullOrBlank(additionalProperties.get("materialTypeId"))) {
+        missingFields.add("materialTypeId");
+      }
+
+      if (additionalProperties.containsKey("permanentLoanTypeId")
+          && isNullOrBlank(additionalProperties.get("permanentLoanTypeId"))) {
+        missingFields.add("permanentLoanTypeId");
+      }
+
+      if (additionalProperties.containsKey("holdingsRecordId")
+          && isNullOrBlank(additionalProperties.get("holdingsRecordId"))) {
+        missingFields.add("holdingsRecordId");
+      }
+
+      // Check status object and its required name field
+      if (additionalProperties.containsKey("status")) {
+        var status = additionalProperties.get("status");
+        if (status == null) {
+          missingFields.add("status");
+        } else if (status instanceof Map<?, ?> statusMap
+            && isNullOrBlank(statusMap.get("name"))) {
+          missingFields.add("status.name");
+        }
+      }
+
+      if (!missingFields.isEmpty()) {
+        errors.add(requiredFieldsError(itemPatch.getId(), missingFields));
+      }
+    }
+
+    if (!errors.isEmpty()) {
+      return Future.failedFuture(new ValidationException(new Errors().withErrors(errors)));
+    }
+
+    return Future.succeededFuture();
+  }
+
+  public static boolean isNullOrBlank(Object value) {
+    return value == null || isBlank(String.valueOf(value));
+  }
+
+  public static Error requiredFieldsError(String itemId, List<String> fieldNames) {
+    var parameters = fieldNames.stream()
+        .map(fieldName -> new org.folio.rest.jaxrs.model.Parameter()
+            .withKey("field")
+            .withValue(fieldName))
+        .toList();
+
+    return new Error()
+      .withMessage("Required fields cannot be removed. ItemId: " + itemId)
+      .withCode("field.required")
+      .withParameters(parameters);
+  }
+
+  public static void transferEffectiveValuesToPatch(Item item, ItemPatch itemPatch) {
+    var additionalProperties = itemPatch.getAdditionalProperties();
+
+    if (item.getEffectiveLocationId() != null) {
+      additionalProperties.put("effectiveLocationId", item.getEffectiveLocationId());
+    }
+
+    if (item.getEffectiveCallNumberComponents() != null) {
+      additionalProperties.put("effectiveCallNumberComponents", item.getEffectiveCallNumberComponents());
+    }
+
+    if (item.getEffectiveShelvingOrder() != null) {
+      additionalProperties.put("effectiveShelvingOrder", item.getEffectiveShelvingOrder());
+    }
+  }
+
+  public static Future<Response> handleUpdateItemsError(Throwable throwable) {
+    var responseClass = ItemStorage.PatchItemStorageItemsResponse.class;
+    try {
+      var respond500 = responseClass.getMethod("respond500WithTextPlain", Object.class);
+      return PgUtil.response(ITEM_TABLE, "", throwable, responseClass, respond500, respond500)
+        .compose(response -> {
+          if (response.getEntity() instanceof Errors errors) {
+            return Future.failedFuture(new ValidationException(errors));
+          }
+          return Future.failedFuture(throwable);
+        });
+    } catch (NoSuchMethodException e) {
+      log.error("handleUpdateItemsError:: Failed to get respond500WithTextPlain method", e);
+      return Future.failedFuture(throwable);
+    }
+  }
+}

--- a/src/main/java/org/folio/services/item/PatchData.java
+++ b/src/main/java/org/folio/services/item/PatchData.java
@@ -1,0 +1,73 @@
+package org.folio.services.item;
+
+import java.util.Objects;
+import org.folio.rest.jaxrs.model.HoldingsRecord;
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.jaxrs.model.ItemPatch;
+
+public class PatchData {
+  private Item oldItem;
+  private Item newItem;
+  private HoldingsRecord oldHoldings;
+  private HoldingsRecord newHoldings;
+  private ItemPatch patchRequest;
+
+  public Item getOldItem() {
+    return oldItem;
+  }
+
+  public Item getNewItem() {
+    return newItem;
+  }
+
+  public HoldingsRecord getOldHoldings() {
+    return oldHoldings;
+  }
+
+  public HoldingsRecord getNewHoldings() {
+    return newHoldings;
+  }
+
+  public ItemPatch getPatchRequest() {
+    return patchRequest;
+  }
+
+  public void setOldItem(Item oldItem) {
+    this.oldItem = oldItem;
+  }
+
+  public void setNewItem(Item newItem) {
+    this.newItem = newItem;
+  }
+
+  public void setOldHoldings(HoldingsRecord oldHoldings) {
+    this.oldHoldings = oldHoldings;
+  }
+
+  public void setNewHoldings(HoldingsRecord newHoldings) {
+    this.newHoldings = newHoldings;
+  }
+
+  public void setPatchRequest(ItemPatch patchRequest) {
+    this.patchRequest = patchRequest;
+  }
+
+  public boolean hasChanges() {
+    var additionalProperties = patchRequest.getAdditionalProperties();
+
+    // If no additional properties beyond id and _version, means no changes for patch request
+    if (additionalProperties == null || additionalProperties.isEmpty()) {
+      return false;
+    }
+
+    // If only holdingsRecordId is present, check if it's different from old item
+    if (additionalProperties.size() == 1 && additionalProperties.containsKey("holdingsRecordId")) {
+      var patchHoldingsId = (String) additionalProperties.get("holdingsRecordId");
+      var oldHoldingsId = oldItem.getHoldingsRecordId();
+      return !Objects.equals(patchHoldingsId, oldHoldingsId);
+    }
+
+    // Any other additional properties mean there's a change
+    return true;
+  }
+}

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -2021,7 +2021,7 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     createItem(smallAngryPlanet(itemId, holdingsRecordId));
 
     // get item
-    CompletableFuture<Response> completableFuture = new CompletableFuture<>();
+    var completableFuture = new CompletableFuture<Response>();
     getClient().get(itemsStorageUrl("/" + itemId), TENANT_ID,
       ResponseHandler.any(completableFuture));
     var response = completableFuture.get(TIMEOUT, TimeUnit.SECONDS);
@@ -2034,24 +2034,22 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     itemsJson.put("order", 55);
 
     // update item via PATCH
-    CompletableFuture<Response> patchCompleted = new CompletableFuture<>();
+    var patchCompleted = new CompletableFuture<Response>();
     getClient().patch(itemsStorageUrl(""), new JsonObject().put("items", new JsonArray().add(itemsJson)),
       TENANT_ID, ResponseHandler.empty(patchCompleted));
     var patchResponse = patchCompleted.get(TIMEOUT, TimeUnit.SECONDS);
     assertThat(patchResponse.getStatusCode(), is(204));
 
     // verify item is updated
-    CompletableFuture<Response> itemFuture = new CompletableFuture<>();
-    getClient().get(itemsStorageUrl("/" + itemId), TENANT_ID,
-      ResponseHandler.json(itemFuture));
-    var itemResponse = itemFuture.get(TIMEOUT, TimeUnit.SECONDS);
+    var itemResponse = getById(itemId);
+    var itemResponseJson = itemResponse.getJson();
 
     assertThat(itemResponse.getStatusCode(), is(200));
-    assertEquals("55", itemResponse.getJson().getValue("order").toString());
-    assertEquals("it00000000001", itemResponse.getJson().getValue("hrid").toString());
-    assertNull(itemResponse.getJson().getValue("barcode"));
+    assertEquals("55", itemResponseJson.getValue("order").toString());
+    assertEquals("it00000000001", itemResponseJson.getValue("hrid").toString());
+    assertNull(itemResponseJson.getValue("barcode"));
 
-    itemMessageChecks.updatedMessagePublished(response.getJson(), getById(itemId).getJson());
+    itemMessageChecks.updatedMessagePublished(response.getJson(), itemResponseJson);
   }
 
   @Test

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -2215,7 +2215,6 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
 
     // modify item body
     var itemsJson = response.getJson();
-    var notExistedItemId = randomUUID();
     itemsJson.put("_version", 5);
 
     // update item via PATCH

--- a/src/test/java/org/folio/rest/support/HttpClient.java
+++ b/src/test/java/org/folio/rest/support/HttpClient.java
@@ -174,6 +174,30 @@ public class HttpClient {
     return asResponse(request(HttpMethod.PUT, url, body, tenantId));
   }
 
+  public void patch(
+    URL url,
+    Object body,
+    String tenantId,
+    Handler<HttpResponse<Buffer>> responseHandler) {
+
+    patch(url, body, Map.of(), tenantId, responseHandler);
+  }
+
+  public void patch(
+    URL url,
+    Object body,
+    Map<String, String> headers,
+    String tenantId,
+    Handler<HttpResponse<Buffer>> responseHandler) {
+
+    request(HttpMethod.PATCH, url, body, headers, tenantId)
+      .recover(error -> {
+        LOG.error(error.getMessage(), error);
+        return null;
+      })
+      .onSuccess(responseHandler);
+  }
+
   public void get(
     String url,
     String tenantId,

--- a/src/test/java/org/folio/services/item/ItemUtilsTest.java
+++ b/src/test/java/org/folio/services/item/ItemUtilsTest.java
@@ -1,0 +1,323 @@
+package org.folio.services.item;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Stream;
+import org.folio.rest.exceptions.ValidationException;
+import org.folio.rest.jaxrs.model.EffectiveCallNumberComponents;
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.jaxrs.model.ItemPatch;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("ItemUtils Tests")
+class ItemUtilsTest {
+
+  @Test
+  @DisplayName("Should throw UnsupportedOperationException when trying to instantiate")
+  void constructor_shouldThrowExceptionOnInstantiation() throws Exception {
+    // Given
+    var constructor = ItemUtils.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+
+    // When & Then
+    var exception = assertThrows(InvocationTargetException.class, constructor::newInstance);
+    assertEquals(UnsupportedOperationException.class, exception.getCause().getClass());
+    assertEquals("Utility class", exception.getCause().getMessage());
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideValidRequiredFieldsCases")
+  @DisplayName("Should succeed validation when all required fields are valid")
+  void validateRequiredFields_shouldSucceedValidationWhenRequiredFieldsAreValid(String description,
+                                                                                List<ItemPatch> items) {
+    // When
+    var result = ItemUtils.validateRequiredFields(items);
+
+    // Then
+    assertTrue(result.succeeded(), description);
+    assertNull(result.result(), description);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideInvalidRequiredFieldsCases")
+  @DisplayName("Should fail validation when required fields are missing or invalid")
+  void validateRequiredFields_shouldFailValidationWhenRequiredFieldsAreInvalid(String description,
+                                                                               List<ItemPatch> items,
+                                                                               int expectedErrorCount) {
+    // When
+    var result = ItemUtils.validateRequiredFields(items);
+
+    // Then
+    assertTrue(result.failed(), description);
+    var exception = (ValidationException) result.cause();
+    assertNotNull(exception.getErrors(), description);
+    assertEquals(expectedErrorCount, exception.getErrors().getErrors().size(), description);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideNullOrBlankValues")
+  @DisplayName("Should correctly identify null or blank values")
+  void isNullOrBlank_shouldIdentifyNullOrBlankValues(String description, Object value, boolean expectedResult) {
+    // When
+    var result = ItemUtils.isNullOrBlank(value);
+
+    // Then
+    assertEquals(expectedResult, result, description);
+  }
+
+  @Test
+  @DisplayName("Should create error with correct message and parameters")
+  void requiredFieldsError_shouldCreateErrorWithCorrectMessageAndParameters() {
+    // Given
+    var itemId = "test-item-id";
+    var fieldNames = List.of("materialTypeId", "status.name");
+
+    // When
+    var error = ItemUtils.requiredFieldsError(itemId, fieldNames);
+
+    // Then
+    assertNotNull(error);
+    assertEquals("Required fields cannot be removed. ItemId: " + itemId, error.getMessage());
+    assertEquals("field.required", error.getCode());
+    assertEquals(2, error.getParameters().size());
+    assertEquals("field", error.getParameters().get(0).getKey());
+    assertEquals("materialTypeId", error.getParameters().get(0).getValue());
+    assertEquals("field", error.getParameters().get(1).getKey());
+    assertEquals("status.name", error.getParameters().get(1).getValue());
+  }
+
+  @Test
+  @DisplayName("Should transfer all effective values to patch")
+  void transferEffectiveValuesToPatch_shouldTransferAllEffectiveValuesToPatch() {
+    // Given
+    var item = new Item();
+    item.setEffectiveLocationId("location-id");
+    var callNumberComponents = new EffectiveCallNumberComponents();
+    callNumberComponents.setCallNumber("call-number");
+    item.setEffectiveCallNumberComponents(callNumberComponents);
+    item.setEffectiveShelvingOrder("shelving-order");
+
+    var itemPatch = new ItemPatch()
+      .withAdditionalProperty("someProperty", "value"); // Initialize with some property
+
+    // When
+    ItemUtils.transferEffectiveValuesToPatch(item, itemPatch);
+
+    // Then
+    var additionalProperties = itemPatch.getAdditionalProperties();
+    assertEquals("location-id", additionalProperties.get("effectiveLocationId"));
+    assertEquals(callNumberComponents, additionalProperties.get("effectiveCallNumberComponents"));
+    assertEquals("shelving-order", additionalProperties.get("effectiveShelvingOrder"));
+  }
+
+  @Test
+  @DisplayName("Should not transfer null effective values to patch")
+  void transferEffectiveValuesToPatch_shouldNotTransferNullEffectiveValuesToPatch() {
+    // Given
+    var item = new Item();
+    item.setEffectiveLocationId(null);
+    item.setEffectiveCallNumberComponents(null);
+    item.setEffectiveShelvingOrder(null);
+
+    var itemPatch = new ItemPatch()
+      .withAdditionalProperty("someProperty", "value"); // Initialize with some property
+
+    // When
+    ItemUtils.transferEffectiveValuesToPatch(item, itemPatch);
+
+    // Then
+    var additionalProperties = itemPatch.getAdditionalProperties();
+    assertFalse(additionalProperties.containsKey("effectiveLocationId"));
+    assertFalse(additionalProperties.containsKey("effectiveCallNumberComponents"));
+    assertFalse(additionalProperties.containsKey("effectiveShelvingOrder"));
+  }
+
+  @Test
+  @DisplayName("Should transfer only non-null effective values to patch")
+  void transferEffectiveValuesToPatch_shouldTransferOnlyNonNullEffectiveValuesToPatch() {
+    // Given
+    var item = new Item();
+    item.setEffectiveLocationId("location-id");
+    item.setEffectiveCallNumberComponents(null);
+    item.setEffectiveShelvingOrder("shelving-order");
+
+    var itemPatch = new ItemPatch()
+      .withAdditionalProperty("someProperty", "value"); // Initialize with some property
+
+    // When
+    ItemUtils.transferEffectiveValuesToPatch(item, itemPatch);
+
+    // Then
+    var additionalProperties = itemPatch.getAdditionalProperties();
+    assertEquals("location-id", additionalProperties.get("effectiveLocationId"));
+    assertFalse(additionalProperties.containsKey("effectiveCallNumberComponents"));
+    assertEquals("shelving-order", additionalProperties.get("effectiveShelvingOrder"));
+  }
+
+  @Test
+  @DisplayName("Should handle update items error and return failed future")
+  void handleUpdateItemsError_shouldHandleUpdateItemsErrorAndReturnFailedFuture() {
+    // Given
+    var throwable = new RuntimeException("Test error");
+
+    // When
+    var result = ItemUtils.handleUpdateItemsError(throwable);
+
+    // Then
+    assertTrue(result.failed());
+    assertTrue(result.cause() instanceof ValidationException || result.cause() instanceof RuntimeException);
+  }
+
+  private static Stream<Arguments> provideValidRequiredFieldsCases() {
+    return Stream.of(
+      Arguments.of(
+        "Empty list of items",
+        List.<ItemPatch>of()
+      ),
+      Arguments.of(
+        "Item with no additional properties",
+        List.of(new ItemPatch())
+      ),
+      Arguments.of(
+        "Item with valid materialTypeId",
+        List.of(new ItemPatch().withAdditionalProperty("materialTypeId", "valid-material-type"))
+      ),
+      Arguments.of(
+        "Item with valid permanentLoanTypeId",
+        List.of(new ItemPatch().withAdditionalProperty("permanentLoanTypeId", "valid-loan-type"))
+      ),
+      Arguments.of(
+        "Item with valid holdingsRecordId",
+        List.of(new ItemPatch().withAdditionalProperty("holdingsRecordId", "valid-holdings-id"))
+      ),
+      Arguments.of(
+        "Item with valid status",
+        List.of(new ItemPatch().withAdditionalProperty("status", Map.of("name", "Available")))
+      ),
+      Arguments.of(
+        "Item with all valid required fields",
+        List.of(new ItemPatch()
+          .withAdditionalProperty("materialTypeId", "material-type")
+          .withAdditionalProperty("permanentLoanTypeId", "loan-type")
+          .withAdditionalProperty("holdingsRecordId", "holdings-id")
+          .withAdditionalProperty("status", Map.of("name", "Available")))
+      ),
+      Arguments.of(
+        "Multiple items with valid fields",
+        List.of(
+          new ItemPatch().withAdditionalProperty("materialTypeId", "material-type-1"),
+          new ItemPatch().withAdditionalProperty("permanentLoanTypeId", "loan-type-2")
+        )
+      )
+    );
+  }
+
+  private static Stream<Arguments> provideInvalidRequiredFieldsCases() {
+    var statusWithNullName = new HashMap<String, Object>();
+    statusWithNullName.put("name", null);
+
+    return Stream.of(
+      Arguments.of(
+        "Item with null materialTypeId",
+        List.of(new ItemPatch().withAdditionalProperty("materialTypeId", null)),
+        1
+      ),
+      Arguments.of(
+        "Item with empty materialTypeId",
+        List.of(new ItemPatch().withAdditionalProperty("materialTypeId", "")),
+        1
+      ),
+      Arguments.of(
+        "Item with blank materialTypeId",
+        List.of(new ItemPatch().withAdditionalProperty("materialTypeId", "   ")),
+        1
+      ),
+      Arguments.of(
+        "Item with null permanentLoanTypeId",
+        List.of(new ItemPatch().withAdditionalProperty("permanentLoanTypeId", null)),
+        1
+      ),
+      Arguments.of(
+        "Item with empty permanentLoanTypeId",
+        List.of(new ItemPatch().withAdditionalProperty("permanentLoanTypeId", "")),
+        1
+      ),
+      Arguments.of(
+        "Item with null holdingsRecordId",
+        List.of(new ItemPatch().withAdditionalProperty("holdingsRecordId", null)),
+        1
+      ),
+      Arguments.of(
+        "Item with empty holdingsRecordId",
+        List.of(new ItemPatch().withAdditionalProperty("holdingsRecordId", "")),
+        1
+      ),
+      Arguments.of(
+        "Item with null status",
+        List.of(new ItemPatch().withAdditionalProperty("status", null)),
+        1
+      ),
+      Arguments.of(
+        "Item with status having null name",
+        List.of(new ItemPatch().withAdditionalProperty("status", statusWithNullName)),
+        1
+      ),
+      Arguments.of(
+        "Item with status having empty name",
+        List.of(new ItemPatch().withAdditionalProperty("status", Map.of("name", ""))),
+        1
+      ),
+      Arguments.of(
+        "Item with status having blank name",
+        List.of(new ItemPatch().withAdditionalProperty("status", Map.of("name", "   "))),
+        1
+      ),
+      Arguments.of(
+        "Item with multiple missing required fields",
+        List.of(new ItemPatch()
+          .withAdditionalProperty("materialTypeId", null)
+          .withAdditionalProperty("permanentLoanTypeId", "")
+          .withAdditionalProperty("holdingsRecordId", "   ")
+          .withAdditionalProperty("status", statusWithNullName)),
+        1 // One error per item, but multiple field parameters
+      ),
+      Arguments.of(
+        "Multiple items with missing fields",
+        List.of(
+          new ItemPatch().withAdditionalProperty("materialTypeId", null),
+          new ItemPatch().withAdditionalProperty("permanentLoanTypeId", "")
+        ),
+        2
+      )
+    );
+  }
+
+  private static Stream<Arguments> provideNullOrBlankValues() {
+    return Stream.of(
+      Arguments.of("Null value", null, true),
+      Arguments.of("Empty string", "", true),
+      Arguments.of("Blank string with spaces", "   ", true),
+      Arguments.of("Blank string with tabs", "\t\t", true),
+      Arguments.of("Blank string with newlines", "\n\n", true),
+      Arguments.of("Valid string", "valid-value", false),
+      Arguments.of("String with content and spaces", " valid ", false),
+      Arguments.of("Number zero", 0, false),
+      Arguments.of("Boolean false", false, false),
+      Arguments.of("Boolean true", true, false),
+      Arguments.of("Non-empty object", Map.of("key", "value"), false)
+    );
+  }
+}

--- a/src/test/java/org/folio/services/item/PatchDataTest.java
+++ b/src/test/java/org/folio/services/item/PatchDataTest.java
@@ -1,0 +1,131 @@
+package org.folio.services.item;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Map;
+import java.util.stream.Stream;
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.rest.jaxrs.model.ItemPatch;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@DisplayName("PatchData Tests")
+class PatchDataTest {
+
+  private PatchData patchData;
+
+  @BeforeEach
+  void setUp() {
+    var oldItem = new Item();
+    oldItem.setId("old-item-id");
+    oldItem.setHoldingsRecordId("old-holdings-id");
+
+    patchData = new PatchData();
+    patchData.setOldItem(oldItem);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideFalseTestCases")
+  @DisplayName("Should return false when hasChanges conditions are not met")
+  void hasChanges_shouldReturnFalse(String description, ItemPatch itemPatch, Item oldItemOverride) {
+    // Given
+    if (oldItemOverride != null) {
+      patchData.setOldItem(oldItemOverride);
+    }
+    patchData.setPatchRequest(itemPatch);
+
+    // When
+    var hasChanges = patchData.hasChanges();
+    
+    // Then
+    assertFalse(hasChanges, description);
+  }
+
+  @ParameterizedTest
+  @MethodSource("provideTrueTestCases")
+  @DisplayName("Should return true when hasChanges conditions are met")
+  void hasChanges_shouldReturnTrue(String description, ItemPatch itemPatch, Item oldItemOverride) {
+    // Given
+    if (oldItemOverride != null) {
+      patchData.setOldItem(oldItemOverride);
+    }
+    patchData.setPatchRequest(itemPatch);
+
+    // When
+    var hasChanges = patchData.hasChanges();
+    
+    // Then
+    assertTrue(hasChanges, description);
+  }
+
+  private static Stream<Arguments> provideFalseTestCases() {
+    return Stream.of(
+      Arguments.of(
+        "No additional properties exist",
+        new ItemPatch(),
+        null
+      ),
+      Arguments.of(
+        "Only holdingsRecordId is present and unchanged",
+        new ItemPatch().withAdditionalProperty("holdingsRecordId", "old-holdings-id"),
+        null
+      ),
+      Arguments.of(
+        "HoldingsRecordId is null in both old and patch",
+        new ItemPatch().withAdditionalProperty("holdingsRecordId", null),
+        new Item().withId("old-item-id").withHoldingsRecordId(null)
+      ),
+      Arguments.of(
+        "Empty string holdingsRecordId in both old and patch",
+        new ItemPatch().withAdditionalProperty("holdingsRecordId", ""),
+        new Item().withId("old-item-id").withHoldingsRecordId("")
+      )
+    );
+  }
+
+  private static Stream<Arguments> provideTrueTestCases() {
+    return Stream.of(
+      Arguments.of(
+        "Only holdingsRecordId is present and changed",
+        new ItemPatch().withAdditionalProperty("holdingsRecordId", "different-holdings-id"),
+        null
+      ),
+      Arguments.of(
+        "HoldingsRecordId changes from non-null to null",
+        new ItemPatch().withAdditionalProperty("holdingsRecordId", null),
+        null
+      ),
+      Arguments.of(
+        "Other properties are present",
+        new ItemPatch().withAdditionalProperty("materialTypeId", "some-material-type-id"),
+        null
+      ),
+      Arguments.of(
+        "Multiple properties including holdingsRecordId are present",
+        new ItemPatch()
+          .withAdditionalProperty("holdingsRecordId", "old-holdings-id")
+          .withAdditionalProperty("materialTypeId", "some-material-type-id"),
+        null
+      ),
+      Arguments.of(
+        "Status property is present",
+        new ItemPatch().withAdditionalProperty("status", Map.of("name", "Available")),
+        null
+      ),
+      Arguments.of(
+        "PermanentLoanTypeId property is present",
+        new ItemPatch().withAdditionalProperty("permanentLoanTypeId", "loan-type-id"),
+        null
+      ),
+      Arguments.of(
+        "HoldingsRecordId changes from empty string to actual value",
+        new ItemPatch().withAdditionalProperty("holdingsRecordId", "new-holdings-id"),
+        new Item().withId("old-item-id").withHoldingsRecordId("")
+      )
+    );
+  }
+}


### PR DESCRIPTION
### Purpose
[MODINVSTOR-1441](https://folio-org.atlassian.net/browse/MODINVSTOR-1441) Create a new API to support the update of items' order.
Implement the `PATCH /item-storage/items` endpoint to support partial updates of items in batches.

### Approach
Request body field details:
- `id` - required UUID-string field for item identification
- `_version` - required integer field for optimistic locking support
The request could also contain other item schema fields.

The logic of item update:
All the same validations as single item PUT
+ validations of required fields

### Changes Checklist
- [x] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Screenshots (if applicable)
Instance created with two holdings records, each holdings record has different call number type + call number, 3 items created for 1'st holdings:
<img width="678" height="418" alt="items-before" src="https://github.com/user-attachments/assets/35c0bcc8-8963-4682-9b33-9a106cbd4972" />
Effective values for item2:
<img width="492" height="233" alt="effective-values-before" src="https://github.com/user-attachments/assets/5c02e13a-9e2e-4ae4-9478-1dbc0b2eab21" />
PATCH request executed with body changing order of all items + moving item2 to another holdings record:
<img width="617" height="505" alt="request" src="https://github.com/user-attachments/assets/6c86b43f-ae73-44a4-9bab-8f122923f0ca" />
Items afterwards:
<img width="735" height="505" alt="items-after" src="https://github.com/user-attachments/assets/779cb665-2260-4b53-a7a7-c5f1dd783540" />
Effective values of item2 after update:
<img width="402" height="148" alt="effective-values-after png" src="https://github.com/user-attachments/assets/b4264142-d20f-4c8b-9d3d-e0180f137b07" />
