### PR TITLE
MODINVSTOR-1505: RMB 35.4.2, Vertx 4.5.23, folio-s3-client 2.3.1

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+## v29.0.17 2026-01-16
+### Dependencies
+* Bump `RMB` from `35.4.1` to `35.4.2` fixing Netty vuln ([MODINVSTOR-1505](https://folio-org.atlassian.net/browse/MODINVSTOR-1505))
+* Bump `Vertx` from `4.5.22` to `4.5.23` fixing Netty vuln ([MODINVSTOR-1505](https://folio-org.atlassian.net/browse/MODINVSTOR-1505))
+* Bump `folio-s3-client` from `2.3.0` to `2.3.1` fixing minio vuln ([MODINVSTOR-1505](https://folio-org.atlassian.net/browse/MODINVSTOR-1505))
+
 ## v29.0.16 2025-12-11
 ### Dependencies
 * Bump `RMB` from `35.4.0` to `35.4.1` ([MODINVSTOR-1495](https://folio-org.atlassian.net/browse/MODINVSTOR-1495))

--- a/pom.xml
+++ b/pom.xml
@@ -12,8 +12,8 @@
     <generate_routing_context>/instance-storage/instances,/instance-storage/instances/retrieve,/holdings-storage/holdings,/holdings-storage/holdings/retrieve,/item-storage/items,/item-storage/items/retrieve,/record-bulk/ids,/oai-pmh-view/instances,/oai-pmh-view/updatedInstanceIds,/oai-pmh-view/enrichedInstances,/inventory-hierarchy/updated-instance-ids,/inventory-hierarchy/items-and-holdings,/inventory-view/instances</generate_routing_context>
     <argLine />
 
-    <raml-module-builder-version>35.4.1</raml-module-builder-version> <!-- also update vertx.version -->
-    <vertx.version>4.5.22</vertx.version>
+    <raml-module-builder-version>35.4.2</raml-module-builder-version> <!-- also update vertx.version -->
+    <vertx.version>4.5.23</vertx.version>
     <marc4j.version>2.9.6</marc4j.version>
     <aspectj.version>1.9.22.1</aspectj.version>
     <folio-kafka-wrapper.version>3.3.1</folio-kafka-wrapper.version>
@@ -22,7 +22,7 @@
     <snappy-java.version>1.1.10.7</snappy-java.version>
     <commons-lang3.version>3.17.0</commons-lang3.version>
     <log4j.version>2.24.3</log4j.version>
-    <folio-s3-client.version>2.3.0</folio-s3-client.version>
+    <folio-s3-client.version>2.3.1</folio-s3-client.version>
 
     <okapi-testing.version>6.2.1</okapi-testing.version>
     <junit.version>5.12.0</junit.version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODINVSTOR-1505

### Purpose
In the Sunflower release/v29.0 branch fix security vulnerabilities:

* CVE-2025-67735 - netty-codec-http - CRLF injection, request smuggling - https://folio-org.atlassian.net/browse/FOLIO-4430
* CVE-2025-59952 - io.minio:minio - XML Injection - https://folio-org.atlassian.net/browse/FOLIO-4391

### Approach
Upgrade RMB from 35.4.1 to 35.4.2: https://github.com/folio-org/raml-module-builder/releases/tag/v35.4.2

Upgrade Vert.x from 4.5.22 to 4.5.23. https://github.com/folio-org/raml-module-builder/releases/tag/v35.4.2

Upgrade folio-s3-client from 2.3.0 to 2.3.1.

These upgrades fix the vulnerabilities.

### Changes Checklist
- n/a **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- n/a **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- n/a **Interface Version Changes**: Indicate any changes to interface versions.
- n/a **Interface Dependencies**: Document added or removed dependencies.
- n/a **Permissions**: Document any changes to permissions.
- [x] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/MODINVSTOR-1505
https://folio-org.atlassian.net/browse/FOLIO-4430
https://folio-org.atlassian.net/browse/FOLIO-4391