### PR TITLE
fix(patch-items-endpoint) fix EffectiveLocationId field and callNumber components

### DIFF
--- a/ramls/item-storage.raml
+++ b/ramls/item-storage.raml
@@ -41,13 +41,14 @@ resourceTypes:
     post:
       is: [validate]
     patch:
+      description: Update multiple items by a single request
       is: [validate]
       body:
         application/json:
           type: itemsPatch
           example:
             strict: false
-            value: examples/items_patch.json
+            value: !include examples/items_patch.json
       responses:
         204:
           description: "Items successfully updated"

--- a/src/main/java/org/folio/rest/support/ItemEffectiveLocationUtil.java
+++ b/src/main/java/org/folio/rest/support/ItemEffectiveLocationUtil.java
@@ -1,9 +1,11 @@
 package org.folio.rest.support;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.nonNull;
 
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
+import org.folio.services.item.PatchData;
 
 public final class ItemEffectiveLocationUtil {
 
@@ -11,13 +13,47 @@ public final class ItemEffectiveLocationUtil {
 
   public static void updateItemEffectiveLocation(Item item, HoldingsRecord holdingsRecord) {
     if (isNull(item.getPermanentLocationId()) && isNull(item.getTemporaryLocationId())) {
-      item.setEffectiveLocationId(isNull(holdingsRecord.getTemporaryLocationId())
-                                  ? holdingsRecord.getPermanentLocationId()
-                                  : holdingsRecord.getTemporaryLocationId());
+      setEffectiveLocationIdFromHolding(item, holdingsRecord);
     } else {
-      item.setEffectiveLocationId(isNull(item.getTemporaryLocationId())
-                                  ? item.getPermanentLocationId()
-                                  : item.getTemporaryLocationId());
+      setEffectiveLocationIdFromItem(item);
     }
+  }
+
+  public static void updateItemEffectiveLocation(Item newItem, PatchData patchData) {
+    var holdingsRecord = patchData.getNewHoldings();
+    var oldItem = patchData.getOldItem();
+    var itemPatchFields = patchData.getPatchRequest().getAdditionalProperties();
+    boolean allItemLocationsNull = isNull(newItem.getPermanentLocationId())
+      && isNull(newItem.getTemporaryLocationId())
+      && isNull(oldItem.getPermanentLocationId())
+      && isNull(oldItem.getTemporaryLocationId());
+
+    if (allItemLocationsNull) {
+      setEffectiveLocationIdFromHolding(newItem, holdingsRecord);
+    } else {
+      if (nonNull(newItem.getTemporaryLocationId())) {
+        newItem.setEffectiveLocationId(newItem.getTemporaryLocationId());
+      } else if (nonNull(oldItem.getTemporaryLocationId()) && !itemPatchFields.containsKey("temporaryLocationId")) {
+        newItem.setEffectiveLocationId(oldItem.getTemporaryLocationId());
+      } else if (nonNull(newItem.getPermanentLocationId())) {
+        newItem.setEffectiveLocationId(newItem.getPermanentLocationId());
+      } else if (nonNull(oldItem.getPermanentLocationId()) && !itemPatchFields.containsKey("permanentLocationId")) {
+        newItem.setEffectiveLocationId(oldItem.getPermanentLocationId());
+      } else {
+        setEffectiveLocationIdFromHolding(newItem, holdingsRecord);
+      }
+    }
+  }
+
+  private static void setEffectiveLocationIdFromHolding(Item newItem, HoldingsRecord holdingsRecord) {
+    newItem.setEffectiveLocationId(isNull(holdingsRecord.getTemporaryLocationId())
+      ? holdingsRecord.getPermanentLocationId()
+      : holdingsRecord.getTemporaryLocationId());
+  }
+
+  private static void setEffectiveLocationIdFromItem(Item item) {
+    item.setEffectiveLocationId(isNull(item.getTemporaryLocationId())
+      ? item.getPermanentLocationId()
+      : item.getTemporaryLocationId());
   }
 }

--- a/src/main/java/org/folio/services/ItemEffectiveValuesService.java
+++ b/src/main/java/org/folio/services/ItemEffectiveValuesService.java
@@ -50,7 +50,7 @@ public class ItemEffectiveValuesService {
   }
 
   public void populateEffectiveValues(Item newItem, PatchData patchData) {
-    updateItemEffectiveLocation(newItem, patchData.getNewHoldings());
+    updateItemEffectiveLocation(newItem, patchData);
     setCallNumberComponents(newItem, patchData);
     calculateAndSetEffectiveShelvingOrder(newItem);
   }

--- a/src/main/java/org/folio/services/ItemEffectiveValuesService.java
+++ b/src/main/java/org/folio/services/ItemEffectiveValuesService.java
@@ -20,6 +20,7 @@ import org.folio.persist.HoldingsRepository;
 import org.folio.rest.exceptions.ValidationException;
 import org.folio.rest.jaxrs.model.HoldingsRecord;
 import org.folio.rest.jaxrs.model.Item;
+import org.folio.services.item.PatchData;
 
 public class ItemEffectiveValuesService {
   private final HoldingsRepository holdingsRepository;
@@ -46,6 +47,12 @@ public class ItemEffectiveValuesService {
     setCallNumberComponents(item, hr);
     calculateAndSetEffectiveShelvingOrder(item);
     return item;
+  }
+
+  public void populateEffectiveValues(Item newItem, PatchData patchData) {
+    updateItemEffectiveLocation(newItem, patchData.getNewHoldings());
+    setCallNumberComponents(newItem, patchData);
+    calculateAndSetEffectiveShelvingOrder(newItem);
   }
 
   private Future<Map<String, HoldingsRecord>> getHoldingsRecordsForItems(List<Item> items) {

--- a/src/main/java/org/folio/services/item/ItemService.java
+++ b/src/main/java/org/folio/services/item/ItemService.java
@@ -546,16 +546,8 @@ public class ItemService {
       : Future.succeededFuture();
 
     return validationFuture.compose(v -> {
-      boolean holdingsChanged = !Objects.equals(
-        patchData.getOldItem().getHoldingsRecordId(),
-        newItem.getHoldingsRecordId()
-      );
-
-      if (holdingsChanged) {
-        effectiveValuesService.populateEffectiveValues(newItem, patchData.getNewHoldings());
-        ItemUtils.transferEffectiveValuesToPatch(newItem, patchData.getPatchRequest());
-      }
-
+      effectiveValuesService.populateEffectiveValues(newItem, patchData);
+      ItemUtils.transferEffectiveValuesToPatch(newItem, patchData.getPatchRequest());
       return Future.succeededFuture(patchData);
     });
   }

--- a/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -2324,6 +2324,145 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  @SneakyThrows
+  public void shouldNotUpdateEffectiveShelvingOrder() {
+    var holdingsRecordId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
+    var itemId = randomUUID();
+    var itemJson = smallAngryPlanet(itemId, holdingsRecordId);
+    itemJson.put("itemLevelCallNumber", "call number");
+    itemJson.put("itemLevelCallNumberSuffix", "suffix");
+
+    // Create item
+    createItem(itemJson);
+
+    // verify item is created with effectiveShelvingOrder field
+    var itemResponse = getById(itemId);
+    var itemResponseJson = itemResponse.getJson();
+    assertThat(itemResponse.getStatusCode(), is(200));
+    assertEquals("call number suffix", itemResponseJson.getValue("effectiveShelvingOrder").toString());
+
+    // Create patch request to update effectiveShelvingOrder field directly
+    var itemPatch = new JsonObject()
+      .put("id", itemId.toString())
+      .put("_version", 1)
+      .put("effectiveShelvingOrder", "new shelving order");
+    var patchRequest = new JsonObject()
+      .put("items", new JsonArray().add(itemPatch));
+
+    // Attempt to patch item
+    var patchCompleted = new CompletableFuture<Response>();
+    getClient().patch(itemsStorageUrl(""), patchRequest, TENANT_ID,
+      ResponseHandler.empty(patchCompleted));
+    var patchResponse = patchCompleted.get(TIMEOUT, TimeUnit.SECONDS);
+
+    assertThat(patchResponse.getStatusCode(), is(204));
+
+    // verify item is updated and effectiveShelvingOrder is unchanged
+    var itemUpdatedResponse = getById(itemId);
+    var itemUpdatedResponseJson = itemUpdatedResponse.getJson();
+    assertThat(itemUpdatedResponse.getStatusCode(), is(200));
+    assertEquals("call number suffix", itemUpdatedResponseJson.getValue("effectiveShelvingOrder").toString());
+  }
+
+  @Test
+  @SneakyThrows
+  public void shouldUpdateEffectiveLocationIdFromItemRecord() {
+    var holdingsRecordId = createInstanceAndHolding(SECOND_FLOOR_LOCATION_ID);
+    var itemId = randomUUID();
+    var itemJson = smallAngryPlanet(itemId, holdingsRecordId);
+    itemJson.put("temporaryLocationId", MAIN_LIBRARY_LOCATION_ID);
+    itemJson.put("permanentLocationId", ANNEX_LIBRARY_LOCATION_ID);
+
+    // Create item
+    createItem(itemJson);
+
+    // verify item is created and effectiveLocation equals temporaryLocationId
+    var itemUpdatedResponse = getById(itemId);
+    var itemUpdatedResponseJson = itemUpdatedResponse.getJson();
+    assertThat(itemUpdatedResponse.getStatusCode(), is(200));
+    assertEquals(MAIN_LIBRARY_LOCATION_ID.toString(),
+      itemUpdatedResponseJson.getValue("effectiveLocationId").toString());
+    assertEquals(MAIN_LIBRARY_LOCATION_ID.toString(),
+      itemUpdatedResponseJson.getValue("temporaryLocationId").toString());
+    assertEquals(ANNEX_LIBRARY_LOCATION_ID.toString(),
+      itemUpdatedResponseJson.getValue("permanentLocationId").toString());
+
+    // update item with temporaryLocationId = null
+    var itemUpdatePatch = new JsonObject()
+      .put("id", itemId.toString())
+      .put("_version", 1)
+      .put("temporaryLocationId", null);
+
+    var patchUpdateRequest = new JsonObject()
+      .put("items", new JsonArray().add(itemUpdatePatch));
+
+    var patchUpdateCompleted = new CompletableFuture<Response>();
+    getClient().patch(itemsStorageUrl(""), patchUpdateRequest, TENANT_ID,
+      ResponseHandler.empty(patchUpdateCompleted));
+    var patchUpdateResponse = patchUpdateCompleted.get(TIMEOUT, TimeUnit.SECONDS);
+
+    assertThat(patchUpdateResponse.getStatusCode(), is(204));
+
+    // verify effectiveLocation id equals permanentLocationId as temporaryLocationId is null
+    var itemResponse = getById(itemId);
+    var itemResponseJson = itemResponse.getJson();
+    assertThat(itemResponse.getStatusCode(), is(200));
+    assertEquals(ANNEX_LIBRARY_LOCATION_ID.toString(), itemResponseJson.getValue("effectiveLocationId").toString());
+    assertEquals(ANNEX_LIBRARY_LOCATION_ID.toString(), itemResponseJson.getValue("permanentLocationId").toString());
+    assertNull(itemResponseJson.getValue("temporaryLocationId"));
+  }
+
+  @Test
+  @SneakyThrows
+  public void shouldUpdateEffectiveLocationIdFromHoldingRecord() {
+    var holdingsRecordId = createInstanceAndHolding(SECOND_FLOOR_LOCATION_ID);
+    var itemId = randomUUID();
+    var itemJson = smallAngryPlanet(itemId, holdingsRecordId);
+    itemJson.put("temporaryLocationId", MAIN_LIBRARY_LOCATION_ID);
+    itemJson.put("permanentLocationId", ANNEX_LIBRARY_LOCATION_ID);
+
+    // Create item
+    createItem(itemJson);
+
+    // verify item is created and effectiveLocation equals temporaryLocationId
+    var itemUpdatedResponse = getById(itemId);
+    var itemUpdatedResponseJson = itemUpdatedResponse.getJson();
+    assertThat(itemUpdatedResponse.getStatusCode(), is(200));
+    assertEquals(MAIN_LIBRARY_LOCATION_ID.toString(),
+      itemUpdatedResponseJson.getValue("effectiveLocationId").toString());
+    assertEquals(MAIN_LIBRARY_LOCATION_ID.toString(),
+      itemUpdatedResponseJson.getValue("temporaryLocationId").toString());
+    assertEquals(ANNEX_LIBRARY_LOCATION_ID.toString(),
+      itemUpdatedResponseJson.getValue("permanentLocationId").toString());
+
+    // update item with temporaryLocationId = null and permanentLocationId = null
+    var itemUpdatePatch = new JsonObject()
+      .put("id", itemId.toString())
+      .put("_version", 1)
+      .put("temporaryLocationId", null)
+      .put("permanentLocationId", null);
+
+    var patchUpdateRequest = new JsonObject()
+      .put("items", new JsonArray().add(itemUpdatePatch));
+
+    var patchUpdateCompleted = new CompletableFuture<Response>();
+    getClient().patch(itemsStorageUrl(""), patchUpdateRequest, TENANT_ID,
+      ResponseHandler.empty(patchUpdateCompleted));
+    var patchUpdateResponse = patchUpdateCompleted.get(TIMEOUT, TimeUnit.SECONDS);
+
+    assertThat(patchUpdateResponse.getStatusCode(), is(204));
+
+    // verify effectiveLocation id equals holding permanentLocationId as holding temporaryLocationId,
+    // item temporaryLocationId and item permanentLocationId are null
+    var itemResponse = getById(itemId);
+    var itemResponseJson = itemResponse.getJson();
+    assertThat(itemResponse.getStatusCode(), is(200));
+    assertEquals(SECOND_FLOOR_LOCATION_ID.toString(), itemResponseJson.getValue("effectiveLocationId").toString());
+    assertNull(itemResponseJson.getValue("temporaryLocationId"));
+    assertNull(itemResponseJson.getValue("permanentLocationId"));
+  }
+
+  @Test
   public void shouldPageAllRetrieveItemsViaPost() throws InterruptedException, ExecutionException, TimeoutException {
     UUID holdingsRecordId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
 


### PR DESCRIPTION
### Purpose
[MODINVSTOR-1441](https://folio-org.atlassian.net/browse/MODINVSTOR-1441) fix EffectiveLocationId field and callNumber components

### Approach

- Fixed the logic for updating Item **`effectiveLocationId`** to correctly handle cases where `temporaryLocationId` and `permanentLocationId` are null in the request body. The `effectiveLocationId` will then be retrieved from the item's associated holding record, using the resolved `temporaryLocationId` and `permanentLocationId`.

When both values (Item `temporaryLocationId` and `permanentLocationId`)  are not present in the request, they are retrieved from the existing item record in the database.

- Fixed the logic for building **CallNumber components**

- Updated the API info: endpoint description and request body example

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Screenshots
* **Added API endpoint description:**
<kbd>
<img width="401" height="210" alt="image"  style="border: 1px solid black" src="https://github.com/user-attachments/assets/65ccb60f-a2a6-4703-ae0f-620e59026398" />
</kbd>

---

* **Fixed API request body example:**
<kbd>
<img width="1196" height="855" alt="image" src="https://github.com/user-attachments/assets/d7a1e9c2-573c-4c47-9757-d647b89d1e54" />
</kbd>

---

* **If `temporaryLocationId` is null then  `effectiveLocationId` will be equals `permanentLocationId` :**
<kbd>
<img width="973" height="556" alt="image" src="https://github.com/user-attachments/assets/e5137cc2-1028-4d53-95e8-c8a3e72da378" />
</kbd>
<kbd>
<img width="890" height="747" alt="image" src="https://github.com/user-attachments/assets/ab61d700-d419-4fa9-89a8-d5209ff1da02" />
</kbd>

---

* **If `temporaryLocationId` and  `permanentLocationId`  are null then  `effectiveLocationId` will be equals Holding `temporaryLocationId`:**
<kbd>
<img width="982" height="565" alt="image" src="https://github.com/user-attachments/assets/e49264ac-d942-49f7-a311-3a9ebeac7740" />
</kbd>
<kbd>
<img width="990" height="628" alt="image" src="https://github.com/user-attachments/assets/095e7916-bb09-4fb9-a450-a14dfee23396" />
</kbd>

---

* **Updated the callNumber components :**
<kbd>
<img width="974" height="647" alt="image" src="https://github.com/user-attachments/assets/caa1ea40-f5c7-4471-8825-2d9725703009" />
</kbd>
<kbd>
<img width="1276" height="532" alt="image" src="https://github.com/user-attachments/assets/88c7d579-ae80-4b16-b743-9ca0110e64de" />
</kbd>

---

* **Partially updated the callNumber components (update Suffix and remove CallNumberTypeId ):**
<kbd>
<img width="966" height="520" alt="image" src="https://github.com/user-attachments/assets/2933bd34-2c80-4208-90d2-53722886b8c8" />
</kbd>
<kbd>
<img width="1294" height="536" alt="image" src="https://github.com/user-attachments/assets/673bd808-6ba6-499e-a10e-55af93270caa" />
</kbd>

