### PR TITLE
Modinvstor 1446

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 ### Features
 * Create feature flag for enabling optimization to prevent redundant updates in Inventory (Instance,Holding,Item) ([MODINVSTOR-1577](https://folio-org.atlassian.net/browse/MODINVSTOR-1577))
+* Integrate folio-custom-fields for item ([MODINVSTOR-1446](https://folio-org.atlassian.net/browse/MODINVSTOR-1446))
 
 ### Bug fixes
 * Populate item and holdings `hrId` in the items-and-holdings view ([MODINVSTOR-1587](https://folio-org.atlassian.net/browse/MODINVSTOR-1587))

--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,8 @@
 ### New APIs versions
 * Provides `settings v1.0`
 * Requires `API_NAME vX.Y`
+* Provides `item-storage v11.3`
+* Provides `custom-fields v3.1`
 
 ### Features
 * Create feature flag for enabling optimization to prevent redundant updates in Inventory (Instance,Holding,Item) ([MODINVSTOR-1577](https://folio-org.atlassian.net/browse/MODINVSTOR-1577))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1442,27 +1442,41 @@
         {
           "methods": ["GET"],
           "pathPattern": "/custom-fields",
-          "permissionsRequired": ["inventory-storage.custom.fields.collection.get"]
+          "permissionsRequired": ["inventory-storage.custom-fields.collection.get"]
+        },
+        {
+          "methods": ["PUT"],
+          "pathPattern": "/custom-fields",
+          "permissionsRequired": ["inventory-storage.custom-fields.collection.put"]
         },
         {
           "methods": ["POST"],
           "pathPattern": "/custom-fields",
-          "permissionsRequired": ["inventory-storage.custom.fields.item.post"]
+          "permissionsRequired": ["inventory-storage.custom-fields.item.post"]
         },
         {
           "methods": ["GET"],
           "pathPattern": "/custom-fields/{id}",
-          "permissionsRequired": ["inventory-storage.custom.fields.item.get"]
+          "permissionsRequired": ["inventory-storage.custom-fields.item.get"]
         },
         {
           "methods": ["PUT"],
           "pathPattern": "/custom-fields/{id}",
-          "permissionsRequired": ["inventory-storage.custom.fields.item.put"]
+          "permissionsRequired": ["inventory-storage.custom-fields.item.put"]
         },
         {
           "methods": ["DELETE"],
           "pathPattern": "/custom-fields/{id}",
-          "permissionsRequired": ["inventory-storage.custom.fields.item.delete"]
+          "permissionsRequired": ["inventory-storage.custom-fields.item.delete"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/custom-fields/stats/{id}",
+          "permissionRequired": ["inventory-storage.custom-fields.item.stats.get"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "custom-fields/option/stats/"
         }
       ]
     }
@@ -1648,6 +1662,62 @@
       "permissionName": "inventory-storage.instances.item.delete",
       "displayName": "inventory storage - delete individual instance",
       "description": "delete individual instance from storage"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.collection.get",
+      "displayName": "Custom Fields - get collection",
+      "description": "Get Custom Fields collection"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.collection.put",
+      "displayName": "Custom Fields - put collection",
+      "description": "Put Custom Fields collection"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.item.post",
+      "displayName": "Custom Fields - create field",
+      "description": "Create Custom Field"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.item.get",
+      "displayName": "Custom Fields - get field",
+      "description": "Get Custom Field"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.item.put",
+      "displayName": "Custom Fields - modify field",
+      "description": "Modify Custom Field"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.item.delete",
+      "displayName": "Custom Fields - delete field",
+      "description": "Delete Custom Field"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.item.stats.get",
+      "displayName": "Custom Fields - get item usage statistic",
+      "description": "Get Custom Field Statistic"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.item.option.stats.get",
+      "displayName": "Custom Fields - get item option usage statistic",
+      "description": "Get Custom Field Option Statistic"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.all",
+      "displayName": "Custom Fields module - all permissions",
+      "description": "Entire set of permissions needed to use the custom fields module",
+      "subPermissions": [
+        "inventory-storage.custom-fields.collection.get",
+        "inventory-storage.custom-fields.collection.put",
+        "inventory-storage.custom-fields.item.post",
+        "inventory-storage.custom-fields.item.get",
+        "inventory-storage.custom-fields.item.put",
+        "inventory-storage.custom-fields.item.delete",
+        "inventory-storage.custom-fields.item.stats.get",
+        "inventory-storage.custom-fields.item.option.stats.get"
+      ],
+      "visible": false
     },
     {
       "permissionName": "inventory-storage.instances.preceding-succeeding-titles.collection.put",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1436,7 +1436,7 @@
     },
     {
       "id": "custom-fields",
-      "version": "1.0",
+      "version": "3.0",
       "interfaceType" : "multiple",
       "handlers": [
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1433,6 +1433,38 @@
           "permissionsRequired": ["inventory-storage.migration.job.item.delete"]
         }
       ]
+    },
+    {
+      "id": "custom-fields",
+      "version": "1.0",
+      "interfaceType" : "multiple",
+      "handlers": [
+        {
+          "methods": ["GET"],
+          "pathPattern": "/custom-fields",
+          "permissionsRequired": ["inventory-storage.custom.fields.collection.get"]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/custom-fields",
+          "permissionsRequired": ["inventory-storage.custom.fields.item.post"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/custom-fields/{id}",
+          "permissionsRequired": ["inventory-storage.custom.fields.item.get"]
+        },
+        {
+          "methods": ["PUT"],
+          "pathPattern": "/custom-fields/{id}",
+          "permissionsRequired": ["inventory-storage.custom.fields.item.put"]
+        },
+        {
+          "methods": ["DELETE"],
+          "pathPattern": "/custom-fields/{id}",
+          "permissionsRequired": ["inventory-storage.custom.fields.item.delete"]
+        }
+      ]
     }
   ],
   "optional": [

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1471,12 +1471,12 @@
         },
         {
           "methods": ["GET"],
-          "pathPattern": "/custom-fields/stats/{id}",
+          "pathPattern": "/custom-fields/{id}/stats",
           "permissionsRequired": ["inventory-storage.custom-fields.item.stats.get"]
         },
         {
           "methods": ["GET"],
-          "pathPattern": "custom-fields/option/stats/",
+          "pathPattern": "/custom-fields/{id}/options/{optId}/stats",
           "permissionsRequired": ["inventory-storage.custom-fields.item.option.stats.get"]
         }
       ]

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1472,11 +1472,12 @@
         {
           "methods": ["GET"],
           "pathPattern": "/custom-fields/stats/{id}",
-          "permissionRequired": ["inventory-storage.custom-fields.item.stats.get"]
+          "permissionsRequired": ["inventory-storage.custom-fields.item.stats.get"]
         },
         {
           "methods": ["GET"],
-          "pathPattern": "custom-fields/option/stats/"
+          "pathPattern": "custom-fields/option/stats/",
+          "permissionsRequired": ["inventory-storage.custom-fields.item.option.stats.get"]
         }
       ]
     }

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1455,7 +1455,7 @@
     },
     {
       "id": "custom-fields",
-      "version": "3.0",
+      "version": "4.0",
       "interfaceType": "multiple",
       "handlers": [
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1451,7 +1451,86 @@
           "pathPattern": "/inventory-settings/{key}",
           "permissionsRequired": ["inventory-storage.settings.item.patch"]
         }
-       ]
+      ]
+    },
+    {
+      "id": "custom-fields",
+      "version": "3.0",
+      "interfaceType": "multiple",
+      "handlers": [
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/custom-fields",
+          "permissionsRequired": [
+            "inventory-storage.custom-fields.collection.get"
+          ]
+        },
+        {
+          "methods": [
+            "PUT"
+          ],
+          "pathPattern": "/custom-fields",
+          "permissionsRequired": [
+            "inventory-storage.custom-fields.collection.put"
+          ]
+        },
+        {
+          "methods": [
+            "POST"
+          ],
+          "pathPattern": "/custom-fields",
+          "permissionsRequired": [
+            "inventory-storage.custom-fields.item.post"
+          ]
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/custom-fields/{id}",
+          "permissionsRequired": [
+            "inventory-storage.custom-fields.item.get"
+          ]
+        },
+        {
+          "methods": [
+            "PUT"
+          ],
+          "pathPattern": "/custom-fields/{id}",
+          "permissionsRequired": [
+            "inventory-storage.custom-fields.item.put"
+          ]
+        },
+        {
+          "methods": [
+            "DELETE"
+          ],
+          "pathPattern": "/custom-fields/{id}",
+          "permissionsRequired": [
+            "inventory-storage.custom-fields.item.delete"
+          ]
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/custom-fields/{id}/stats",
+          "permissionsRequired": [
+            "inventory-storage.custom-fields.item.stats.get"
+          ]
+        },
+        {
+          "methods": [
+            "GET"
+          ],
+          "pathPattern": "/custom-fields/{id}/options/{optId}/stats",
+          "permissionsRequired": [
+            "inventory-storage.custom-fields.item.option.stats.get"
+          ]
+        }
+      ]
     }
   ],
   "optional": [
@@ -1635,6 +1714,62 @@
       "permissionName": "inventory-storage.instances.item.delete",
       "displayName": "inventory storage - delete individual instance",
       "description": "delete individual instance from storage"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.collection.get",
+      "displayName": "Custom Fields - get collection",
+      "description": "Get Custom Fields collection"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.collection.put",
+      "displayName": "Custom Fields - put collection",
+      "description": "Put Custom Fields collection"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.item.post",
+      "displayName": "Custom Fields - create field",
+      "description": "Create Custom Field"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.item.get",
+      "displayName": "Custom Fields - get field",
+      "description": "Get Custom Field"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.item.put",
+      "displayName": "Custom Fields - modify field",
+      "description": "Modify Custom Field"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.item.delete",
+      "displayName": "Custom Fields - delete field",
+      "description": "Delete Custom Field"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.item.stats.get",
+      "displayName": "Custom Fields - get item usage statistic",
+      "description": "Get Custom Field Statistic"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.item.option.stats.get",
+      "displayName": "Custom Fields - get item option usage statistic",
+      "description": "Get Custom Field Option Statistic"
+    },
+    {
+      "permissionName": "inventory-storage.custom-fields.all",
+      "displayName": "Custom Fields module - all permissions",
+      "description": "Entire set of permissions needed to use the custom fields module",
+      "subPermissions": [
+        "inventory-storage.custom-fields.collection.get",
+        "inventory-storage.custom-fields.collection.put",
+        "inventory-storage.custom-fields.item.post",
+        "inventory-storage.custom-fields.item.get",
+        "inventory-storage.custom-fields.item.put",
+        "inventory-storage.custom-fields.item.delete",
+        "inventory-storage.custom-fields.item.stats.get",
+        "inventory-storage.custom-fields.item.option.stats.get"
+      ],
+      "visible": false
     },
     {
       "permissionName": "inventory-storage.instances.preceding-succeeding-titles.collection.put",

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1455,7 +1455,7 @@
     },
     {
       "id": "custom-fields",
-      "version": "4.0",
+      "version": "3.1",
       "interfaceType": "multiple",
       "handlers": [
         {

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -24,7 +24,7 @@
     },
     {
       "id": "item-storage",
-      "version": "11.2",
+      "version": "11.3",
       "handlers": [
         {
           "methods": ["GET"],

--- a/mod-inventory-storage-server/pom.xml
+++ b/mod-inventory-storage-server/pom.xml
@@ -66,6 +66,11 @@
       <artifactId>folio-s3-client</artifactId>
       <version>${folio-s3-client.version}</version>
     </dependency>
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-custom-fields</artifactId>
+      <version>2.3.1</version>
+    </dependency>
 
     <!-- Test Dependencies  -->
     <dependency>

--- a/mod-inventory-storage-server/pom.xml
+++ b/mod-inventory-storage-server/pom.xml
@@ -69,7 +69,7 @@
     <dependency>
       <groupId>org.folio</groupId>
       <artifactId>folio-custom-fields</artifactId>
-      <version>2.3.1</version>
+      <version>${folio-custom-fields.version}</version>
     </dependency>
 
     <!-- Test Dependencies  -->

--- a/mod-inventory-storage-server/pom.xml
+++ b/mod-inventory-storage-server/pom.xml
@@ -66,7 +66,12 @@
       <artifactId>folio-liquibase-util</artifactId>
       <version>1.11.0</version>
     </dependency>
- 
+    <dependency>
+      <groupId>org.folio</groupId>
+      <artifactId>folio-custom-fields</artifactId>
+      <version>${folio-custom-fields.version}</version>
+    </dependency>
+
     <!-- Test Dependencies  -->
     <dependency>
       <groupId>io.vertx</groupId>

--- a/mod-inventory-storage-server/src/main/java/org/folio/services/record/RecordServiceFactoryImpl.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/services/record/RecordServiceFactoryImpl.java
@@ -1,0 +1,17 @@
+package org.folio.services.record;
+
+import io.vertx.core.Vertx;
+import java.util.Map;
+import org.folio.service.RecordService;
+import org.folio.service.RecordServiceImpl;
+import org.folio.service.spi.RecordServiceFactory;
+
+public class RecordServiceFactoryImpl implements RecordServiceFactory {
+
+  @Override
+  public RecordService create(Vertx vertx) {
+    return RecordServiceImpl.createForSingleTable(
+      vertx,
+      Map.of("item", "item"));
+  }
+}

--- a/mod-inventory-storage-server/src/main/resources/META-INF/services/org.folio.service.spi.RecordServiceFactory
+++ b/mod-inventory-storage-server/src/main/resources/META-INF/services/org.folio.service.spi.RecordServiceFactory
@@ -1,0 +1,1 @@
+org.folio.services.record.RecordServiceFactoryImpl

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/create_custom_fields_indexes.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/create_custom_fields_indexes.sql
@@ -1,0 +1,118 @@
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.check_values_and_get_tablename(jsonb_data jsonb)
+RETURNS TEXT
+AS $$
+DECLARE
+    table_name TEXT;
+BEGIN
+    -- Check if the required keys are present in the jsonb column
+    IF (jsonb_data->>'refId') IS NULL
+      OR (jsonb_data->>'type') IS NULL
+      OR (jsonb_data->>'entityType') IS NULL THEN
+          RAISE EXCEPTION 'One or more required keys (refId, type, entityType) are missing in the jsonb column';
+          RETURN NULL;
+    ELSE
+        -- Set the tableName variable based on the entityType value
+        IF (jsonb_data->>'entityType') = 'item' THEN
+            table_name := 'item';
+        ELSE
+            RAISE EXCEPTION 'Invalid entityType value: %', jsonb_data->>'entityType';
+            RETURN NULL;
+        END IF;
+    END IF;
+
+    RETURN table_name;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.create_custom_fields_indexes(jsonb_data jsonb)
+RETURNS VOID AS $$
+DECLARE
+    index_name TEXT;
+    schema_name TEXT;
+    table_name TEXT;
+    ref_id TEXT;
+BEGIN
+    table_name := ${myuniversity}_${mymodule}.check_values_and_get_tablename(jsonb_data);
+    ref_id := jsonb_data->>'refId';
+    schema_name := '${myuniversity}_${mymodule}';
+    index_name := table_name || '_custom_fields_' || ref_id || '_idx_gin';
+
+    -- create gin index for custom field
+    EXECUTE FORMAT(
+      'CREATE INDEX IF NOT EXISTS %I ON %I.%I USING GIN (lower(%I.f_unaccent(jsonb->''customFields''->>''%s'')) public.gin_trgm_ops)',
+      index_name,
+      schema_name,
+      table_name,
+      schema_name,
+      ref_id
+    );
+
+    -- create another btree index if custom field is of type DATE_PICKER
+    IF (jsonb_data->>'type' = 'DATE_PICKER') THEN
+        index_name := table_name || '_custom_fields_' || ref_id || '_idx';
+        EXECUTE FORMAT(
+          'CREATE INDEX IF NOT EXISTS %I ON %I.%I USING BTREE ((jsonb->''customFields''->>''%s''))',
+          index_name,
+          schema_name,
+          table_name,
+          ref_id
+        );
+    END IF;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.drop_custom_fields_indexes(jsonb_data jsonb)
+RETURNS VOID AS $$
+DECLARE
+    index_name TEXT;
+    index_name2 TEXT;
+    schema_name TEXT;
+    table_name TEXT;
+    ref_id TEXT;
+BEGIN
+    table_name := ${myuniversity}_${mymodule}.check_values_and_get_tablename(jsonb_data);
+    ref_id := jsonb_data->>'refId';
+    schema_name := '${myuniversity}_${mymodule}';
+    index_name := table_name || '_custom_fields_' || ref_id || '_idx_gin';
+    index_name2 := table_name || '_custom_fields_' || ref_id || '_idx';
+
+    -- drop gin and btree index if they exist
+    EXECUTE FORMAT('DROP INDEX IF EXISTS %I.%I', schema_name, index_name);
+    EXECUTE FORMAT('DROP INDEX IF EXISTS %I.%I', schema_name, index_name2);
+END;
+$$ LANGUAGE plpgsql;
+
+-- create trigger functions
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.custom_fields_create_idx()
+RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM ${myuniversity}_${mymodule}.create_custom_fields_indexes(NEW.jsonb);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql
+SECURITY DEFINER;
+
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.custom_fields_drop_idx()
+RETURNS TRIGGER AS $$
+BEGIN
+    PERFORM ${myuniversity}_${mymodule}.drop_custom_fields_indexes(OLD.jsonb);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql
+SECURITY DEFINER;
+
+-- create triggers
+DROP TRIGGER IF EXISTS trigger_custom_fields_insert ON ${myuniversity}_${mymodule}.custom_fields;
+CREATE TRIGGER trigger_custom_fields_insert
+AFTER INSERT ON ${myuniversity}_${mymodule}.custom_fields
+FOR EACH ROW
+EXECUTE PROCEDURE ${myuniversity}_${mymodule}.custom_fields_create_idx();
+
+DROP TRIGGER IF EXISTS trigger_custom_fields_delete ON ${myuniversity}_${mymodule}.custom_fields;
+CREATE TRIGGER trigger_custom_fields_delete
+AFTER DELETE ON ${myuniversity}_${mymodule}.custom_fields
+FOR EACH ROW
+EXECUTE PROCEDURE ${myuniversity}_${mymodule}.custom_fields_drop_idx();
+
+-- create indexes for existing custom fields if they do not exist
+SELECT ${myuniversity}_${mymodule}.create_custom_fields_indexes(jsonb) FROM ${myuniversity}_${mymodule}.custom_fields;

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/item/item_table.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/item/item_table.sql
@@ -1,2 +1,2 @@
-CREATE INDEX IF NOT EXISTS item_customfields_recordservice_idx_gin ON ${myuniversity}_${mymodule}.po_line
+CREATE INDEX IF NOT EXISTS item_customfields_recordservice_idx_gin ON ${myuniversity}_${mymodule}.item
   USING GIN ((jsonb->'customFields'));

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/item/item_table.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/item/item_table.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS item_customfields_recordservice_idx_gin ON ${myuniversity}_${mymodule}.po_line
+  USING GIN ((jsonb->'customFields'));

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/item/item_table.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/item/item_table.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS item_customfields_recordservice_idx_gin ON ${myuniversity}_${mymodule}.item
+  USING GIN ((jsonb->'customFields'));

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -6,6 +6,11 @@
       "fromModuleVersion": "1.0"
     },
     {
+      "run": "after",
+      "snippetPath": "create_custom_fields_indexes.sql",
+      "fromModuleVersion": "mod-inventory-storage-29.0.12"
+    },
+    {
       "tableName": "authority",
       "mode": "delete",
       "withMetadata": true,

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -1,6 +1,11 @@
 {
   "tables": [
     {
+      "run": "after",
+      "snippetPath": "create_custom_fields_table.sql",
+      "fromModuleVersion": "1.0"
+    },
+    {
       "tableName": "authority",
       "mode": "delete",
       "withMetadata": true,

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -1,16 +1,6 @@
 {
   "tables": [
     {
-      "run": "after",
-      "snippetPath": "create_custom_fields_table.sql",
-      "fromModuleVersion": "1.0"
-    },
-    {
-      "run": "after",
-      "snippetPath": "create_custom_fields_indexes.sql",
-      "fromModuleVersion": "mod-inventory-storage-29.0.12"
-    },
-    {
       "tableName": "authority",
       "mode": "delete",
       "withMetadata": true,
@@ -1371,6 +1361,16 @@
     {
       "run": "after",
       "snippetPath": "instance/createInstanceNotesStaffOnlyIndex.sql",
+      "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "create_custom_fields_table.sql",
+      "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "create_custom_fields_indexes.sql",
       "fromModuleVersion": "30.0.0"
     }
   ]

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -890,6 +890,16 @@
     {
       "run": "after",
       "snippetPath": "change_function_owner.sql"
+    },
+    {
+      "run": "after",
+      "snippetPath": "create_custom_fields_table.sql",
+      "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "create_custom_fields_indexes.sql",
+      "fromModuleVersion": "30.0.0"
     }
   ]
 }

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -894,12 +894,12 @@
     {
       "run": "after",
       "snippetPath": "create_custom_fields_table.sql",
-      "fromModuleVersion": "30.0.0"
+      "fromModuleVersion": "30.1.0"
     },
     {
       "run": "after",
       "snippetPath": "create_custom_fields_indexes.sql",
-      "fromModuleVersion": "30.0.0"
+      "fromModuleVersion": "30.1.0"
     }
   ]
 }

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
@@ -4,6 +4,8 @@ import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
 import static org.folio.utility.ModuleUtility.getClient;
 import static org.folio.utility.ModuleUtility.vertxUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
@@ -198,7 +200,9 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
         headers,
         TENANT_ID,
         ResponseHandler.any(createCompleted));
-    return get(createCompleted);
+    Response response = get(createCompleted);
+    assertThat(response.getStatusCode(), is(201));
+    return response;
   }
 
   private Response getCustomFieldAndExpectText() {

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
@@ -34,30 +34,79 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
 
   private final UUID userId = UUID.randomUUID();
-  private final JsonObject meta = new JsonObject()
-      .put("creation_date", "2016-11-05T07:23")
-      .put("last_login_date", "");
-
-  private final JsonObject personal = new JsonObject()
-      .put("lastName", "Handey")
-      .put("firstName", "Jack")
-      .put("preferredFirstName", "Jackie")
-      .put("email", "jhandey@biglibrary.org")
-      .put("phone", "2125551212");
-
-  private final JsonObject user = new JsonObject()
-      .put("username", "jhandey")
-      .put("id", userId)
-      .put("active", true)
-      .put("type", "patron")
-      .put("patronGroup", "4bb563d9-3f9d-4e1e-8d1d-04e75666d68f")
-      .put("meta", meta)
-      .put("personal", personal);
-
+  private final JsonObject user = createSimpleUser(userId);
+  private UUID holdingId;
   private final List<JsonObject> simpleItems = List
       .of(simpleItem(), simpleItem(), simpleItem());
-
   private final List<CustomField> customFields = createCustomFields("item");
+
+  @Before
+  public void beforeEach() {
+    StorageTestSuite.deleteAll(itemsStorageUrl(""));
+    removeAllEvents();
+    // folio-custom-field depends on UserService information for saving custom
+    // fields
+    WireMock.stubFor(WireMock.get("/users/" + userId)
+        .willReturn(WireMock.okJson(user.encode())));
+    holdingId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
+  }
+
+  @After
+  public void afterEach() {
+    StorageTestSuite.deleteAll(itemsStorageUrl(""));
+    removeAllEvents();
+  }
+
+  @Test
+  public void testAddCustomFieldsToItem() {
+    // given
+    IndividualResource item1 = saveItem(simpleItems.get(0).put("holdingsRecordId", holdingId.toString()));
+    Response response = saveCustomFieldAndExpectText(customFields.get(0));
+    saveCustomFieldAndExpectText(customFields.get(1));
+    saveCustomFieldAndExpectText(customFields.get(2));
+    Response response3 = getCustomFieldAndExpectText();
+    simpleItems.get(0);
+    // when
+    // add customfield to item1
+    // then
+    // customfield has an entry customfield with reference to the customfield object
+    // and a value
+  }
+
+  @Test
+  public void putCustomFields() {
+
+  }
+
+  @Test
+  public void postCustomFields() {
+
+  }
+
+  @Test
+  public void getCustomFieldById() {
+
+  }
+
+  @Test
+  public void putCustomFieldById() {
+
+  }
+
+  @Test
+  public void deleteCustomFieldById() {
+
+  }
+
+  @Test
+  public void getCustomFieldStatsById() {
+
+  }
+
+  @Test
+  public void getCustomFieldOptionStats() {
+
+  }
 
   private List<CustomField> createCustomFields(String entityType) {
     CustomField textbox = new CustomField()
@@ -142,71 +191,25 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
     return itemsClient.create(itemToCreate);
   }
 
-  @Before
-  public void beforeEach() {
-    StorageTestSuite.deleteAll(itemsStorageUrl(""));
-    removeAllEvents();
-    // folio-custom-field depends on UserService information for saving custom
-    // fields
-    WireMock.stubFor(WireMock.get("/users/" + userId)
-        .willReturn(WireMock.okJson(user.encode())));
-  }
+  private JsonObject createSimpleUser(UUID newUserId) {
+    JsonObject meta = new JsonObject()
+        .put("creation_date", "2016-11-05T07:23")
+        .put("last_login_date", "");
 
-  @After
-  public void afterEach() {
-    StorageTestSuite.deleteAll(itemsStorageUrl(""));
-    removeAllEvents();
-  }
+    JsonObject personal = new JsonObject()
+        .put("lastName", "Handey")
+        .put("firstName", "Jack")
+        .put("preferredFirstName", "Jackie")
+        .put("email", "jhandey@biglibrary.org")
+        .put("phone", "2125551212");
 
-  @Test
-  public void testGetCustomFields() {
-    // given
-    UUID holdingId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
-    IndividualResource item1 = saveItem(simpleItems.get(0).put("holdingsRecordId", holdingId.toString()));
-    Response response = saveCustomFieldAndExpectText(customFields.get(0));
-    saveCustomFieldAndExpectText(customFields.get(1));
-    saveCustomFieldAndExpectText(customFields.get(2));
-    Response response3 = getCustomFieldAndExpectText();
-    simpleItems.get(0);
-    // when
-    // add customfield to item1
-    // then
-    // customfield has an entry customfield with reference to the customfield object
-    // and a value
-  }
-
-  @Test
-  public void putCustomFields() {
-
-  }
-
-  @Test
-  public void postCustomFields() {
-
-  }
-
-  @Test
-  public void getCustomFieldById() {
-
-  }
-
-  @Test
-  public void putCustomFieldById() {
-
-  }
-
-  @Test
-  public void deleteCustomFieldById() {
-
-  }
-
-  @Test
-  public void getCustomFieldStatsById() {
-
-  }
-
-  @Test
-  public void getCustomFieldOptionStats() {
-
+    return new JsonObject()
+        .put("username", "jhandey")
+        .put("id", newUserId)
+        .put("active", true)
+        .put("type", "patron")
+        .put("patronGroup", "4bb563d9-3f9d-4e1e-8d1d-04e75666d68f")
+        .put("meta", meta)
+        .put("personal", personal);
   }
 }

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
@@ -1,0 +1,188 @@
+package org.folio.rest.api;
+
+import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
+import static org.folio.utility.ModuleUtility.getClient;
+import static org.folio.utility.ModuleUtility.vertxUrl;
+import static org.folio.utility.RestUtility.TENANT_ID;
+
+import io.vertx.core.json.JsonObject;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import junitparams.JUnitParamsRunner;
+
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.rest.jaxrs.model.CustomField;
+import org.folio.rest.jaxrs.model.CustomField.Type;
+import org.folio.rest.jaxrs.model.SelectField;
+import org.folio.rest.jaxrs.model.SelectFieldOption;
+import org.folio.rest.jaxrs.model.SelectFieldOptions;
+import org.folio.rest.support.Response;
+import org.folio.rest.support.ResponseHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitParamsRunner.class)
+public class CustomFieldsApiTest extends TestBase {
+
+  private final UUID userId = UUID.randomUUID();
+
+  private final List<JsonObject> simpleItems = List
+      .of(simpleItem(), simpleItem(), simpleItem());
+
+  private final List<CustomField> customFields = createCustomFields("item");
+
+  private List<CustomField> createCustomFields(String entityType) {
+    CustomField textbox = new CustomField()
+        .withId(UUID.randomUUID().toString())
+        .withName("textbox")
+        .withType(Type.TEXTBOX_SHORT)
+        .withEntityType(entityType);
+    CustomField singleselect = new CustomField()
+        .withId(UUID.randomUUID().toString())
+        .withName("singleselect")
+        .withType(Type.SINGLE_SELECT_DROPDOWN)
+        .withSelectField(
+            new SelectField()
+                .withMultiSelect(false)
+                .withOptions(
+                    new SelectFieldOptions()
+                        .withValues(
+                            Arrays.asList(
+                                new SelectFieldOption().withId("opt_0").withValue("opt0"),
+                                new SelectFieldOption().withId("opt_1").withValue("opt1"),
+                                new SelectFieldOption().withId("opt_2").withValue("opt2")))))
+        .withEntityType(entityType);
+    CustomField multiselect = new CustomField()
+        .withId(UUID.randomUUID().toString())
+        .withName("multiselect")
+        .withType(Type.MULTI_SELECT_DROPDOWN)
+        .withSelectField(
+            new SelectField()
+                .withMultiSelect(true)
+                .withOptions(
+                    new SelectFieldOptions()
+                        .withValues(
+                            Arrays.asList(
+                                new SelectFieldOption().withId("opt_0").withValue("opt0"),
+                                new SelectFieldOption().withId("opt_1").withValue("opt1"),
+                                new SelectFieldOption().withId("opt_2").withValue("opt2"),
+                                new SelectFieldOption().withId("opt_3").withValue("opt3")))))
+        .withEntityType(entityType);
+
+    return List.of(textbox, singleselect, multiselect);
+  }
+
+  private JsonObject simpleItem() {
+    return new JsonObject()
+        .put("id", UUID.randomUUID().toString())
+        .put("status", new JsonObject().put("name", "Available"))
+        .put("holdingsRecordId", UUID.randomUUID().toString())
+        .put("materialTypeId", UUID.randomUUID().toString())
+        .put("permanentLoanTypeId", UUID.randomUUID().toString());
+  }
+
+  private JsonObject itemAddCustomFields(JsonObject itemToCreate, JsonObject customFields) {
+    return itemToCreate.copy().put("customFields", customFields);
+  }
+
+  public static URL customFieldsUrl(String subPath) {
+    return vertxUrl("/custom-fields" + subPath);
+  }
+
+  private Response saveCustomFieldAndExpectText(CustomField customFieldToCreate) {
+    var createCompleted = new CompletableFuture<Response>();
+    getClient().post(
+        customFieldsUrl(""),
+        JsonObject.mapFrom(customFieldToCreate),
+        Map.of(XOkapiHeaders.USER_ID, userId.toString()),
+        TENANT_ID,
+        ResponseHandler.any(createCompleted));
+    return get(createCompleted);
+  }
+
+  // private Response getCustomFieldAndExpectText() {
+  // var createCompleted = new CompletableFuture<Response>();
+  // getClient().get(customFieldsUrl(""), TENANT_ID,
+  // ResponseHandler.any(createCompleted));
+  // return get(createCompleted);
+  // }
+
+  private Response saveItemAndExpectText(JsonObject itemToCreate) {
+    var createCompleted = new CompletableFuture<Response>();
+    getClient().post(
+        itemsStorageUrl(""),
+        itemToCreate,
+        TENANT_ID,
+        ResponseHandler.any(createCompleted));
+    return get(createCompleted);
+  }
+
+  @Before
+  public void beforeEach() {
+    StorageTestSuite.deleteAll(itemsStorageUrl(""));
+    removeAllEvents();
+  }
+
+  @After
+  public void afterEach() {
+    StorageTestSuite.deleteAll(itemsStorageUrl(""));
+    removeAllEvents();
+  }
+
+  @Test
+  public void testGetCustomFields() {
+    // given
+    // Response response2 = saveItemAndExpectText(simpleItems.get(0));
+    Response response = saveCustomFieldAndExpectText(customFields.get(0));
+    // unauthorized, create user or mock UserService.getUserInfo, mocking did not
+    // work
+    // Response response = getCustomFieldAndExpectText();
+    // Response response2 = saveItemAndExpectText(simpleItems.get(0));
+    saveCustomFieldAndExpectText(customFields.get(1));
+    saveCustomFieldAndExpectText(customFields.get(2));
+    simpleItems.get(0);
+    // when
+    // then
+  }
+
+  @Test
+  public void putCustomFields() {
+
+  }
+
+  @Test
+  public void postCustomFields() {
+
+  }
+
+  @Test
+  public void getCustomFieldById() {
+
+  }
+
+  @Test
+  public void putCustomFieldById() {
+
+  }
+
+  @Test
+  public void deleteCustomFieldById() {
+
+  }
+
+  @Test
+  public void getCustomFieldStatsById() {
+
+  }
+
+  @Test
+  public void getCustomFieldOptionStats() {
+
+  }
+}

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
@@ -20,6 +20,7 @@ import org.folio.rest.jaxrs.model.CustomField.Type;
 import org.folio.rest.jaxrs.model.SelectField;
 import org.folio.rest.jaxrs.model.SelectFieldOption;
 import org.folio.rest.jaxrs.model.SelectFieldOptions;
+import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
 import org.junit.After;
@@ -103,9 +104,8 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
     return new JsonObject()
         .put("id", UUID.randomUUID().toString())
         .put("status", new JsonObject().put("name", "Available"))
-        .put("holdingsRecordId", UUID.randomUUID().toString())
-        .put("materialTypeId", UUID.randomUUID().toString())
-        .put("permanentLoanTypeId", UUID.randomUUID().toString());
+        .put("materialTypeId", journalMaterialTypeID)
+        .put("permanentLoanTypeId", canCirculateLoanTypeId);
   }
 
   private JsonObject itemAddCustomFields(JsonObject itemToCreate, JsonObject customFields) {
@@ -131,21 +131,15 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
     return get(createCompleted);
   }
 
-  // private Response getCustomFieldAndExpectText() {
-  // var createCompleted = new CompletableFuture<Response>();
-  // getClient().get(customFieldsUrl(""), TENANT_ID,
-  // ResponseHandler.any(createCompleted));
-  // return get(createCompleted);
-  // }
-
-  private Response saveItemAndExpectText(JsonObject itemToCreate) {
+  private Response getCustomFieldAndExpectText() {
     var createCompleted = new CompletableFuture<Response>();
-    getClient().post(
-        itemsStorageUrl(""),
-        itemToCreate,
-        TENANT_ID,
+    getClient().get(customFieldsUrl(""), TENANT_ID,
         ResponseHandler.any(createCompleted));
     return get(createCompleted);
+  }
+
+  private IndividualResource saveItem(JsonObject itemToCreate) {
+    return itemsClient.create(itemToCreate);
   }
 
   @Before
@@ -167,15 +161,18 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
   @Test
   public void testGetCustomFields() {
     // given
-    // Response response2 = saveItemAndExpectText(simpleItems.get(0));
+    UUID holdingId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
+    IndividualResource item1 = saveItem(simpleItems.get(0).put("holdingsRecordId", holdingId.toString()));
     Response response = saveCustomFieldAndExpectText(customFields.get(0));
-    // Response response = getCustomFieldAndExpectText();
-    // Response response2 = saveItemAndExpectText(simpleItems.get(0));
     saveCustomFieldAndExpectText(customFields.get(1));
     saveCustomFieldAndExpectText(customFields.get(2));
+    Response response3 = getCustomFieldAndExpectText();
     simpleItems.get(0);
     // when
+    // add customfield to item1
     // then
+    // customfield has an entry customfield with reference to the customfield object
+    // and a value
   }
 
   @Test

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
@@ -135,6 +135,18 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
 
   }
 
+  private JsonObject createSelectField(int numberOfValues) {
+    JsonArray values = new JsonArray();
+    for (int i = 0; i < numberOfValues; i++) {
+      values = values.add(new JsonObject().put(ID, "opt_" + i).put(VALUE, "opt" + i));
+    }
+
+    return new JsonObject()
+        .put(MULTI_SELECT, false)
+        .put(OPTIONS, new JsonObject()
+            .put(VALUES, values));
+  }
+
   private List<JsonObject> createCustomFields(String entityType) {
     JsonObject textbox = new JsonObject()
         .put(ID, UUID.randomUUID().toString())
@@ -147,27 +159,14 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
         .put(NAME, "singleselect")
         .put(TYPE, Type.SINGLE_SELECT_DROPDOWN)
         .put(ENTITY_TYPE, entityType)
-        .put(SELECT_FIELD, new JsonObject()
-            .put(MULTI_SELECT, false)
-            .put(OPTIONS, new JsonObject()
-                .put(VALUES, new JsonArray()
-                    .add(new JsonObject().put(ID, "opt_0").put(VALUE, "opt0"))
-                    .add(new JsonObject().put(ID, "opt_1").put(VALUE, "opt1"))
-                    .add(new JsonObject().put(ID, "opt_2").put(VALUE, "opt2")))));
+        .put(SELECT_FIELD, createSelectField(3));
 
     JsonObject multiselect = new JsonObject()
         .put(ID, UUID.randomUUID().toString())
         .put(NAME, "multiselect")
         .put(TYPE, Type.MULTI_SELECT_DROPDOWN)
         .put(ENTITY_TYPE, entityType)
-        .put(SELECT_FIELD, new JsonObject()
-            .put(MULTI_SELECT, true)
-            .put(OPTIONS, new JsonObject()
-                .put(VALUES, new JsonArray()
-                    .add(new JsonObject().put(ID, "opt_0").put(VALUE, "opt0"))
-                    .add(new JsonObject().put(ID, "opt_1").put(VALUE, "opt1"))
-                    .add(new JsonObject().put(ID, "opt_2").put(VALUE, "opt2"))
-                    .add(new JsonObject().put(ID, "opt_3").put(VALUE, "opt3")))));
+        .put(SELECT_FIELD, createSelectField(4));
     return List.of(textbox, singleselect, multiselect);
   }
 

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
@@ -110,9 +110,7 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
     // (textbox, singleselect, multiselect)
     // when
     // saving the custom fields in the database
-    saveCustomField(customFields.get(0));
-    saveCustomField(customFields.get(1));
-    saveCustomField(customFields.get(2));
+    saveCustomFields(List.of(customFields.get(0), customFields.get(1), customFields.get(2)));
     // adding references to the 3 custom fields and
     // corresponding values for each of the items
     JsonObject itemWithCustomField0 = itemAddCustomFields(0);
@@ -201,9 +199,7 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
     // (textbox, singleselect, multiselect)
     // when
     // saving the custom fields in the database
-    saveCustomField(customFields.get(0));
-    saveCustomField(customFields.get(1));
-    saveCustomField(customFields.get(2));
+    saveCustomFields(List.of(customFields.get(0), customFields.get(1), customFields.get(2)));
     // adding references to the 3 custom fields and
     // corresponding values for each of the items
     // and saving the items with custom field values in the database
@@ -448,6 +444,21 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
     Response response = get(updateCompleted);
     assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
     return response;
+  }
+
+  /**
+   * Save the custom fields with the API.
+   * Assert the custom fields got created by checking the status code.
+   * Here we also need to add the mock to a user interface because custom fields
+   * still have dependencies on a user
+   *
+   * @param customFieldsObjects List of JsonObjects representing the custom fields
+   * @return List of Response objects from the creation requests
+   */
+  private List<Response> saveCustomFields(List<JsonObject> customFieldsObjects) {
+    return customFieldsObjects.stream()
+        .map(this::saveCustomField)
+        .toList();
   }
 
   /**

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
@@ -39,6 +39,8 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
   private static final String ACTIVE = "active";
   private static final String CREATION_DATE = "creation_date";
   private static final String CUSTOM_FIELDS = "customFields";
+  private static final String CUSTOM_FIELDS_OPTIONS_STATS_ENDPOINT = "/{id}/options/{optId}/stats";
+  private static final String CUSTOM_FIELDS_STATS_ENDPOINT = "/{id}/stats";
   private static final String CUSTOM_FIELDS_URL = "/custom-fields";
   private static final String EMAIL = "email";
   private static final String ENTITY_TYPE = "entityType";
@@ -53,6 +55,9 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
   private static final String META = "meta";
   private static final String MULTI_SELECT = "multiSelect";
   private static final String NAME = "name";
+  private static final String NAME_MULTISELECT = "multiselect";
+  private static final String NAME_SINGLE_SELECT = "singleselect";
+  private static final String NAME_TEXTBOX = "textbox";
   private static final String OPTIONS = "options";
   private static final String PATRON_GROUP = "patronGroup";
   private static final String PERMANENT_LOAN_TYPE_ID = "permanentLoanTypeId";
@@ -66,30 +71,29 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
   private static final String USERS_URL = "/users/";
   private static final String VALUE = "value";
   private static final String VALUES = "values";
-  private static final String CUSTOM_FIELDS_STATS_ENDPOINT = "/{id}/stats";
-  private static final String CUSTOM_FIELDS_OPTIONS_STATS_ENDPOINT = "/{id}/options/{optId}/stats";
 
-  private final UUID userId = UUID.randomUUID();
-  private final JsonObject user = createSimpleUser(userId);
-  private UUID holdingId;
+  private final List<JsonObject> customFields = createCustomFields(ITEM);
+  private UUID holdingId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
   private final List<JsonObject> simpleItems = List
       .of(simpleItem(), simpleItem(), simpleItem());
-  private final List<JsonObject> customFields = createCustomFields(ITEM);
+  private final UUID userId = UUID.randomUUID();
+  private final JsonObject user = createSimpleUser(userId);
 
   @Before
   public void beforeEach() {
     StorageTestSuite.deleteAll(itemsStorageUrl(""));
+    updateCustomFields(List.of()); // there is no deleteAll
     removeAllEvents();
     // folio-custom-field depends on UserService information for saving custom
     // fields
     WireMock.stubFor(WireMock.get(USERS_URL + userId)
         .willReturn(WireMock.okJson(user.encode())));
-    holdingId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
   }
 
   @After
   public void afterEach() {
     StorageTestSuite.deleteAll(itemsStorageUrl(""));
+    updateCustomFields(List.of());
     removeAllEvents();
   }
 
@@ -126,9 +130,10 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
   }
 
   /**
-   *
+   * Should automatically update the item, when a related custom field is deleted.
    * POST /custom-fields
    * GET /custom-fields
+   * DELETE /custom-fields/{id}
    * GET /custom-fields/{id}/stats
    */
   @Test
@@ -136,79 +141,105 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
     // given
     // simple item and default custom field as JsonObject
     // (textbox)
-    // when
-    // saving the custom field in the database
+    // saved in the database
     assertEquals(0, getCustomFieldsCount());
-    saveCustomField(customFields.get(0));
+    int customFieldIndex = 0;
+    saveCustomField(customFields.get(customFieldIndex));
     assertEquals(1, getCustomFieldsCount());
-    assertEquals(0, getCustomFieldStatisticCount(customFieldsId(0)));
-    // adding references to the custom field and
-    // corresponding value
-    // and saving the items with custom field values in the database
-    IndividualResource item = saveItem(itemAddCustomFields(0, List.of(0)));
-    assertEquals(true, itemContainsCustomField(item, "textbox"));
-    assertEquals(1, getCustomFieldStatisticCount(customFieldsId(0)));
-    deleteCustomField(customFieldsId(0));
+    assertEquals(0, getCustomFieldStatisticCount(customFieldsId(customFieldIndex)));
+    IndividualResource item = saveItem(itemAddCustomFields(0, List.of(customFieldIndex)));
+    assertEquals(true, itemContainsCustomField(item, NAME_TEXTBOX));
+    assertEquals(1, getCustomFieldStatisticCount(customFieldsId(customFieldIndex)));
+    // when
+    // deleting the custom field in the database
+    deleteCustomField(customFieldsId(customFieldIndex));
     // then
-    // the items should be created
     assertEquals(0, getCustomFieldsCount());
     // check that item has no custom field anymore
     IndividualResource updatedItem = getItem(item.getId());
-    assertEquals(false, itemContainsCustomField(updatedItem, "textbox"));
+    assertEquals(false, itemContainsCustomField(updatedItem, NAME_TEXTBOX));
   }
 
   /**
-   * remove single option from custom field
-   * customFieldsPO.get(1).getSelectField().getOptions().getValues().removeFirst();
-   * putCustomField(customFieldsPO.get(1));
-   * 
-   * assertEquals(2,
-   * purchaseOrder1.getCustomFields().getAdditionalProperties().size());
-   * assertNull(purchaseOrder1.getCustomFields().getAdditionalProperties().get("singleselect"));
-   * assertThat(purchaseOrder2, samePropertyValuesAs(purchaseOrders.get(1)));
-   * 
+   * Should automatically update the item, when a related custom field is
+   * updated.
    * POST /custom-fields
    * PUT /custom-fields/{id}
    */
   @Test
-  public void testCustomFieldPut() {
+  public void testPutCustomField() {
     // given
     // simple item and default custom field as JsonObject
-    // (singleselect)
+    // (multiselect)
+    // the simple item with custom field values in the database
+    saveCustomField(customFields.get(2));
+    IndividualResource item = saveItem(itemAddCustomFields(0, List.of(2)));
+    assertEquals(2, getItemMultiselectSize(item));
     // when
-    // saving the custom field in the database
-    saveCustomField(customFields.get(1));
-    // adding references to the custom field and
-    // corresponding value
-    // and saving the items with custom field values in the database
-    IndividualResource item = saveItem(itemAddCustomFields(0, List.of(1)));
-
+    // updating the custom field
+    // (from 4 options to only 2 options)
+    customFields.get(2)
+        .put(SELECT_FIELD, createSelectField(2, true));
+    updateCustomField(customFields.get(2));
+    // then
+    // the reference in the item for custom fields should also be updated
+    // before opt1, opt2; now only opt1, because opt2 was deleted
+    IndividualResource updatedItem = getItem(item.getId());
+    assertEquals(1, getItemMultiselectSize(updatedItem));
   }
 
+  /**
+   * Should automatically update items, when all custom fields are updated and the
+   * rest is deleted.
+   * POST /custom-fields
+   * PUT /custom-fields
+   */
   @Test
-  void testPutPutCustomFieldCollection() {
-    // // populate with sample data
-    // populateSampleData();
+  public void testPutCustomFieldCollection() {
+    // given
+    // 2 simple items and default custom fields as JsonObjects
+    // (textbox, singleselect, multiselect)
+    // when
+    // saving the custom fields in the database
+    saveCustomField(customFields.get(0));
+    saveCustomField(customFields.get(1));
+    saveCustomField(customFields.get(2));
+    // adding references to the 3 custom fields and
+    // corresponding values for each of the items
+    // and saving the items with custom field values in the database
+    JsonObject itemWithCustomField0 = itemAddCustomFields(0);
+    IndividualResource item1 = saveItem(itemWithCustomField0);
+    assertEquals(true, itemCustomFieldsContainsKey(item1, NAME_SINGLE_SELECT));
+    assertEquals(true, itemCustomFieldsContainsKey(item1, NAME_TEXTBOX));
+    assertEquals(true, itemCustomFieldsContainsKey(item1, NAME_MULTISELECT));
+    JsonObject itemWithCustomField1 = itemAddCustomFields(1);
+    IndividualResource item2 = saveItem(itemWithCustomField1);
+    assertEquals(true, itemCustomFieldsContainsKey(item2, NAME_SINGLE_SELECT));
+    assertEquals(true, itemCustomFieldsContainsKey(item2, NAME_TEXTBOX));
+    assertEquals(true, itemCustomFieldsContainsKey(item2, NAME_MULTISELECT));
+    // new custom fields
+    JsonObject newCustomField = customFields.get(2).put(NAME, "newMultiselect").put(ID, UUID.randomUUID().toString());
+    List<JsonObject> customFieldsToUpdate = List.of(newCustomField, customFields.get(0), customFields.get(1));
+    // when
+    // updating custom fields
+    updateCustomFields(customFieldsToUpdate);
+    // then
+    IndividualResource updatedItem1 = getItem(item1.getId());
+    assertEquals(true, itemCustomFieldsContainsKey(updatedItem1, NAME_SINGLE_SELECT));
+    assertEquals(true, itemCustomFieldsContainsKey(updatedItem1, NAME_TEXTBOX));
+    assertEquals(false, itemCustomFieldsContainsKey(updatedItem1, NAME_MULTISELECT));
+    IndividualResource updatedItem2 = getItem(item2.getId());
+    assertEquals(true, itemCustomFieldsContainsKey(updatedItem2, NAME_SINGLE_SELECT));
+    assertEquals(true, itemCustomFieldsContainsKey(updatedItem2, NAME_TEXTBOX));
+    assertEquals(false, itemCustomFieldsContainsKey(updatedItem2, NAME_MULTISELECT));
+  }
 
-    // // remove opt from custom field using PutCustomFieldsCollection
-    // customFieldsPO.get(1).getSelectField().getOptions().getValues().removeFirst();
-    // putCustomFieldCollection(
-    // new PutCustomFieldCollection()
-    // .withCustomFields(customFieldsPO)
-    // .withEntityType("purchase_order"));
+  private boolean itemCustomFieldsContainsKey(IndividualResource item, String key) {
+    return ((JsonObject) item.getJson().getValue(CUSTOM_FIELDS)).containsKey(key);
+  }
 
-    // // POs should be updated
-    // Map<String, PurchaseOrder> allPurchaseOrders = getAllPurchaseOrders();
-    // PurchaseOrder purchaseOrder1 =
-    // allPurchaseOrders.get(purchaseOrders.get(0).getId());
-    // PurchaseOrder purchaseOrder2 =
-    // allPurchaseOrders.get(purchaseOrders.get(1).getId());
-    // assertEquals(2,
-    // purchaseOrder1.getCustomFields().getAdditionalProperties().size());
-    // assertNull(purchaseOrder1.getCustomFields().getAdditionalProperties().get("singleselect"));
-    // assertEquals(3,
-    // purchaseOrder2.getCustomFields().getAdditionalProperties().size());
-    // assertThat(purchaseOrder2, samePropertyValuesAs(purchaseOrders.get(1)));
+  private int getItemMultiselectSize(IndividualResource item) {
+    return ((JsonArray) ((JsonObject) item.getJson().getValue(CUSTOM_FIELDS)).getValue(NAME_MULTISELECT)).size();
   }
 
   private boolean itemContainsCustomField(IndividualResource item, String name) {
@@ -252,37 +283,52 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
   private List<JsonObject> createCustomFields(String entityType) {
     JsonObject textbox = new JsonObject()
         .put(ID, UUID.randomUUID().toString())
-        .put(NAME, "textbox")
+        .put(NAME, NAME_TEXTBOX)
         .put(TYPE, Type.TEXTBOX_SHORT)
         .put(ENTITY_TYPE, entityType);
 
     JsonObject singleselect = new JsonObject()
         .put(ID, UUID.randomUUID().toString())
-        .put(NAME, "singleselect")
+        .put(NAME, NAME_SINGLE_SELECT)
         .put(TYPE, Type.SINGLE_SELECT_DROPDOWN)
         .put(ENTITY_TYPE, entityType)
         .put(SELECT_FIELD, createSelectField(3, false));
 
     JsonObject multiselect = new JsonObject()
         .put(ID, UUID.randomUUID().toString())
-        .put(NAME, "multiselect")
+        .put(NAME, NAME_MULTISELECT)
         .put(TYPE, Type.MULTI_SELECT_DROPDOWN)
         .put(ENTITY_TYPE, entityType)
         .put(SELECT_FIELD, createSelectField(4, true));
     return List.of(textbox, singleselect, multiselect);
   }
 
+  /**
+   * Create custom field values which can be inserted in items.
+   *
+   * @param customFieldIndices indices of the example custom field values to
+   *                           insert
+   * @return JsonObject representing the custom field values
+   */
   private JsonObject createCustomFieldValues(List<Integer> customFieldIndices) {
     JsonObject customFieldValues = new JsonObject();
-    if (customFieldIndices.contains(0))
-      customFieldValues.put("textbox", "text1");
-    if (customFieldIndices.contains(1))
-      customFieldValues.put("singleselect", "opt_0");
-    if (customFieldIndices.contains(2))
-      customFieldValues.put("multiselect", new JsonArray().add("opt_1").add("opt_2"));
+    if (customFieldIndices.contains(0)) {
+      customFieldValues.put(NAME_TEXTBOX, "text1");
+    }
+    if (customFieldIndices.contains(1)) {
+      customFieldValues.put(NAME_SINGLE_SELECT, "opt_0");
+    }
+    if (customFieldIndices.contains(2)) {
+      customFieldValues.put(NAME_MULTISELECT, new JsonArray().add("opt_1").add("opt_2"));
+    }
     return customFieldValues;
   }
 
+  /**
+   * Create a minimal item.
+   *
+   * @return a simple item as JsonObject
+   */
   private JsonObject simpleItem() {
     return new JsonObject()
         .put(ID, UUID.randomUUID().toString())
@@ -302,6 +348,14 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
     return itemAddCustomFields(itemToCreateIndex, List.of(0, 1, 2));
   }
 
+  /**
+   * Add custom field values to the simple item referenced by itemToCreateIndex.
+   *
+   * @param itemToCreateIndex  index of simpleItems
+   * @param customFieldIndices indices of the custom fields which should get added
+   *                           to the item
+   * @return the simple item with added custom fields
+   */
   private JsonObject itemAddCustomFields(int itemToCreateIndex, List<Integer> customFieldIndices) {
     return simpleItems
         .get(itemToCreateIndex)
@@ -315,8 +369,8 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
   }
 
   /**
-   * Save the customfield with the API.
-   * Assert the customfields got created by checking the status code.
+   * Save the custom field with the API.
+   * Assert the custom fields got created by checking the status code.
    * Here we also need to add the mock to a user interface because custom fields
    * still have dependencies on a user
    *
@@ -340,15 +394,73 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
     return response;
   }
 
-  private Response deleteCustomField(String id) {
-    var createCompleted = new CompletableFuture<Response>();
+  /**
+   * Update the custom field with the API.
+   * Assert the custom fields got update by checking the status code.
+   * Here we also need to add the mock to a user interface because custom fields
+   * still have dependencies on a user
+   *
+   * @param customFieldToUpdate The JsonObject representing the custom field
+   * @return Response of the update request
+   */
+  private Response updateCustomField(JsonObject customFieldToUpdate) {
+    var updateCompleted = new CompletableFuture<Response>();
     String usersUrl = HTTP_LOCALHOST + mockServer.port();
     Map<String, String> headers = Map
         .of(XOkapiHeaders.USER_ID, userId.toString(), XOkapiHeaders.URL, usersUrl,
             XOkapiHeaders.URL_TO, usersUrl);
+    getClient().put(
+        customFieldsUrl("/" + customFieldToUpdate.getString(ID)),
+        customFieldToUpdate,
+        headers,
+        TENANT_ID,
+        ResponseHandler.any(updateCompleted));
+    Response response = get(updateCompleted);
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+    return response;
+  }
+
+  /**
+   * Update the custom fields and delete the rest with the API.
+   * Assert the custom fields got update by checking the status code.
+   * Here we also need to add the mock to a user interface because custom fields
+   * still have dependencies on a user
+   *
+   * @param customFieldsToUpdate List of JsonObjects representing the custom
+   *                             fields
+   * @return Response of the update request
+   */
+  private Response updateCustomFields(List<JsonObject> customFieldsToUpdate) {
+    var updateCompleted = new CompletableFuture<Response>();
+    String usersUrl = HTTP_LOCALHOST + mockServer.port();
+    Map<String, String> headers = Map
+        .of(XOkapiHeaders.USER_ID, userId.toString(), XOkapiHeaders.URL, usersUrl,
+            XOkapiHeaders.URL_TO, usersUrl);
+    JsonObject customFieldsObject = new JsonObject()
+        .put(CUSTOM_FIELDS, customFieldsToUpdate)
+        .put(ENTITY_TYPE, ITEM);
+    getClient().put(
+        customFieldsUrl(""),
+        customFieldsObject,
+        headers,
+        TENANT_ID,
+        ResponseHandler.any(updateCompleted));
+    Response response = get(updateCompleted);
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+    return response;
+  }
+
+  /**
+   * Delete the custom field by id with the API.
+   * Assert the custom fields got deleted by checking the status code.
+   *
+   * @param id of the custom field
+   * @return Response of the delete request
+   */
+  private Response deleteCustomField(String id) {
+    var createCompleted = new CompletableFuture<Response>();
     getClient().delete(
         customFieldsUrl("/" + id),
-        headers,
         TENANT_ID,
         ResponseHandler.any(createCompleted));
     Response response = get(createCompleted);
@@ -366,12 +478,24 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
     return itemsClient.create(itemToCreate);
   }
 
+  /**
+   * Get item by UUID.
+   *
+   * @param id UUID of the item you want to get
+   * @return The IndividualResource of the json response of the get request
+   */
   private IndividualResource getItem(UUID id) {
     Response response = itemsClient.getById(id);
     assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_OK));
     return new IndividualResource(response);
   }
 
+  /**
+   * Create a simple user with the specified UUID.
+   *
+   * @param newUserId UUID for the user
+   * @return a JsonObject of the simple user
+   */
   private JsonObject createSimpleUser(UUID newUserId) {
     JsonObject meta = new JsonObject()
         .put(CREATION_DATE, "2016-11-05T07:23")
@@ -394,6 +518,13 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
         .put(PERSONAL, personal);
   }
 
+  /**
+   * Get the custom field statistic count with the API.
+   * Asserts the correct response status
+   *
+   * @param customFieldId id of the custom field
+   * @return count of the custom field statistic as int
+   */
   private int getCustomFieldStatisticCount(String customFieldId) {
     return given()
         .header(new Header(TENANT, TENANT_ID))
@@ -406,6 +537,14 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
         .getCount();
   }
 
+  /**
+   * Get the custom field option statistic count with the API.
+   * Asserts the correct response status
+   *
+   * @param customFieldId id of the custom field
+   * @param optionId      id of the option
+   * @return count of the custom field option statistic as int
+   */
   private int getCustomFieldOptionStatisticCount(String customFieldId, String optionId) {
     return given()
         .header(new Header(TENANT, TENANT_ID))
@@ -418,6 +557,12 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
         .getCount();
   }
 
+  /**
+   * Get the number of custom fields in the database with the API.
+   * Asserts the correct response status
+   *
+   * @return the number of custom fields as int
+   */
   private int getCustomFieldsCount() {
     var createCompleted = new CompletableFuture<Response>();
     getClient().get(

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
@@ -84,20 +84,30 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
     removeAllEvents();
   }
 
+  /*
+   * Create simple items with custom fields.
+   */
   @Test
-  public void testAddCustomFieldsToItem() {
+  public void testSaveItemsWithCustomFields() {
     // given
-    IndividualResource item1 = saveItem(simpleItems.get(0).put(HOLDING_RECORD_ID, holdingId.toString()));
-    Response response = saveCustomFieldAndExpectText(customFields.get(0));
-    saveCustomFieldAndExpectText(customFields.get(1));
-    saveCustomFieldAndExpectText(customFields.get(2));
-    Response response3 = getCustomFieldAndExpectText();
-    simpleItems.get(0);
+    // 3 simple items and default custom fields as JsonObjects
+    // (textbox, singleselect, multiselect)
     // when
-    // add customfield to item1
+    // saving the custom fields in the database
+    saveCustomField(customFields.get(0));
+    saveCustomField(customFields.get(1));
+    saveCustomField(customFields.get(2));
+    // adding references to the 3 custom fields and
+    // corresponding values for each of the items
+    JsonObject itemWithCustomField0 = itemAddCustomFields(0);
+    JsonObject itemWithCustomField1 = itemAddCustomFields(1);
+    JsonObject itemWithCustomField2 = itemAddCustomFields(2);
+    // and saving the items with custom field values in the database
+    saveItem(itemWithCustomField0);
+    saveItem(itemWithCustomField1);
+    saveItem(itemWithCustomField2);
     // then
-    // customfield has an entry customfield with reference to the customfield object
-    // and a value
+    // the items should be created.
   }
 
   @Test

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
@@ -16,10 +16,10 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.util.concurrent.CompletableFuture;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import junitparams.JUnitParamsRunner;
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.jaxrs.model.CustomField.Type;
@@ -29,8 +29,8 @@ import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.runner.RunWith;
 import org.junit.Test;
+import org.junit.runner.RunWith;
 
 @RunWith(JUnitParamsRunner.class)
 public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
@@ -158,7 +158,7 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
   /**
    * Creates a select field or multiselect.
    * Adds numberOfValues options to the select.
-   * 
+   *
    * @param numberOfValues number of options added
    * @param multiselect    flag deciding if result is a select field or a
    *                       multiselect
@@ -167,7 +167,9 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
   private JsonObject createSelectField(int numberOfValues, boolean multiselect) {
     JsonArray values = new JsonArray();
     for (int i = 0; i < numberOfValues; i++) {
-      values = values.add(new JsonObject().put(ID, "opt_" + i).put(VALUE, "opt" + i));
+      values.add(new JsonObject()
+          .put(ID, "opt_" + i)
+          .put(VALUE, "opt" + i));
     }
 
     return new JsonObject()
@@ -179,8 +181,8 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
   /**
    * Create a list of custom fields as json objects for the entityType
    * The list consists of a textbox, a single select and a multi select.
-   * 
-   * @param entityType
+   *
+   * @param entityType The entity type the custom field is added to
    * @return list of custom fields as json objects
    */
   private List<JsonObject> createCustomFields(String entityType) {
@@ -224,7 +226,7 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
   /**
    * Add custom field references by name and values to the specified item
    * by the choosen index in simpleItems.
-   * 
+   *
    * @param itemToCreateIndex index of choosen item from simpleItems
    * @return a complete json object with custom fields
    */
@@ -243,12 +245,11 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
   /**
    * Save the customfield with the API.
    * Assert the customfields got created by checking the status code.
-   * 
    * Here we also need to add the mock to a user interface because custom fields
    * still have dependencies on a user
-   * 
-   * @param customFieldToCreate
-   * @return
+   *
+   * @param customFieldToCreate The JsonObject representing the custom field
+   * @return Response of the creation request
    */
   private Response saveCustomField(JsonObject customFieldToCreate) {
     var createCompleted = new CompletableFuture<Response>();
@@ -269,9 +270,9 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
 
   /**
    * Asserts the item got created by checking the status code.
-   * 
-   * @param itemToCreate
-   * @return
+   *
+   * @param itemToCreate The JsonObject representing the item to create
+   * @return The IndividualResource of the json response of the creation request
    */
   private IndividualResource saveItem(JsonObject itemToCreate) {
     return itemsClient.create(itemToCreate);

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
@@ -7,15 +7,15 @@ import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import com.github.tomakehurst.wiremock.client.WireMock;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.net.URL;
+import java.util.concurrent.CompletableFuture;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import junitparams.JUnitParamsRunner;
-
 import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.jaxrs.model.CustomField.Type;
 import org.folio.rest.support.IndividualResource;
@@ -23,10 +23,8 @@ import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
 import org.junit.After;
 import org.junit.Before;
-import org.junit.Test;
 import org.junit.runner.RunWith;
-
-import com.github.tomakehurst.wiremock.client.WireMock;
+import org.junit.Test;
 
 @RunWith(JUnitParamsRunner.class)
 public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
@@ -10,6 +10,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.concurrent.CompletableFuture;
 import java.util.List;
@@ -209,7 +210,7 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
         TENANT_ID,
         ResponseHandler.any(createCompleted));
     Response response = get(createCompleted);
-    assertThat(response.getStatusCode(), is(201));
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
     return response;
   }
 

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
@@ -5,9 +5,9 @@ import static org.folio.utility.ModuleUtility.getClient;
 import static org.folio.utility.ModuleUtility.vertxUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 
+import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -15,11 +15,7 @@ import java.util.concurrent.CompletableFuture;
 import junitparams.JUnitParamsRunner;
 
 import org.folio.okapi.common.XOkapiHeaders;
-import org.folio.rest.jaxrs.model.CustomField;
 import org.folio.rest.jaxrs.model.CustomField.Type;
-import org.folio.rest.jaxrs.model.SelectField;
-import org.folio.rest.jaxrs.model.SelectFieldOption;
-import org.folio.rest.jaxrs.model.SelectFieldOptions;
 import org.folio.rest.support.IndividualResource;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
@@ -33,12 +29,43 @@ import com.github.tomakehurst.wiremock.client.WireMock;
 @RunWith(JUnitParamsRunner.class)
 public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
 
+  private static final String ACTIVE = "active";
+  private static final String CREATION_DATE = "creation_date";
+  private static final String CUSTOM_FIELDS = "customFields";
+  private static final String CUSTOM_FIELDS_URL = "/custom-fields";
+  private static final String EMAIL = "email";
+  private static final String ENTITY_TYPE = "entityType";
+  private static final String FIRST_NAME = "firstName";
+  private static final String HOLDING_RECORD_ID = "holdingsRecordId";
+  private static final String HTTP_LOCALHOST = "http://localhost:";
+  private static final String ID = "id";
+  private static final String ITEM = "item";
+  private static final String LAST_LOGIN_DATE = "last_login_date";
+  private static final String LAST_NAME = "lastName";
+  private static final String MATERIAL_TYPE_ID = "materialTypeId";
+  private static final String META = "meta";
+  private static final String MULTI_SELECT = "multiSelect";
+  private static final String NAME = "name";
+  private static final String OPTIONS = "options";
+  private static final String PATRON_GROUP = "patronGroup";
+  private static final String PERMANENT_LOAN_TYPE_ID = "permanentLoanTypeId";
+  private static final String PERSONAL = "personal";
+  private static final String PHONE = "phone";
+  private static final String PREFERRED_FIRST_NAME = "preferredFirstName";
+  private static final String SELECT_FIELD = "selectField";
+  private static final String STATUS = "status";
+  private static final String TYPE = "type";
+  private static final String USERNAME = "username";
+  private static final String USERS_URL = "/users/";
+  private static final String VALUE = "value";
+  private static final String VALUES = "values";
+
   private final UUID userId = UUID.randomUUID();
   private final JsonObject user = createSimpleUser(userId);
   private UUID holdingId;
   private final List<JsonObject> simpleItems = List
       .of(simpleItem(), simpleItem(), simpleItem());
-  private final List<CustomField> customFields = createCustomFields("item");
+  private final List<JsonObject> customFields = createCustomFields(ITEM);
 
   @Before
   public void beforeEach() {
@@ -46,7 +73,7 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
     removeAllEvents();
     // folio-custom-field depends on UserService information for saving custom
     // fields
-    WireMock.stubFor(WireMock.get("/users/" + userId)
+    WireMock.stubFor(WireMock.get(USERS_URL + userId)
         .willReturn(WireMock.okJson(user.encode())));
     holdingId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
   }
@@ -60,7 +87,7 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
   @Test
   public void testAddCustomFieldsToItem() {
     // given
-    IndividualResource item1 = saveItem(simpleItems.get(0).put("holdingsRecordId", holdingId.toString()));
+    IndividualResource item1 = saveItem(simpleItems.get(0).put(HOLDING_RECORD_ID, holdingId.toString()));
     Response response = saveCustomFieldAndExpectText(customFields.get(0));
     saveCustomFieldAndExpectText(customFields.get(1));
     saveCustomFieldAndExpectText(customFields.get(2));
@@ -108,72 +135,67 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
 
   }
 
-  private List<CustomField> createCustomFields(String entityType) {
-    CustomField textbox = new CustomField()
-        .withId(UUID.randomUUID().toString())
-        .withName("textbox")
-        .withType(Type.TEXTBOX_SHORT)
-        .withEntityType(entityType);
-    CustomField singleselect = new CustomField()
-        .withId(UUID.randomUUID().toString())
-        .withName("singleselect")
-        .withType(Type.SINGLE_SELECT_DROPDOWN)
-        .withSelectField(
-            new SelectField()
-                .withMultiSelect(false)
-                .withOptions(
-                    new SelectFieldOptions()
-                        .withValues(
-                            Arrays.asList(
-                                new SelectFieldOption().withId("opt_0").withValue("opt0"),
-                                new SelectFieldOption().withId("opt_1").withValue("opt1"),
-                                new SelectFieldOption().withId("opt_2").withValue("opt2")))))
-        .withEntityType(entityType);
-    CustomField multiselect = new CustomField()
-        .withId(UUID.randomUUID().toString())
-        .withName("multiselect")
-        .withType(Type.MULTI_SELECT_DROPDOWN)
-        .withSelectField(
-            new SelectField()
-                .withMultiSelect(true)
-                .withOptions(
-                    new SelectFieldOptions()
-                        .withValues(
-                            Arrays.asList(
-                                new SelectFieldOption().withId("opt_0").withValue("opt0"),
-                                new SelectFieldOption().withId("opt_1").withValue("opt1"),
-                                new SelectFieldOption().withId("opt_2").withValue("opt2"),
-                                new SelectFieldOption().withId("opt_3").withValue("opt3")))))
-        .withEntityType(entityType);
+  private List<JsonObject> createCustomFields(String entityType) {
+    JsonObject textbox = new JsonObject()
+        .put(ID, UUID.randomUUID().toString())
+        .put(NAME, "textbox")
+        .put(TYPE, Type.TEXTBOX_SHORT)
+        .put(ENTITY_TYPE, entityType);
 
+    JsonObject singleselect = new JsonObject()
+        .put(ID, UUID.randomUUID().toString())
+        .put(NAME, "singleselect")
+        .put(TYPE, Type.SINGLE_SELECT_DROPDOWN)
+        .put(ENTITY_TYPE, entityType)
+        .put(SELECT_FIELD, new JsonObject()
+            .put(MULTI_SELECT, false)
+            .put(OPTIONS, new JsonObject()
+                .put(VALUES, new JsonArray()
+                    .add(new JsonObject().put(ID, "opt_0").put(VALUE, "opt0"))
+                    .add(new JsonObject().put(ID, "opt_1").put(VALUE, "opt1"))
+                    .add(new JsonObject().put(ID, "opt_2").put(VALUE, "opt2")))));
+
+    JsonObject multiselect = new JsonObject()
+        .put(ID, UUID.randomUUID().toString())
+        .put(NAME, "multiselect")
+        .put(TYPE, Type.MULTI_SELECT_DROPDOWN)
+        .put(ENTITY_TYPE, entityType)
+        .put(SELECT_FIELD, new JsonObject()
+            .put(MULTI_SELECT, true)
+            .put(OPTIONS, new JsonObject()
+                .put(VALUES, new JsonArray()
+                    .add(new JsonObject().put(ID, "opt_0").put(VALUE, "opt0"))
+                    .add(new JsonObject().put(ID, "opt_1").put(VALUE, "opt1"))
+                    .add(new JsonObject().put(ID, "opt_2").put(VALUE, "opt2"))
+                    .add(new JsonObject().put(ID, "opt_3").put(VALUE, "opt3")))));
     return List.of(textbox, singleselect, multiselect);
   }
 
   private JsonObject simpleItem() {
     return new JsonObject()
-        .put("id", UUID.randomUUID().toString())
-        .put("status", new JsonObject().put("name", "Available"))
-        .put("materialTypeId", journalMaterialTypeID)
-        .put("permanentLoanTypeId", canCirculateLoanTypeId);
+        .put(ID, UUID.randomUUID().toString())
+        .put(STATUS, new JsonObject().put(NAME, "Available"))
+        .put(MATERIAL_TYPE_ID, journalMaterialTypeID)
+        .put(PERMANENT_LOAN_TYPE_ID, canCirculateLoanTypeId);
   }
 
   private JsonObject itemAddCustomFields(JsonObject itemToCreate, JsonObject customFields) {
-    return itemToCreate.copy().put("customFields", customFields);
+    return itemToCreate.copy().put(CUSTOM_FIELDS, customFields);
   }
 
-  public static URL customFieldsUrl(String subPath) {
-    return vertxUrl("/custom-fields" + subPath);
+  private static URL customFieldsUrl(String subPath) {
+    return vertxUrl(CUSTOM_FIELDS_URL + subPath);
   }
 
-  private Response saveCustomFieldAndExpectText(CustomField customFieldToCreate) {
+  private Response saveCustomFieldAndExpectText(JsonObject customFieldToCreate) {
     var createCompleted = new CompletableFuture<Response>();
-    String usersUrl = "http://localhost:" + mockServer.port();
+    String usersUrl = HTTP_LOCALHOST + mockServer.port();
     Map<String, String> headers = Map
         .of(XOkapiHeaders.USER_ID, userId.toString(), XOkapiHeaders.URL, usersUrl,
             XOkapiHeaders.URL_TO, usersUrl);
     getClient().post(
         customFieldsUrl(""),
-        JsonObject.mapFrom(customFieldToCreate),
+        customFieldToCreate,
         headers,
         TENANT_ID,
         ResponseHandler.any(createCompleted));
@@ -193,23 +215,23 @@ public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
 
   private JsonObject createSimpleUser(UUID newUserId) {
     JsonObject meta = new JsonObject()
-        .put("creation_date", "2016-11-05T07:23")
-        .put("last_login_date", "");
+        .put(CREATION_DATE, "2016-11-05T07:23")
+        .put(LAST_LOGIN_DATE, "");
 
     JsonObject personal = new JsonObject()
-        .put("lastName", "Handey")
-        .put("firstName", "Jack")
-        .put("preferredFirstName", "Jackie")
-        .put("email", "jhandey@biglibrary.org")
-        .put("phone", "2125551212");
+        .put(LAST_NAME, "Handey")
+        .put(FIRST_NAME, "Jack")
+        .put(PREFERRED_FIRST_NAME, "Jackie")
+        .put(EMAIL, "jhandey@biglibrary.org")
+        .put(PHONE, "2125551212");
 
     return new JsonObject()
-        .put("username", "jhandey")
-        .put("id", newUserId)
-        .put("active", true)
-        .put("type", "patron")
-        .put("patronGroup", "4bb563d9-3f9d-4e1e-8d1d-04e75666d68f")
-        .put("meta", meta)
-        .put("personal", personal);
+        .put(USERNAME, "jhandey")
+        .put(ID, newUserId)
+        .put(ACTIVE, true)
+        .put(TYPE, "patron")
+        .put(PATRON_GROUP, "4bb563d9-3f9d-4e1e-8d1d-04e75666d68f")
+        .put(META, meta)
+        .put(PERSONAL, personal);
   }
 }

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/CustomFieldsApiTest.java
@@ -1,0 +1,587 @@
+package org.folio.rest.api;
+
+import static io.restassured.RestAssured.given;
+import static org.folio.okapi.common.XOkapiHeaders.TENANT;
+import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
+import static org.folio.utility.ModuleUtility.getClient;
+import static org.folio.utility.ModuleUtility.vertxUrl;
+import static org.folio.utility.RestUtility.TENANT_ID;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.restassured.http.Header;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import junitparams.JUnitParamsRunner;
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.rest.jaxrs.model.CustomField.Type;
+import org.folio.rest.jaxrs.model.CustomFieldOptionStatistic;
+import org.folio.rest.jaxrs.model.CustomFieldStatistic;
+import org.folio.rest.support.IndividualResource;
+import org.folio.rest.support.Response;
+import org.folio.rest.support.ResponseHandler;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitParamsRunner.class)
+public class CustomFieldsApiTest extends TestBaseWithInventoryUtil {
+
+  private static final String ACTIVE = "active";
+  private static final String CREATION_DATE = "creation_date";
+  private static final String CUSTOM_FIELDS = "customFields";
+  private static final String CUSTOM_FIELDS_OPTIONS_STATS_ENDPOINT = "/{id}/options/{optId}/stats";
+  private static final String CUSTOM_FIELDS_STATS_ENDPOINT = "/{id}/stats";
+  private static final String CUSTOM_FIELDS_URL = "/custom-fields";
+  private static final String EMAIL = "email";
+  private static final String ENTITY_TYPE = "entityType";
+  private static final String FIRST_NAME = "firstName";
+  private static final String HOLDING_RECORD_ID = "holdingsRecordId";
+  private static final String HTTP_LOCALHOST = "http://localhost:";
+  private static final String ID = "id";
+  private static final String ITEM = "item";
+  private static final String LAST_LOGIN_DATE = "last_login_date";
+  private static final String LAST_NAME = "lastName";
+  private static final String MATERIAL_TYPE_ID = "materialTypeId";
+  private static final String META = "meta";
+  private static final String MULTI_SELECT = "multiSelect";
+  private static final String NAME = "name";
+  private static final String NAME_MULTISELECT = "multiselect";
+  private static final String NAME_SINGLE_SELECT = "singleselect";
+  private static final String NAME_TEXTBOX = "textbox";
+  private static final String OPTIONS = "options";
+  private static final String PATRON_GROUP = "patronGroup";
+  private static final String PERMANENT_LOAN_TYPE_ID = "permanentLoanTypeId";
+  private static final String PERSONAL = "personal";
+  private static final String PHONE = "phone";
+  private static final String PREFERRED_FIRST_NAME = "preferredFirstName";
+  private static final String SELECT_FIELD = "selectField";
+  private static final String STATUS = "status";
+  private static final String TYPE = "type";
+  private static final String USERNAME = "username";
+  private static final String USERS_URL = "/users/";
+  private static final String VALUE = "value";
+  private static final String VALUES = "values";
+
+  private final List<JsonObject> customFields = createCustomFields(ITEM);
+  private UUID holdingId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
+  private final List<JsonObject> simpleItems = List
+      .of(simpleItem(), simpleItem(), simpleItem());
+  private final UUID userId = UUID.randomUUID();
+  private final JsonObject user = createSimpleUser(userId);
+
+  @Before
+  public void beforeEach() {
+    StorageTestSuite.deleteAll(itemsStorageUrl(""));
+    updateCustomFields(List.of()); // there is no deleteAll
+    removeAllEvents();
+    // folio-custom-field depends on UserService information for saving custom
+    // fields
+    WireMock.stubFor(WireMock.get(USERS_URL + userId)
+        .willReturn(WireMock.okJson(user.encode())));
+  }
+
+  @After
+  public void afterEach() {
+    StorageTestSuite.deleteAll(itemsStorageUrl(""));
+    updateCustomFields(List.of());
+    removeAllEvents();
+  }
+
+  /*
+   * Create simple items with custom fields and check the statistics count.
+   * POST /custom-fields
+   * GET /custom-fields/{id}/stats
+   * GET /custom-fields/{id}/options/{optId}/stats
+   */
+  @Test
+  public void testSaveItemsWithCustomFields() {
+    // given
+    // 3 simple items and default custom fields as JsonObjects
+    // (textbox, singleselect, multiselect)
+    // when
+    // saving the custom fields in the database
+    saveCustomFields(List.of(customFields.get(0), customFields.get(1), customFields.get(2)));
+    // adding references to the 3 custom fields and
+    // corresponding values for each of the items
+    JsonObject itemWithCustomField0 = itemAddCustomFields(0);
+    JsonObject itemWithCustomField1 = itemAddCustomFields(1);
+    JsonObject itemWithCustomField2 = itemAddCustomFields(2);
+    // and saving the items with custom field values in the database
+    saveItem(itemWithCustomField0);
+    saveItem(itemWithCustomField1);
+    saveItem(itemWithCustomField2);
+    // then
+    // the items should be created
+    // and statistics should work.
+    assertEquals(3, getCustomFieldStatisticCount(customFieldsId(1)));
+    assertEquals(3, getCustomFieldOptionStatisticCount(customFieldsId(1), "opt_0"));
+  }
+
+  /**
+   * Should automatically update the item, when a related custom field is deleted.
+   * POST /custom-fields
+   * GET /custom-fields
+   * DELETE /custom-fields/{id}
+   * GET /custom-fields/{id}/stats
+   */
+  @Test
+  public void testDeleteCustomField() {
+    // given
+    // simple item and default custom field as JsonObject
+    // (textbox)
+    // saved in the database
+    assertEquals(0, getCustomFieldsCount());
+    int customFieldIndex = 0;
+    saveCustomField(customFields.get(customFieldIndex));
+    assertEquals(1, getCustomFieldsCount());
+    assertEquals(0, getCustomFieldStatisticCount(customFieldsId(customFieldIndex)));
+    IndividualResource item = saveItem(itemAddCustomFields(0, List.of(customFieldIndex)));
+    assertEquals(true, itemContainsCustomField(item, NAME_TEXTBOX));
+    assertEquals(1, getCustomFieldStatisticCount(customFieldsId(customFieldIndex)));
+    // when
+    // deleting the custom field in the database
+    deleteCustomField(customFieldsId(customFieldIndex));
+    // then
+    assertEquals(0, getCustomFieldsCount());
+    // check that item has no custom field anymore
+    IndividualResource updatedItem = getItem(item.getId());
+    assertEquals(false, itemContainsCustomField(updatedItem, NAME_TEXTBOX));
+  }
+
+  /**
+   * Should automatically update the item, when a related custom field is
+   * updated.
+   * POST /custom-fields
+   * PUT /custom-fields/{id}
+   */
+  @Test
+  public void testPutCustomField() {
+    // given
+    // simple item and default custom field as JsonObject
+    // (multiselect)
+    // the simple item with custom field values in the database
+    saveCustomField(customFields.get(2));
+    IndividualResource item = saveItem(itemAddCustomFields(0, List.of(2)));
+    assertEquals(2, getItemMultiselectSize(item));
+    // when
+    // updating the custom field
+    // (from 4 options to only 2 options)
+    customFields.get(2)
+        .put(SELECT_FIELD, createSelectField(2, true));
+    updateCustomField(customFields.get(2));
+    // then
+    // the reference in the item for custom fields should also be updated
+    // before opt1, opt2; now only opt1, because opt2 was deleted
+    IndividualResource updatedItem = getItem(item.getId());
+    assertEquals(1, getItemMultiselectSize(updatedItem));
+  }
+
+  /**
+   * Should automatically update items, when all custom fields are updated and the
+   * rest is deleted.
+   * POST /custom-fields
+   * PUT /custom-fields
+   */
+  @Test
+  public void testPutCustomFieldCollection() {
+    // given
+    // 2 simple items and default custom fields as JsonObjects
+    // (textbox, singleselect, multiselect)
+    // when
+    // saving the custom fields in the database
+    saveCustomFields(List.of(customFields.get(0), customFields.get(1), customFields.get(2)));
+    // adding references to the 3 custom fields and
+    // corresponding values for each of the items
+    // and saving the items with custom field values in the database
+    JsonObject itemWithCustomField0 = itemAddCustomFields(0);
+    IndividualResource item1 = saveItem(itemWithCustomField0);
+    assertEquals(true, itemCustomFieldsContainsKey(item1, NAME_SINGLE_SELECT));
+    assertEquals(true, itemCustomFieldsContainsKey(item1, NAME_TEXTBOX));
+    assertEquals(true, itemCustomFieldsContainsKey(item1, NAME_MULTISELECT));
+    JsonObject itemWithCustomField1 = itemAddCustomFields(1);
+    IndividualResource item2 = saveItem(itemWithCustomField1);
+    assertEquals(true, itemCustomFieldsContainsKey(item2, NAME_SINGLE_SELECT));
+    assertEquals(true, itemCustomFieldsContainsKey(item2, NAME_TEXTBOX));
+    assertEquals(true, itemCustomFieldsContainsKey(item2, NAME_MULTISELECT));
+    // new custom fields
+    JsonObject newCustomField = customFields.get(2).put(NAME, "newMultiselect").put(ID, UUID.randomUUID().toString());
+    List<JsonObject> customFieldsToUpdate = List.of(newCustomField, customFields.get(0), customFields.get(1));
+    // when
+    // updating custom fields
+    updateCustomFields(customFieldsToUpdate);
+    // then
+    IndividualResource updatedItem1 = getItem(item1.getId());
+    assertEquals(true, itemCustomFieldsContainsKey(updatedItem1, NAME_SINGLE_SELECT));
+    assertEquals(true, itemCustomFieldsContainsKey(updatedItem1, NAME_TEXTBOX));
+    assertEquals(false, itemCustomFieldsContainsKey(updatedItem1, NAME_MULTISELECT));
+    IndividualResource updatedItem2 = getItem(item2.getId());
+    assertEquals(true, itemCustomFieldsContainsKey(updatedItem2, NAME_SINGLE_SELECT));
+    assertEquals(true, itemCustomFieldsContainsKey(updatedItem2, NAME_TEXTBOX));
+    assertEquals(false, itemCustomFieldsContainsKey(updatedItem2, NAME_MULTISELECT));
+  }
+
+  private boolean itemCustomFieldsContainsKey(IndividualResource item, String key) {
+    return ((JsonObject) item.getJson().getValue(CUSTOM_FIELDS)).containsKey(key);
+  }
+
+  private int getItemMultiselectSize(IndividualResource item) {
+    return ((JsonArray) ((JsonObject) item.getJson().getValue(CUSTOM_FIELDS)).getValue(NAME_MULTISELECT)).size();
+  }
+
+  private boolean itemContainsCustomField(IndividualResource item, String name) {
+    return ((JsonObject) item.getJson().getValue(CUSTOM_FIELDS)).containsKey(name);
+  }
+
+  private String customFieldsId(int index) {
+    return customFields.get(index).getString(ID);
+  }
+
+  /**
+   * Creates a select field or multiselect.
+   * Adds numberOfValues options to the select.
+   *
+   * @param numberOfValues number of options added
+   * @param multiselect    flag deciding if result is a select field or a
+   *                       multiselect
+   * @return a select field or multiselect as JsonObject
+   */
+  private JsonObject createSelectField(int numberOfValues, boolean multiselect) {
+    JsonArray values = new JsonArray();
+    for (int i = 0; i < numberOfValues; i++) {
+      values.add(new JsonObject()
+          .put(ID, "opt_" + i)
+          .put(VALUE, "opt" + i));
+    }
+
+    return new JsonObject()
+        .put(MULTI_SELECT, multiselect)
+        .put(OPTIONS, new JsonObject()
+            .put(VALUES, values));
+  }
+
+  /**
+   * Create a list of custom fields as json objects for the entityType
+   * The list consists of a textbox, a single select and a multi select.
+   *
+   * @param entityType The entity type the custom field is added to
+   * @return list of custom fields as json objects
+   */
+  private List<JsonObject> createCustomFields(String entityType) {
+    JsonObject textbox = new JsonObject()
+        .put(ID, UUID.randomUUID().toString())
+        .put(NAME, NAME_TEXTBOX)
+        .put(TYPE, Type.TEXTBOX_SHORT)
+        .put(ENTITY_TYPE, entityType);
+
+    JsonObject singleselect = new JsonObject()
+        .put(ID, UUID.randomUUID().toString())
+        .put(NAME, NAME_SINGLE_SELECT)
+        .put(TYPE, Type.SINGLE_SELECT_DROPDOWN)
+        .put(ENTITY_TYPE, entityType)
+        .put(SELECT_FIELD, createSelectField(3, false));
+
+    JsonObject multiselect = new JsonObject()
+        .put(ID, UUID.randomUUID().toString())
+        .put(NAME, NAME_MULTISELECT)
+        .put(TYPE, Type.MULTI_SELECT_DROPDOWN)
+        .put(ENTITY_TYPE, entityType)
+        .put(SELECT_FIELD, createSelectField(4, true));
+    return List.of(textbox, singleselect, multiselect);
+  }
+
+  /**
+   * Create custom field values which can be inserted in items.
+   *
+   * @param customFieldIndices indices of the example custom field values to
+   *                           insert
+   * @return JsonObject representing the custom field values
+   */
+  private JsonObject createCustomFieldValues(List<Integer> customFieldIndices) {
+    JsonObject customFieldValues = new JsonObject();
+    if (customFieldIndices.contains(0)) {
+      customFieldValues.put(NAME_TEXTBOX, "text1");
+    }
+    if (customFieldIndices.contains(1)) {
+      customFieldValues.put(NAME_SINGLE_SELECT, "opt_0");
+    }
+    if (customFieldIndices.contains(2)) {
+      customFieldValues.put(NAME_MULTISELECT, new JsonArray().add("opt_1").add("opt_2"));
+    }
+    return customFieldValues;
+  }
+
+  /**
+   * Create a minimal item.
+   *
+   * @return a simple item as JsonObject
+   */
+  private JsonObject simpleItem() {
+    return new JsonObject()
+        .put(ID, UUID.randomUUID().toString())
+        .put(STATUS, new JsonObject().put(NAME, "Available"))
+        .put(MATERIAL_TYPE_ID, journalMaterialTypeID)
+        .put(PERMANENT_LOAN_TYPE_ID, canCirculateLoanTypeID);
+  }
+
+  /**
+   * Add custom field references by name and values to the specified item
+   * by the choosen index in simpleItems.
+   *
+   * @param itemToCreateIndex index of choosen item from simpleItems
+   * @return a complete json object with custom fields
+   */
+  private JsonObject itemAddCustomFields(int itemToCreateIndex) {
+    return itemAddCustomFields(itemToCreateIndex, List.of(0, 1, 2));
+  }
+
+  /**
+   * Add custom field values to the simple item referenced by itemToCreateIndex.
+   *
+   * @param itemToCreateIndex  index of simpleItems
+   * @param customFieldIndices indices of the custom fields which should get added
+   *                           to the item
+   * @return the simple item with added custom fields
+   */
+  private JsonObject itemAddCustomFields(int itemToCreateIndex, List<Integer> customFieldIndices) {
+    return simpleItems
+        .get(itemToCreateIndex)
+        .copy()
+        .put(HOLDING_RECORD_ID, holdingId.toString())
+        .put(CUSTOM_FIELDS, createCustomFieldValues(customFieldIndices));
+  }
+
+  private static URL customFieldsUrl(String subPath) {
+    return vertxUrl(CUSTOM_FIELDS_URL + subPath);
+  }
+
+  /**
+   * Save the custom field with the API.
+   * Assert the custom fields got created by checking the status code.
+   * Here we also need to add the mock to a user interface because custom fields
+   * still have dependencies on a user
+   *
+   * @param customFieldToCreate The JsonObject representing the custom field
+   * @return Response of the creation request
+   */
+  private Response saveCustomField(JsonObject customFieldToCreate) {
+    var createCompleted = new CompletableFuture<Response>();
+    String usersUrl = HTTP_LOCALHOST + mockServer.port();
+    Map<String, String> headers = Map
+        .of(XOkapiHeaders.USER_ID, userId.toString(), XOkapiHeaders.URL, usersUrl,
+            XOkapiHeaders.URL_TO, usersUrl);
+    getClient().post(
+        customFieldsUrl(""),
+        customFieldToCreate,
+        headers,
+        TENANT_ID,
+        ResponseHandler.any(createCompleted));
+    Response response = get(createCompleted);
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+    return response;
+  }
+
+  /**
+   * Update the custom field with the API.
+   * Assert the custom fields got update by checking the status code.
+   * Here we also need to add the mock to a user interface because custom fields
+   * still have dependencies on a user
+   *
+   * @param customFieldToUpdate The JsonObject representing the custom field
+   * @return Response of the update request
+   */
+  private Response updateCustomField(JsonObject customFieldToUpdate) {
+    var updateCompleted = new CompletableFuture<Response>();
+    String usersUrl = HTTP_LOCALHOST + mockServer.port();
+    Map<String, String> headers = Map
+        .of(XOkapiHeaders.USER_ID, userId.toString(), XOkapiHeaders.URL, usersUrl,
+            XOkapiHeaders.URL_TO, usersUrl);
+    getClient().put(
+        customFieldsUrl("/" + customFieldToUpdate.getString(ID)),
+        customFieldToUpdate,
+        headers,
+        TENANT_ID,
+        ResponseHandler.any(updateCompleted));
+    Response response = get(updateCompleted);
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+    return response;
+  }
+
+  /**
+   * Update the custom fields and delete the rest with the API.
+   * Assert the custom fields got update by checking the status code.
+   * Here we also need to add the mock to a user interface because custom fields
+   * still have dependencies on a user
+   *
+   * @param customFieldsToUpdate List of JsonObjects representing the custom
+   *                             fields
+   * @return Response of the update request
+   */
+  private Response updateCustomFields(List<JsonObject> customFieldsToUpdate) {
+    var updateCompleted = new CompletableFuture<Response>();
+    String usersUrl = HTTP_LOCALHOST + mockServer.port();
+    Map<String, String> headers = Map
+        .of(XOkapiHeaders.USER_ID, userId.toString(), XOkapiHeaders.URL, usersUrl,
+            XOkapiHeaders.URL_TO, usersUrl);
+    JsonObject customFieldsObject = new JsonObject()
+        .put(CUSTOM_FIELDS, customFieldsToUpdate)
+        .put(ENTITY_TYPE, ITEM);
+    getClient().put(
+        customFieldsUrl(""),
+        customFieldsObject,
+        headers,
+        TENANT_ID,
+        ResponseHandler.any(updateCompleted));
+    Response response = get(updateCompleted);
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+    return response;
+  }
+
+  /**
+   * Save the custom fields with the API.
+   * Assert the custom fields got created by checking the status code.
+   * Here we also need to add the mock to a user interface because custom fields
+   * still have dependencies on a user
+   *
+   * @param customFieldsObjects List of JsonObjects representing the custom fields
+   * @return List of Response objects from the creation requests
+   */
+  private List<Response> saveCustomFields(List<JsonObject> customFieldsObjects) {
+    return customFieldsObjects.stream()
+        .map(this::saveCustomField)
+        .toList();
+  }
+
+  /**
+   * Delete the custom field by id with the API.
+   * Assert the custom fields got deleted by checking the status code.
+   *
+   * @param id of the custom field
+   * @return Response of the delete request
+   */
+  private Response deleteCustomField(String id) {
+    var createCompleted = new CompletableFuture<Response>();
+    getClient().delete(
+        customFieldsUrl("/" + id),
+        TENANT_ID,
+        ResponseHandler.any(createCompleted));
+    Response response = get(createCompleted);
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
+    return response;
+  }
+
+  /**
+   * Asserts the item got created by checking the status code.
+   *
+   * @param itemToCreate The JsonObject representing the item to create
+   * @return The IndividualResource of the json response of the creation request
+   */
+  private IndividualResource saveItem(JsonObject itemToCreate) {
+    return itemsClient.create(itemToCreate);
+  }
+
+  /**
+   * Get item by UUID.
+   *
+   * @param id UUID of the item you want to get
+   * @return The IndividualResource of the json response of the get request
+   */
+  private IndividualResource getItem(UUID id) {
+    Response response = itemsClient.getById(id);
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+    return new IndividualResource(response);
+  }
+
+  /**
+   * Create a simple user with the specified UUID.
+   *
+   * @param newUserId UUID for the user
+   * @return a JsonObject of the simple user
+   */
+  private JsonObject createSimpleUser(UUID newUserId) {
+    JsonObject meta = new JsonObject()
+        .put(CREATION_DATE, "2016-11-05T07:23")
+        .put(LAST_LOGIN_DATE, "");
+
+    JsonObject personal = new JsonObject()
+        .put(LAST_NAME, "Handey")
+        .put(FIRST_NAME, "Jack")
+        .put(PREFERRED_FIRST_NAME, "Jackie")
+        .put(EMAIL, "jhandey@biglibrary.org")
+        .put(PHONE, "2125551212");
+
+    return new JsonObject()
+        .put(USERNAME, "jhandey")
+        .put(ID, newUserId)
+        .put(ACTIVE, true)
+        .put(TYPE, "patron")
+        .put(PATRON_GROUP, "4bb563d9-3f9d-4e1e-8d1d-04e75666d68f")
+        .put(META, meta)
+        .put(PERSONAL, personal);
+  }
+
+  /**
+   * Get the custom field statistic count with the API.
+   * Asserts the correct response status
+   *
+   * @param customFieldId id of the custom field
+   * @return count of the custom field statistic as int
+   */
+  private int getCustomFieldStatisticCount(String customFieldId) {
+    return given()
+        .header(new Header(TENANT, TENANT_ID))
+        .pathParams(ID, customFieldId)
+        .get(customFieldsUrl(CUSTOM_FIELDS_STATS_ENDPOINT))
+        .then()
+        .statusCode(200)
+        .extract()
+        .as(CustomFieldStatistic.class)
+        .getCount();
+  }
+
+  /**
+   * Get the custom field option statistic count with the API.
+   * Asserts the correct response status
+   *
+   * @param customFieldId id of the custom field
+   * @param optionId      id of the option
+   * @return count of the custom field option statistic as int
+   */
+  private int getCustomFieldOptionStatisticCount(String customFieldId, String optionId) {
+    return given()
+        .header(new Header(TENANT, TENANT_ID))
+        .pathParams(ID, customFieldId, "optId", optionId)
+        .get(customFieldsUrl(CUSTOM_FIELDS_OPTIONS_STATS_ENDPOINT))
+        .then()
+        .statusCode(200)
+        .extract()
+        .as(CustomFieldOptionStatistic.class)
+        .getCount();
+  }
+
+  /**
+   * Get the number of custom fields in the database with the API.
+   * Asserts the correct response status
+   *
+   * @return the number of custom fields as int
+   */
+  private int getCustomFieldsCount() {
+    var createCompleted = new CompletableFuture<Response>();
+    getClient().get(
+        customFieldsUrl("/"),
+        TENANT_ID,
+        ResponseHandler.any(createCompleted));
+    Response response = get(createCompleted);
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+    return new JsonObject(response.getBody()).getInteger("totalRecords");
+  }
+}

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -41,6 +41,7 @@ import org.junit.runners.Suite;
   AsyncMigrationTest.class,
   AuditDeleteTest.class,
   BoundWithStorageTest.class,
+  CustomFieldsApiTest.class,
   DereferencedItemStorageTest.class,
   EffectiveLocationMigrationTest.class,
   HoldingsStorageTest.class,

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -41,6 +41,7 @@ import org.junit.runners.Suite;
   AsyncMigrationTest.class,
   AuditDeleteTest.class,
   BoundWithStorageTest.class,
+  CustomFieldsApiTest.class,
   DereferencedItemStorageTest.class,
   HoldingsStorageTest.class,
   HridSettingsStorageParameterizedTest.class,

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <log4j.version>2.25.3</log4j.version>
     <folio-s3-client.version>3.0.0-SNAPSHOT</folio-s3-client.version>
     <jackson.version>2.21.1</jackson.version>
+    <folio-custom-fields.version>3.0.0-SNAPSHOT</folio-custom-fields.version>
 
     <!-- Test dependency versions -->
     <okapi-testing.version>7.0.2</okapi-testing.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>org.folio</groupId>
@@ -34,6 +35,7 @@
     <log4j.version>2.26.1</log4j.version>
     <folio-s3-client.version>3.0.2</folio-s3-client.version>
     <jackson.version>2.22.0</jackson.version>
+    <folio-custom-fields.version>3.0.0-SNAPSHOT</folio-custom-fields.version>
 
     <!-- Test dependency versions -->
     <okapi-testing.version>7.0.5</okapi-testing.version>

--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <log4j.version>2.26.1</log4j.version>
     <folio-s3-client.version>3.0.2</folio-s3-client.version>
     <jackson.version>2.22.0</jackson.version>
-    <folio-custom-fields.version>3.0.0-SNAPSHOT</folio-custom-fields.version>
+    <folio-custom-fields.version>4.0.0-SNAPSHOT</folio-custom-fields.version>
 
     <!-- Test dependency versions -->
     <okapi-testing.version>7.0.5</okapi-testing.version>

--- a/ramls/item-storage.raml
+++ b/ramls/item-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Item Storage
-version: v11.2
+version: v11.3
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 

--- a/ramls/schemas/common/custom_fields.json
+++ b/ramls/schemas/common/custom_fields.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "description": "Object that contains custom field",
+  "type": "object",
+  "javaName": "CustomFields",
+  "additionalProperties": true
+}

--- a/ramls/schemas/item-storage/item.json
+++ b/ramls/schemas/item-storage/item.json
@@ -313,7 +313,7 @@
     "customFields": {
       "description": "Object that contains custom fields",
       "type": "object",
-      "additionalProperties": true
+      "$ref": "../common/custom_fields.json"
     }
   },
   "additionalProperties": false,

--- a/ramls/schemas/item-storage/item.json
+++ b/ramls/schemas/item-storage/item.json
@@ -309,6 +309,11 @@
       "type": "object",
       "description": "Information about when an item was last scanned in the Inventory app.",
       "$ref": "itemLastCheckIn.json"
+    },
+    "customFields": {
+      "description": "Object that contains custom fields",
+      "type": "object",
+      "additionalProperties": true
     }
   },
   "additionalProperties": false,

--- a/ramls/schemas/item-storage/item.json
+++ b/ramls/schemas/item-storage/item.json
@@ -309,6 +309,11 @@
       "type": "object",
       "description": "Information about when an item was last scanned in the Inventory app.",
       "$ref": "itemLastCheckIn.json"
+    },
+    "customFields": {
+      "description": "Object that contains custom fields",
+      "type": "object",
+      "$ref": "../common/custom_fields.json"
     }
   },
   "additionalProperties": false,


### PR DESCRIPTION
### Purpose
_Describe the purpose of this pull request. Why is this change necessary? What problem does it solve?_

This pull request is for integrating the `folio-custom-fields` backend library into mod-inventory-storage, so that it supports storing custiom field values on inventory items.

### Approach
_How does this change fulfill the purpose? Provide a high-level overview of the technical approach taken to address the problem._

We followed the guide in https://github.com/folio-org/folio-custom-fields for implementing the library and used the implementation in https://github.com/folio-org/mod-orders-storage as reference.

### Changes Checklist
- [x] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [x] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [x] **Interface Version Changes**: Indicate any changes to interface versions.
- [x] **Interface Dependencies**: Document added or removed dependencies.
- [x] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

**New API**

GET, PUT, POST /custom-fields
GET, PUT, DELETE /custom-fields/{id}
GET /custom-fields/{id}/stats
GET /custom-fields/{id}/options/{optId}/stats

**Permissions**

inventory-storage.custom-fields.all
inventory-storage.custom-fields.collection.get
inventory-storage.custom-fields.collection.put
inventory-storage.custom-fields.item.post
inventory-storage.custom-fields.item.get
inventory-storage.custom-fields.item.put
inventory-storage.custom-fields.item.delete
inventory-storage.custom-fields.item.stats.get
inventory-storage.custom-fields.item.option.stats.get

### Related Issues
_List any Jira issues related to this pull request._

https://folio-org.atlassian.net/browse/MODINVSTOR-1446
https://folio-org.atlassian.net/browse/UXPROD-5370

### Learning and Resources (if applicable)
_Discuss any research conducted during the development of this pull request. Include links to relevant blog posts, patterns, libraries, or addons that were used to solve the problem._

https://github.com/folio-org/folio-custom-fields
https://github.com/folio-org/mod-orders-storage
https://www.baeldung.com/java-passing-method-parameter

### Screenshots (if applicable)
_If this pull request involves any visual changes or new features, consider including screenshots or GIFs to illustrate the changes._
