### PR TITLE
feat: implement sanitizers for HoldingsRecord, Instance, and Item

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -42,6 +42,7 @@
 * Improve performance of get_items_and_holdings_view to avoid extra memory and space consumption ([MODINVSTOR-1474](https://folio-org.atlassian.net/browse/MODINVSTOR-1474))
 * Add source field to reference data and update existing loan types ([MODINVSTOR-1476](https://folio-org.atlassian.net/browse/MODINVSTOR-1476))
 * Add default empty values for S3_SECRET_ACCESS_KEY and S3_ACCESS_KEY_ID ([MODINVSTOR-1489](https://folio-org.atlassian.net/browse/MODINVSTOR-1489))
+* Implement sanitizers for HoldingsRecord, Instance, and Item ([MODINVSTOR-1497](https://folio-org.atlassian.net/browse/MODINVSTOR-1497))
 
 ### Bug fixes
 * Fix ordering of electronic access items for inventory-hierarchy, oai-pmh-view ([MODINVSTOR-1224](https://folio-org.atlassian.net/browse/MODINVSTOR-1224))

--- a/src/main/java/org/folio/services/sanitizer/Sanitizer.java
+++ b/src/main/java/org/folio/services/sanitizer/Sanitizer.java
@@ -1,0 +1,33 @@
+package org.folio.services.sanitizer;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.commons.lang3.StringUtils;
+import org.jspecify.annotations.Nullable;
+
+@FunctionalInterface
+public interface Sanitizer<T> {
+
+  void sanitize(@Nullable T entity);
+
+  default List<String> cleanList(@Nullable List<String> list) {
+    if (list == null) {
+      return new ArrayList<>();
+    }
+    return list.stream()
+      .filter(StringUtils::isNotBlank)
+      .toList();
+  }
+
+  default Set<String> cleanSet(@Nullable Set<String> set) {
+    if (set == null) {
+      return new LinkedHashSet<>();
+    }
+    return set.stream()
+      .filter(StringUtils::isNotBlank)
+      .collect(Collectors.toCollection(LinkedHashSet::new));
+  }
+}

--- a/src/main/java/org/folio/services/sanitizer/SanitizerFactory.java
+++ b/src/main/java/org/folio/services/sanitizer/SanitizerFactory.java
@@ -1,0 +1,36 @@
+package org.folio.services.sanitizer;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.folio.rest.jaxrs.model.HoldingsRecord;
+import org.folio.rest.jaxrs.model.Instance;
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.services.sanitizer.impl.HoldingsRecordSanitizer;
+import org.folio.services.sanitizer.impl.InstanceSanitizer;
+import org.folio.services.sanitizer.impl.ItemSanitizer;
+
+public final class SanitizerFactory {
+
+  private static final Map<Class<?>, Sanitizer<?>> SANITIZERS = createSanitizers();
+
+  private SanitizerFactory() {
+    throw new UnsupportedOperationException("Factory class");
+  }
+
+  private static Map<Class<?>, Sanitizer<?>> createSanitizers() {
+    Map<Class<?>, Sanitizer<?>> map = new HashMap<>();
+    map.put(Instance.class, new InstanceSanitizer());
+    map.put(Item.class, new ItemSanitizer());
+    map.put(HoldingsRecord.class, new HoldingsRecordSanitizer());
+    return Map.copyOf(map);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T> Sanitizer<T> getSanitizer(Class<T> clazz) {
+    var sanitizer = SANITIZERS.get(clazz);
+    if (sanitizer == null) {
+      throw new IllegalArgumentException("Sanitizer not found for class " + clazz.getName());
+    }
+    return (Sanitizer<T>) sanitizer;
+  }
+}

--- a/src/main/java/org/folio/services/sanitizer/impl/HoldingsRecordSanitizer.java
+++ b/src/main/java/org/folio/services/sanitizer/impl/HoldingsRecordSanitizer.java
@@ -1,0 +1,18 @@
+package org.folio.services.sanitizer.impl;
+
+import org.folio.rest.jaxrs.model.HoldingsRecord;
+import org.folio.services.sanitizer.Sanitizer;
+import org.jspecify.annotations.Nullable;
+
+public final class HoldingsRecordSanitizer implements Sanitizer<HoldingsRecord> {
+
+  @Override
+  public void sanitize(@Nullable HoldingsRecord holdings) {
+    if (holdings == null) {
+      return;
+    }
+    holdings.setAdministrativeNotes(cleanList(holdings.getAdministrativeNotes()));
+    holdings.setStatisticalCodeIds(cleanSet(holdings.getStatisticalCodeIds()));
+    holdings.setFormerIds(cleanSet(holdings.getFormerIds()));
+  }
+}

--- a/src/main/java/org/folio/services/sanitizer/impl/InstanceSanitizer.java
+++ b/src/main/java/org/folio/services/sanitizer/impl/InstanceSanitizer.java
@@ -1,0 +1,24 @@
+package org.folio.services.sanitizer.impl;
+
+import org.folio.rest.jaxrs.model.Instance;
+import org.folio.services.sanitizer.Sanitizer;
+import org.jspecify.annotations.Nullable;
+
+public final class InstanceSanitizer implements Sanitizer<Instance> {
+
+  @Override
+  public void sanitize(@Nullable Instance instance) {
+    if (instance == null) {
+      return;
+    }
+    instance.setInstanceFormatIds(cleanList(instance.getInstanceFormatIds()));
+    instance.setPhysicalDescriptions(cleanList(instance.getPhysicalDescriptions()));
+    instance.setLanguages(cleanList(instance.getLanguages()));
+    instance.setAdministrativeNotes(cleanList(instance.getAdministrativeNotes()));
+    instance.setEditions(cleanSet(instance.getEditions()));
+    instance.setPublicationRange(cleanSet(instance.getPublicationRange()));
+    instance.setPublicationFrequency(cleanSet(instance.getPublicationFrequency()));
+    instance.setNatureOfContentTermIds(cleanSet(instance.getNatureOfContentTermIds()));
+    instance.setStatisticalCodeIds(cleanSet(instance.getStatisticalCodeIds()));
+  }
+}

--- a/src/main/java/org/folio/services/sanitizer/impl/ItemSanitizer.java
+++ b/src/main/java/org/folio/services/sanitizer/impl/ItemSanitizer.java
@@ -1,0 +1,17 @@
+package org.folio.services.sanitizer.impl;
+
+import org.folio.rest.jaxrs.model.Item;
+import org.folio.services.sanitizer.Sanitizer;
+import org.jspecify.annotations.Nullable;
+
+public final class ItemSanitizer implements Sanitizer<Item> {
+
+  @Override
+  public void sanitize(@Nullable Item item) {
+    if (item == null) {
+      return;
+    }
+    item.setAdministrativeNotes(cleanList(item.getAdministrativeNotes()));
+    item.setStatisticalCodeIds(cleanSet(item.getStatisticalCodeIds()));
+  }
+}

--- a/src/test/java/org/folio/services/sanitizer/SanitizerFactoryTest.java
+++ b/src/test/java/org/folio/services/sanitizer/SanitizerFactoryTest.java
@@ -1,0 +1,57 @@
+package org.folio.services.sanitizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.folio.rest.jaxrs.model.HoldingsRecord;
+import org.folio.rest.jaxrs.model.Instance;
+import org.folio.rest.jaxrs.model.Item;
+import org.junit.jupiter.api.Test;
+
+class SanitizerFactoryTest {
+
+  @Test
+  void getSanitizerShouldReturnInstanceSanitizer() {
+    Sanitizer<Instance> sanitizer = SanitizerFactory.getSanitizer(Instance.class);
+    assertNotNull(sanitizer);
+  }
+
+  @Test
+  void getSanitizerShouldReturnItemSanitizer() {
+    Sanitizer<Item> sanitizer = SanitizerFactory.getSanitizer(Item.class);
+    assertNotNull(sanitizer);
+  }
+
+  @Test
+  void getSanitizerShouldReturnHoldingsRecordSanitizer() {
+    Sanitizer<HoldingsRecord> sanitizer = SanitizerFactory.getSanitizer(HoldingsRecord.class);
+    assertNotNull(sanitizer);
+  }
+
+  @Test
+  void getSanitizerShouldThrowExceptionForUnsupportedClass() {
+    IllegalArgumentException exception = assertThrows(
+      IllegalArgumentException.class,
+      () -> SanitizerFactory.getSanitizer(String.class)
+    );
+    assertEquals("Sanitizer not found for class java.lang.String", exception.getMessage());
+  }
+
+  @Test
+  void getSanitizerShouldReturnSameSanitizerInstanceForSameClass() {
+    Sanitizer<Instance> sanitizer1 = SanitizerFactory.getSanitizer(Instance.class);
+    Sanitizer<Instance> sanitizer2 = SanitizerFactory.getSanitizer(Instance.class);
+    assertEquals(sanitizer1, sanitizer2);
+  }
+
+  @Test
+  void constructorShouldThrowUnsupportedOperationException() throws NoSuchMethodException {
+    var constructor = SanitizerFactory.class.getDeclaredConstructor();
+    constructor.setAccessible(true);
+    var exception = assertThrows(Exception.class, constructor::newInstance);
+    assertInstanceOf(UnsupportedOperationException.class, exception.getCause());
+    assertEquals("Factory class", exception.getCause().getMessage());
+  }
+}

--- a/src/test/java/org/folio/services/sanitizer/SanitizerTest.java
+++ b/src/test/java/org/folio/services/sanitizer/SanitizerTest.java
@@ -1,0 +1,109 @@
+package org.folio.services.sanitizer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+
+class SanitizerTest {
+
+  private static final Sanitizer<String> TEST_SANITIZER = entity -> { };
+
+  @Test
+  void cleanListShouldReturnEmptyListWhenInputIsNull() {
+    List<String> result = TEST_SANITIZER.cleanList(null);
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void cleanListShouldReturnEmptyListWhenInputIsEmpty() {
+    List<String> result = TEST_SANITIZER.cleanList(new ArrayList<>());
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  void cleanListShouldFilterOutBlankStrings() {
+    List<String> input = Arrays.asList("valid", "", "  ", null, "another");
+    List<String> result = TEST_SANITIZER.cleanList(input);
+    assertEquals(2, result.size());
+    assertEquals("valid", result.get(0));
+    assertEquals("another", result.get(1));
+  }
+
+  @Test
+  void cleanListShouldFilterOutWhitespaceOnlyStrings() {
+    List<String> input = Arrays.asList("value1", "   ", "\t", "\n", "value2");
+    List<String> result = TEST_SANITIZER.cleanList(input);
+    assertEquals(2, result.size());
+    assertEquals("value1", result.get(0));
+    assertEquals("value2", result.get(1));
+  }
+
+  @Test
+  void cleanListShouldPreserveOrder() {
+    List<String> input = Arrays.asList("first", "", "second", "  ", "third");
+    List<String> result = TEST_SANITIZER.cleanList(input);
+    assertEquals(Arrays.asList("first", "second", "third"), result);
+  }
+
+  @Test
+  void cleanSetShouldReturnEmptySetWhenInputIsNull() {
+    Set<String> result = TEST_SANITIZER.cleanSet(null);
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+    assertInstanceOf(LinkedHashSet.class, result);
+  }
+
+  @Test
+  void cleanSetShouldReturnEmptySetWhenInputIsEmpty() {
+    Set<String> result = TEST_SANITIZER.cleanSet(new LinkedHashSet<>());
+    assertNotNull(result);
+    assertTrue(result.isEmpty());
+    assertInstanceOf(LinkedHashSet.class, result);
+  }
+
+  @Test
+  void cleanSetShouldFilterOutBlankStrings() {
+    Set<String> input = new LinkedHashSet<>(Arrays.asList("valid", "", "  ", "another"));
+    Set<String> result = TEST_SANITIZER.cleanSet(input);
+    assertEquals(2, result.size());
+    assertTrue(result.contains("valid"));
+    assertTrue(result.contains("another"));
+  }
+
+  @Test
+  void cleanSetShouldFilterOutWhitespaceOnlyStrings() {
+    Set<String> input = new LinkedHashSet<>(Arrays.asList("value1", "   ", "\t", "\n", "value2"));
+    Set<String> result = TEST_SANITIZER.cleanSet(input);
+    assertEquals(2, result.size());
+    assertTrue(result.contains("value1"));
+    assertTrue(result.contains("value2"));
+  }
+
+  @Test
+  void cleanSetShouldPreserveInsertionOrder() {
+    Set<String> input = new LinkedHashSet<>(Arrays.asList("first", "", "second", "  ", "third"));
+    Set<String> result = TEST_SANITIZER.cleanSet(input);
+    assertEquals(3, result.size());
+    List<String> resultList = new ArrayList<>(result);
+    assertEquals("first", resultList.get(0));
+    assertEquals("second", resultList.get(1));
+    assertEquals("third", resultList.get(2));
+  }
+
+  @Test
+  void cleanSetShouldReturnLinkedHashSetType() {
+    Set<String> input = new LinkedHashSet<>(Arrays.asList("a", "b", "c"));
+    Set<String> result = TEST_SANITIZER.cleanSet(input);
+    assertInstanceOf(LinkedHashSet.class, result);
+  }
+}

--- a/src/test/java/org/folio/services/sanitizer/impl/HoldingsRecordSanitizerTest.java
+++ b/src/test/java/org/folio/services/sanitizer/impl/HoldingsRecordSanitizerTest.java
@@ -1,0 +1,226 @@
+package org.folio.services.sanitizer.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import java.util.List;
+import org.folio.rest.jaxrs.model.HoldingsRecord;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class HoldingsRecordSanitizerTest {
+
+  private HoldingsRecordSanitizer sanitizer;
+
+  @BeforeEach
+  void setUp() {
+    sanitizer = new HoldingsRecordSanitizer();
+  }
+
+  @Test
+  void sanitizeShouldHandleNullHoldingsRecord() {
+    assertDoesNotThrow(() -> sanitizer.sanitize(null));
+  }
+
+  @Test
+  void sanitizeShouldCleanAdministrativeNotes() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setAdministrativeNotes(Arrays.asList("note1", "", "note2", "  ", "note3"));
+    sanitizer.sanitize(holdings);
+    assertEquals(3, holdings.getAdministrativeNotes().size());
+    assertEquals(Arrays.asList("note1", "note2", "note3"), holdings.getAdministrativeNotes());
+  }
+
+  @Test
+  void sanitizeShouldHandleNullAdministrativeNotes() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setAdministrativeNotes(null);
+    sanitizer.sanitize(holdings);
+    assertNotNull(holdings.getAdministrativeNotes());
+    assertTrue(holdings.getAdministrativeNotes().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldHandleEmptyAdministrativeNotes() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setAdministrativeNotes(new ArrayList<>());
+    sanitizer.sanitize(holdings);
+    assertNotNull(holdings.getAdministrativeNotes());
+    assertTrue(holdings.getAdministrativeNotes().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldFilterOutWhitespaceOnlyAdministrativeNotes() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setAdministrativeNotes(Arrays.asList("valid note", "\t", "\n", "   "));
+    sanitizer.sanitize(holdings);
+    assertEquals(1, holdings.getAdministrativeNotes().size());
+    assertEquals("valid note", holdings.getAdministrativeNotes().getFirst());
+  }
+
+  @Test
+  void sanitizeShouldCleanStatisticalCodeIds() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setStatisticalCodeIds(new LinkedHashSet<>(Arrays.asList("code1", "", "code2", "  ", "code3")));
+    sanitizer.sanitize(holdings);
+    assertEquals(3, holdings.getStatisticalCodeIds().size());
+    assertTrue(holdings.getStatisticalCodeIds().contains("code1"));
+    assertTrue(holdings.getStatisticalCodeIds().contains("code2"));
+    assertTrue(holdings.getStatisticalCodeIds().contains("code3"));
+  }
+
+  @Test
+  void sanitizeShouldHandleNullStatisticalCodeIds() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setStatisticalCodeIds(null);
+    sanitizer.sanitize(holdings);
+    assertNotNull(holdings.getStatisticalCodeIds());
+    assertTrue(holdings.getStatisticalCodeIds().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldHandleEmptyStatisticalCodeIds() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setStatisticalCodeIds(new LinkedHashSet<>());
+    sanitizer.sanitize(holdings);
+    assertNotNull(holdings.getStatisticalCodeIds());
+    assertTrue(holdings.getStatisticalCodeIds().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldFilterOutWhitespaceOnlyStatisticalCodeIds() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setStatisticalCodeIds(new LinkedHashSet<>(Arrays.asList("valid-code", "   ", "\t", "\n")));
+    sanitizer.sanitize(holdings);
+    assertEquals(1, holdings.getStatisticalCodeIds().size());
+    assertTrue(holdings.getStatisticalCodeIds().contains("valid-code"));
+  }
+
+  @Test
+  void sanitizeShouldCleanFormerIds() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setFormerIds(new LinkedHashSet<>(Arrays.asList("id1", "", "id2", "  ", "id3")));
+    sanitizer.sanitize(holdings);
+    assertEquals(3, holdings.getFormerIds().size());
+    assertTrue(holdings.getFormerIds().contains("id1"));
+    assertTrue(holdings.getFormerIds().contains("id2"));
+    assertTrue(holdings.getFormerIds().contains("id3"));
+  }
+
+  @Test
+  void sanitizeShouldHandleNullFormerIds() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setFormerIds(null);
+    sanitizer.sanitize(holdings);
+    assertNotNull(holdings.getFormerIds());
+    assertTrue(holdings.getFormerIds().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldHandleEmptyFormerIds() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setFormerIds(new LinkedHashSet<>());
+    sanitizer.sanitize(holdings);
+    assertNotNull(holdings.getFormerIds());
+    assertTrue(holdings.getFormerIds().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldFilterOutWhitespaceOnlyFormerIds() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setFormerIds(new LinkedHashSet<>(Arrays.asList("valid-id", "   ", "\t", "\n")));
+    sanitizer.sanitize(holdings);
+    assertEquals(1, holdings.getFormerIds().size());
+    assertTrue(holdings.getFormerIds().contains("valid-id"));
+  }
+
+  @Test
+  void sanitizeShouldCleanAllFieldsSimultaneously() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setAdministrativeNotes(Arrays.asList("note1", "", "note2", "  "));
+    holdings.setStatisticalCodeIds(new LinkedHashSet<>(Arrays.asList("code1", "", "code2")));
+    holdings.setFormerIds(new LinkedHashSet<>(Arrays.asList("id1", "", "id2")));
+    
+    sanitizer.sanitize(holdings);
+    
+    assertEquals(2, holdings.getAdministrativeNotes().size());
+    assertEquals(Arrays.asList("note1", "note2"), holdings.getAdministrativeNotes());
+    assertEquals(2, holdings.getStatisticalCodeIds().size());
+    assertTrue(holdings.getStatisticalCodeIds().contains("code1"));
+    assertTrue(holdings.getStatisticalCodeIds().contains("code2"));
+    assertEquals(2, holdings.getFormerIds().size());
+    assertTrue(holdings.getFormerIds().contains("id1"));
+    assertTrue(holdings.getFormerIds().contains("id2"));
+  }
+
+  @Test
+  void sanitizeShouldPreserveOrderInAdministrativeNotes() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    List<String> notes = new ArrayList<>(Arrays.asList("first", "", "second", "  ", "third"));
+    holdings.setAdministrativeNotes(notes);
+    sanitizer.sanitize(holdings);
+    assertEquals(Arrays.asList("first", "second", "third"), holdings.getAdministrativeNotes());
+  }
+
+  @Test
+  void sanitizeShouldPreserveOrderInStatisticalCodeIds() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    LinkedHashSet<String> codes = new LinkedHashSet<>(Arrays.asList("code1", "", "code2", "  ", "code3"));
+    holdings.setStatisticalCodeIds(codes);
+    sanitizer.sanitize(holdings);
+    List<String> codesList = new ArrayList<>(holdings.getStatisticalCodeIds());
+    assertEquals(3, codesList.size());
+    assertEquals("code1", codesList.get(0));
+    assertEquals("code2", codesList.get(1));
+    assertEquals("code3", codesList.get(2));
+  }
+
+  @Test
+  void sanitizeShouldPreserveOrderInFormerIds() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    LinkedHashSet<String> ids = new LinkedHashSet<>(Arrays.asList("id1", "", "id2", "  ", "id3"));
+    holdings.setFormerIds(ids);
+    sanitizer.sanitize(holdings);
+    List<String> idsList = new ArrayList<>(holdings.getFormerIds());
+    assertEquals(3, idsList.size());
+    assertEquals("id1", idsList.get(0));
+    assertEquals("id2", idsList.get(1));
+    assertEquals("id3", idsList.get(2));
+  }
+
+  @Test
+  void sanitizeShouldHandleAllBlankValues() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setAdministrativeNotes(Arrays.asList("", "  ", "\t", "\n"));
+    holdings.setStatisticalCodeIds(new LinkedHashSet<>(Arrays.asList("", "  ", "\t")));
+    holdings.setFormerIds(new LinkedHashSet<>(Arrays.asList("", "\n", "  ")));
+    
+    sanitizer.sanitize(holdings);
+    
+    assertTrue(holdings.getAdministrativeNotes().isEmpty());
+    assertTrue(holdings.getStatisticalCodeIds().isEmpty());
+    assertTrue(holdings.getFormerIds().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldReturnLinkedHashSetForStatisticalCodeIds() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setStatisticalCodeIds(new LinkedHashSet<>(Arrays.asList("code1", "code2")));
+    sanitizer.sanitize(holdings);
+    assertInstanceOf(LinkedHashSet.class, holdings.getStatisticalCodeIds());
+  }
+
+  @Test
+  void sanitizeShouldReturnLinkedHashSetForFormerIds() {
+    HoldingsRecord holdings = new HoldingsRecord();
+    holdings.setFormerIds(new LinkedHashSet<>(Arrays.asList("id1", "id2")));
+    sanitizer.sanitize(holdings);
+    assertInstanceOf(LinkedHashSet.class, holdings.getFormerIds());
+  }
+}

--- a/src/test/java/org/folio/services/sanitizer/impl/InstanceSanitizerTest.java
+++ b/src/test/java/org/folio/services/sanitizer/impl/InstanceSanitizerTest.java
@@ -1,0 +1,243 @@
+package org.folio.services.sanitizer.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import org.folio.rest.jaxrs.model.Instance;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class InstanceSanitizerTest {
+
+  private InstanceSanitizer sanitizer;
+
+  @BeforeEach
+  void setUp() {
+    sanitizer = new InstanceSanitizer();
+  }
+
+  @Test
+  void sanitizeShouldHandleNullInstance() {
+    assertDoesNotThrow(() -> sanitizer.sanitize(null));
+  }
+
+  @Test
+  void sanitizeShouldCleanInstanceFormatIds() {
+    var instance = new Instance();
+    instance.setInstanceFormatIds(Arrays.asList("id1", "", "id2", "  ", "id3"));
+    sanitizer.sanitize(instance);
+    assertEquals(3, instance.getInstanceFormatIds().size());
+    assertEquals(Arrays.asList("id1", "id2", "id3"), instance.getInstanceFormatIds());
+  }
+
+  @Test
+  void sanitizeShouldHandleNullInstanceFormatIds() {
+    var instance = new Instance();
+    instance.setInstanceFormatIds(null);
+    sanitizer.sanitize(instance);
+    assertNotNull(instance.getInstanceFormatIds());
+    assertTrue(instance.getInstanceFormatIds().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldCleanPhysicalDescriptions() {
+    var instance = new Instance();
+    instance.setPhysicalDescriptions(Arrays.asList("desc1", "", "desc2", "   "));
+    sanitizer.sanitize(instance);
+    assertEquals(2, instance.getPhysicalDescriptions().size());
+    assertEquals(Arrays.asList("desc1", "desc2"), instance.getPhysicalDescriptions());
+  }
+
+  @Test
+  void sanitizeShouldHandleNullPhysicalDescriptions() {
+    var instance = new Instance();
+    instance.setPhysicalDescriptions(null);
+    sanitizer.sanitize(instance);
+    assertNotNull(instance.getPhysicalDescriptions());
+    assertTrue(instance.getPhysicalDescriptions().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldCleanLanguages() {
+    var instance = new Instance();
+    instance.setLanguages(Arrays.asList("eng", "", "spa", "\t"));
+    sanitizer.sanitize(instance);
+    assertEquals(2, instance.getLanguages().size());
+    assertEquals(Arrays.asList("eng", "spa"), instance.getLanguages());
+  }
+
+  @Test
+  void sanitizeShouldHandleNullLanguages() {
+    var instance = new Instance();
+    instance.setLanguages(null);
+    sanitizer.sanitize(instance);
+    assertNotNull(instance.getLanguages());
+    assertTrue(instance.getLanguages().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldCleanAdministrativeNotes() {
+    var instance = new Instance();
+    instance.setAdministrativeNotes(Arrays.asList("note1", "", "note2"));
+    sanitizer.sanitize(instance);
+    assertEquals(2, instance.getAdministrativeNotes().size());
+    assertEquals(Arrays.asList("note1", "note2"), instance.getAdministrativeNotes());
+  }
+
+  @Test
+  void sanitizeShouldHandleNullAdministrativeNotes() {
+    var instance = new Instance();
+    instance.setAdministrativeNotes(null);
+    sanitizer.sanitize(instance);
+    assertNotNull(instance.getAdministrativeNotes());
+    assertTrue(instance.getAdministrativeNotes().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldCleanEditions() {
+    var instance = new Instance();
+    instance.setEditions(new LinkedHashSet<>(Arrays.asList("1st ed.", "", "2nd ed.", "  ")));
+    sanitizer.sanitize(instance);
+    assertEquals(2, instance.getEditions().size());
+    assertTrue(instance.getEditions().contains("1st ed."));
+    assertTrue(instance.getEditions().contains("2nd ed."));
+  }
+
+  @Test
+  void sanitizeShouldHandleNullEditions() {
+    var instance = new Instance();
+    instance.setEditions(null);
+    sanitizer.sanitize(instance);
+    assertNotNull(instance.getEditions());
+    assertTrue(instance.getEditions().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldCleanPublicationRange() {
+    var instance = new Instance();
+    instance.setPublicationRange(new LinkedHashSet<>(Arrays.asList("2000-2010", "", "2011-2020")));
+    sanitizer.sanitize(instance);
+    assertEquals(2, instance.getPublicationRange().size());
+    assertTrue(instance.getPublicationRange().contains("2000-2010"));
+    assertTrue(instance.getPublicationRange().contains("2011-2020"));
+  }
+
+  @Test
+  void sanitizeShouldHandleNullPublicationRange() {
+    var instance = new Instance();
+    instance.setPublicationRange(null);
+    sanitizer.sanitize(instance);
+    assertNotNull(instance.getPublicationRange());
+    assertTrue(instance.getPublicationRange().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldCleanPublicationFrequency() {
+    var instance = new Instance();
+    instance.setPublicationFrequency(new LinkedHashSet<>(Arrays.asList("monthly", "", "quarterly")));
+    sanitizer.sanitize(instance);
+    assertEquals(2, instance.getPublicationFrequency().size());
+    assertTrue(instance.getPublicationFrequency().contains("monthly"));
+    assertTrue(instance.getPublicationFrequency().contains("quarterly"));
+  }
+
+  @Test
+  void sanitizeShouldHandleNullPublicationFrequency() {
+    var instance = new Instance();
+    instance.setPublicationFrequency(null);
+    sanitizer.sanitize(instance);
+    assertNotNull(instance.getPublicationFrequency());
+    assertTrue(instance.getPublicationFrequency().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldCleanNatureOfContentTermIds() {
+    var instance = new Instance();
+    instance.setNatureOfContentTermIds(new LinkedHashSet<>(Arrays.asList("term1", "", "term2")));
+    sanitizer.sanitize(instance);
+    assertEquals(2, instance.getNatureOfContentTermIds().size());
+    assertTrue(instance.getNatureOfContentTermIds().contains("term1"));
+    assertTrue(instance.getNatureOfContentTermIds().contains("term2"));
+  }
+
+  @Test
+  void sanitizeShouldHandleNullNatureOfContentTermIds() {
+    var instance = new Instance();
+    instance.setNatureOfContentTermIds(null);
+    sanitizer.sanitize(instance);
+    assertNotNull(instance.getNatureOfContentTermIds());
+    assertTrue(instance.getNatureOfContentTermIds().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldCleanStatisticalCodeIds() {
+    var instance = new Instance();
+    instance.setStatisticalCodeIds(new LinkedHashSet<>(Arrays.asList("code1", "", "code2")));
+    sanitizer.sanitize(instance);
+    assertEquals(2, instance.getStatisticalCodeIds().size());
+    assertTrue(instance.getStatisticalCodeIds().contains("code1"));
+    assertTrue(instance.getStatisticalCodeIds().contains("code2"));
+  }
+
+  @Test
+  void sanitizeShouldHandleNullStatisticalCodeIds() {
+    var instance = new Instance();
+    instance.setStatisticalCodeIds(null);
+    sanitizer.sanitize(instance);
+    assertNotNull(instance.getStatisticalCodeIds());
+    assertTrue(instance.getStatisticalCodeIds().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldCleanAllFieldsSimultaneously() {
+    var instance = new Instance();
+    instance.setInstanceFormatIds(Arrays.asList("format1", "", "format2"));
+    instance.setPhysicalDescriptions(Arrays.asList("desc1", "  "));
+    instance.setLanguages(Arrays.asList("", "eng"));
+    instance.setAdministrativeNotes(Arrays.asList("note1", ""));
+    instance.setEditions(new LinkedHashSet<>(Arrays.asList("ed1", "")));
+    instance.setPublicationRange(new LinkedHashSet<>(Arrays.asList("", "2020")));
+    instance.setPublicationFrequency(new LinkedHashSet<>(Arrays.asList("monthly", "")));
+    instance.setNatureOfContentTermIds(new LinkedHashSet<>(Arrays.asList("", "term1")));
+    instance.setStatisticalCodeIds(new LinkedHashSet<>(Arrays.asList("code1", "")));
+
+    sanitizer.sanitize(instance);
+
+    assertEquals(2, instance.getInstanceFormatIds().size());
+    assertEquals(1, instance.getPhysicalDescriptions().size());
+    assertEquals(1, instance.getLanguages().size());
+    assertEquals(1, instance.getAdministrativeNotes().size());
+    assertEquals(1, instance.getEditions().size());
+    assertEquals(1, instance.getPublicationRange().size());
+    assertEquals(1, instance.getPublicationFrequency().size());
+    assertEquals(1, instance.getNatureOfContentTermIds().size());
+    assertEquals(1, instance.getStatisticalCodeIds().size());
+  }
+
+  @Test
+  void sanitizeShouldPreserveOrderInLists() {
+    var instance = new Instance();
+    var languages = new ArrayList<>(Arrays.asList("eng", "", "spa", "  ", "fra"));
+    instance.setLanguages(languages);
+    sanitizer.sanitize(instance);
+    assertEquals(Arrays.asList("eng", "spa", "fra"), instance.getLanguages());
+  }
+
+  @Test
+  void sanitizeShouldPreserveOrderInSets() {
+    var instance = new Instance();
+    var editions = new LinkedHashSet<>(Arrays.asList("1st", "", "2nd", "  ", "3rd"));
+    instance.setEditions(editions);
+    sanitizer.sanitize(instance);
+    var editionsList = new ArrayList<>(instance.getEditions());
+    assertEquals(3, editionsList.size());
+    assertEquals("1st", editionsList.get(0));
+    assertEquals("2nd", editionsList.get(1));
+    assertEquals("3rd", editionsList.get(2));
+  }
+}

--- a/src/test/java/org/folio/services/sanitizer/impl/ItemSanitizerTest.java
+++ b/src/test/java/org/folio/services/sanitizer/impl/ItemSanitizerTest.java
@@ -1,0 +1,182 @@
+package org.folio.services.sanitizer.impl;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashSet;
+import org.folio.rest.jaxrs.model.Item;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class ItemSanitizerTest {
+
+  private ItemSanitizer sanitizer;
+
+  @BeforeEach
+  void setUp() {
+    sanitizer = new ItemSanitizer();
+  }
+
+  @Test
+  void sanitizeShouldHandleNullItem() {
+    assertDoesNotThrow(() -> sanitizer.sanitize(null));
+  }
+
+  @Test
+  void sanitizeShouldCleanAdministrativeNotes() {
+    var item = new Item();
+    item.setAdministrativeNotes(Arrays.asList("note1", "", "note2", "  ", "note3"));
+
+    sanitizer.sanitize(item);
+
+    assertEquals(3, item.getAdministrativeNotes().size());
+    assertEquals(Arrays.asList("note1", "note2", "note3"), item.getAdministrativeNotes());
+  }
+
+  @Test
+  void sanitizeShouldHandleNullAdministrativeNotes() {
+    var item = new Item();
+    item.setAdministrativeNotes(null);
+
+    sanitizer.sanitize(item);
+
+    assertNotNull(item.getAdministrativeNotes());
+    assertTrue(item.getAdministrativeNotes().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldHandleEmptyAdministrativeNotes() {
+    var item = new Item();
+    item.setAdministrativeNotes(new ArrayList<>());
+
+    sanitizer.sanitize(item);
+
+    assertNotNull(item.getAdministrativeNotes());
+    assertTrue(item.getAdministrativeNotes().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldFilterOutWhitespaceOnlyAdministrativeNotes() {
+    var item = new Item();
+    item.setAdministrativeNotes(Arrays.asList("valid note", "\t", "\n", "   "));
+
+    sanitizer.sanitize(item);
+
+    assertEquals(1, item.getAdministrativeNotes().size());
+    assertEquals("valid note", item.getAdministrativeNotes().getFirst());
+  }
+
+  @Test
+  void sanitizeShouldCleanStatisticalCodeIds() {
+    var item = new Item();
+    item.setStatisticalCodeIds(new LinkedHashSet<>(Arrays.asList("code1", "", "code2", "  ", "code3")));
+
+    sanitizer.sanitize(item);
+
+    assertEquals(3, item.getStatisticalCodeIds().size());
+    assertTrue(item.getStatisticalCodeIds().contains("code1"));
+    assertTrue(item.getStatisticalCodeIds().contains("code2"));
+    assertTrue(item.getStatisticalCodeIds().contains("code3"));
+  }
+
+  @Test
+  void sanitizeShouldHandleNullStatisticalCodeIds() {
+    var item = new Item();
+    item.setStatisticalCodeIds(null);
+
+    sanitizer.sanitize(item);
+
+    assertNotNull(item.getStatisticalCodeIds());
+    assertTrue(item.getStatisticalCodeIds().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldHandleEmptyStatisticalCodeIds() {
+    var item = new Item();
+    item.setStatisticalCodeIds(new LinkedHashSet<>());
+
+    sanitizer.sanitize(item);
+
+    assertNotNull(item.getStatisticalCodeIds());
+    assertTrue(item.getStatisticalCodeIds().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldFilterOutWhitespaceOnlyStatisticalCodeIds() {
+    Item item = new Item();
+    item.setStatisticalCodeIds(new LinkedHashSet<>(Arrays.asList("valid-code", "   ", "\t", "\n")));
+
+    sanitizer.sanitize(item);
+
+    assertEquals(1, item.getStatisticalCodeIds().size());
+    assertTrue(item.getStatisticalCodeIds().contains("valid-code"));
+  }
+
+  @Test
+  void sanitizeShouldCleanBothFieldsSimultaneously() {
+    var item = new Item();
+    item.setAdministrativeNotes(Arrays.asList("note1", "", "note2", "  "));
+    item.setStatisticalCodeIds(new LinkedHashSet<>(Arrays.asList("code1", "", "code2")));
+
+    sanitizer.sanitize(item);
+
+    assertEquals(2, item.getAdministrativeNotes().size());
+    assertEquals(Arrays.asList("note1", "note2"), item.getAdministrativeNotes());
+    assertEquals(2, item.getStatisticalCodeIds().size());
+    assertTrue(item.getStatisticalCodeIds().contains("code1"));
+    assertTrue(item.getStatisticalCodeIds().contains("code2"));
+  }
+
+  @Test
+  void sanitizeShouldPreserveOrderInAdministrativeNotes() {
+    var item = new Item();
+    var notes = new ArrayList<>(Arrays.asList("first", "", "second", "  ", "third"));
+    item.setAdministrativeNotes(notes);
+
+    sanitizer.sanitize(item);
+
+    assertEquals(Arrays.asList("first", "second", "third"), item.getAdministrativeNotes());
+  }
+
+  @Test
+  void sanitizeShouldPreserveOrderInStatisticalCodeIds() {
+    var item = new Item();
+    var codes = new LinkedHashSet<>(Arrays.asList("code1", "", "code2", "  ", "code3"));
+    item.setStatisticalCodeIds(codes);
+
+    sanitizer.sanitize(item);
+
+    var codesList = new ArrayList<>(item.getStatisticalCodeIds());
+    assertEquals(3, codesList.size());
+    assertEquals("code1", codesList.get(0));
+    assertEquals("code2", codesList.get(1));
+    assertEquals("code3", codesList.get(2));
+  }
+
+  @Test
+  void sanitizeShouldHandleAllBlankValues() {
+    var item = new Item();
+    item.setAdministrativeNotes(Arrays.asList("", "  ", "\t", "\n"));
+    item.setStatisticalCodeIds(new LinkedHashSet<>(Arrays.asList("", "  ", "\t")));
+
+    sanitizer.sanitize(item);
+
+    assertTrue(item.getAdministrativeNotes().isEmpty());
+    assertTrue(item.getStatisticalCodeIds().isEmpty());
+  }
+
+  @Test
+  void sanitizeShouldReturnLinkedHashSetForStatisticalCodeIds() {
+    Item item = new Item();
+    item.setStatisticalCodeIds(new LinkedHashSet<>(Arrays.asList("code1", "code2")));
+
+    sanitizer.sanitize(item);
+
+    assertInstanceOf(LinkedHashSet.class, item.getStatisticalCodeIds());
+  }
+}


### PR DESCRIPTION
### Purpose
Fix issue when an Instance could be created with empty elements in "instanceFormatIds", "natureOfContentTermIds" arrays

### Approach
implement sanitizers to clean-up item, holdings, instance DTO string collections

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODINVSTOR-1497