### PR TITLE
MODINVSTOR-1520 Add indexes to the instance table

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -46,6 +46,7 @@
 * Create a submodule with generated DTOs ([MODINVSTOR-1499](https://folio-org.atlassian.net/browse/MODINVSTOR-1499))
 * Implement of PATCH requests for instances ([MODINVSTOR-1456](https://folio-org.atlassian.net/browse/MODINVSTOR-1456))
 * Improve batch results of the PATCH /item-storage/items endpoint ([MODINVSTOR-1514](https://folio-org.atlassian.net/browse/MODINVSTOR-1514))
+* Add several new indexes to the instance table for use by FQM ([MODINVSTOR-1520](https://folio-org.atlassian.net/browse/MODINVSTOR-1520))
 
 ### Bug fixes
 * Fix ordering of electronic access items for inventory-hierarchy, oai-pmh-view ([MODINVSTOR-1224](https://folio-org.atlassian.net/browse/MODINVSTOR-1224))

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/createJsonbArrayIndexFunctions.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/createJsonbArrayIndexFunctions.sql
@@ -1,0 +1,28 @@
+-- Convert text to lowercase and remove accents for consistent indexing
+-- Usage: normalize_token('Sømé Téxt wîth Åcçéñts') -> 'some text with accents'
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.normalize_token(input_text text)
+  RETURNS text AS
+$$
+SELECT lower(${myuniversity}_${mymodule}.f_unaccent(input_text))
+$$ LANGUAGE sql IMMUTABLE
+                PARALLEL SAFE;
+
+-- Normalize each element in a JSONB array of strings and aggregate back into a JSONB array
+-- Usage: normalize_jsonb_array('["Sømé", "Téxt", "wîth", "Åcçéñts"]'::jsonb) -> '["some", "text", "with", "accents"]'
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.normalize_jsonb_array(input_array jsonb)
+  RETURNS jsonb AS
+$$
+SELECT coalesce(jsonb_agg(${myuniversity}_${mymodule}.normalize_token(val)), '[]' ::jsonb)
+FROM jsonb_array_elements_text(input_array) AS val
+$$ LANGUAGE sql IMMUTABLE
+                PARALLEL SAFE;
+
+-- Extract values from a JSONB array of objects based on specified keys and aggregate into a JSONB array
+-- Usage: extract_values('{"items": [{"name": "Item1", "value": "A"}, {"name": "Item2", "value": "B"}]}'::jsonb, 'items', 'value') -> '["A", "B"]'
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.extract_values(input_jsonb jsonb, array_key text, value_key text)
+  RETURNS jsonb AS
+$$
+SELECT coalesce(jsonb_agg(elem -> value_key), '[]'::jsonb)
+FROM jsonb_array_elements(input_jsonb -> array_key) AS elem
+$$ LANGUAGE sql IMMUTABLE
+                PARALLEL SAFE;

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/createToTimestampFunction.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/createToTimestampFunction.sql
@@ -1,0 +1,12 @@
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.to_timestamp(text)
+  RETURNS timestamp AS $$
+BEGIN
+  -- We assume the input text is always in a format (like ISO 8601)
+  -- that casts consistently to timestamp. This function turns the
+  -- ::timestamp cast into an IMMUTABLE function, so that it can be
+  -- used in indexes
+  RETURN $1::timestamp;
+EXCEPTION WHEN others THEN
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceCatalogedDateIndex.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceCatalogedDateIndex.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS instance_cataloged_date_idx ON ${myuniversity}_${mymodule}.instance
+  (${myuniversity}_${mymodule}.to_timestamp(jsonb->>'catalogedDate'));

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceClassificationNumberIndex.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceClassificationNumberIndex.sql
@@ -1,0 +1,6 @@
+CREATE INDEX IF NOT EXISTS instance_classifications_number_idx ON ${myuniversity}_${mymodule}.instance
+  USING gin (
+             ${myuniversity}_${mymodule}.normalize_jsonb_array(
+               ${myuniversity}_${mymodule}.extract_values(jsonb, 'classifications', 'classificationNumber'))
+             jsonb_path_ops
+    );

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceCreationDateIndex.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceCreationDateIndex.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS instance_creation_date_idx ON ${myuniversity}_${mymodule}.instance
+  (creation_date);

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceFormatIdsIndex.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceFormatIdsIndex.sql
@@ -1,0 +1,2 @@
+CREATE INDEX IF NOT EXISTS instance_format_ids_idx ON ${myuniversity}_${mymodule}.instance
+  USING gin ((jsonb -> 'instanceFormatIds') jsonb_path_ops);

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceIdentifierIndex.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceIdentifierIndex.sql
@@ -1,0 +1,6 @@
+CREATE INDEX IF NOT EXISTS instance_identifiers_values_idx ON ${myuniversity}_${mymodule}.instance
+  USING gin (
+             ${myuniversity}_${mymodule}.normalize_jsonb_array(
+               ${myuniversity}_${mymodule}.extract_values(jsonb, 'identifiers', 'value'))
+             jsonb_path_ops
+    );

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstancePublicationDateIndex.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstancePublicationDateIndex.sql
@@ -1,0 +1,6 @@
+CREATE INDEX IF NOT EXISTS instance_publication_date_idx ON ${myuniversity}_${mymodule}.instance
+  USING gin (
+             ${myuniversity}_${mymodule}.normalize_jsonb_array(
+               ${myuniversity}_${mymodule}.extract_values(jsonb, 'publication', 'dateOfPublication'))
+             jsonb_path_ops
+    );

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceSubjectValueIndex.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceSubjectValueIndex.sql
@@ -1,0 +1,6 @@
+CREATE INDEX IF NOT EXISTS instance_subjects_values_idx ON ${myuniversity}_${mymodule}.instance
+  USING gin (
+             ${myuniversity}_${mymodule}.normalize_jsonb_array(
+               ${myuniversity}_${mymodule}.extract_values(jsonb, 'subjects', 'value'))
+             jsonb_path_ops
+    );

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -1292,6 +1292,51 @@
       "run": "after",
       "snippetPath": "loan-types/updateLoanTypeSources.sql",
       "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "createToTimestampFunction.sql",
+      "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "createJsonbArrayIndexFunctions.sql",
+      "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "instance/createInstanceClassificationNumberIndex.sql",
+      "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "instance/createInstanceCreationDateIndex.sql",
+      "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "instance/createInstanceIdentifierIndex.sql",
+      "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "instance/createInstancePublicationDateIndex.sql",
+      "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "instance/createInstanceSubjectValueIndex.sql",
+      "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "instance/createInstanceCatalogedDateIndex.sql",
+      "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "instance/createInstanceFormatIdsIndex.sql",
+      "fromModuleVersion": "30.0.0"
     }
   ]
 }


### PR DESCRIPTION
### Purpose
This PR adds indexes for several instance fields. This will enable FQM to efficiently run queries based on these fields. They were identified as commonly used fields in FQM, but none of them have (useful) indexes available right now.

### Approach
FQM works by accessing live data via DB views. This means that indexes in the source schema can be used directly by FQM to improve its query performance.

### Changes Checklist
- [X] **Database Schema Changes**: This adds several DB functions and indexes via SQL scripts. In an upgrade, sysops will probably want to manually run these scripts. If they don't, then the DB objects will still be created, but the upgrade process will hang for a potentially very long time as the indexes are created.
- [X] **Manual Testing**: This has been tested in the Corsair eperf rancher environment. I'll be doing further testing before merging, too.
- [X] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
MODINVSTOR-1520
MODFQMMGR-1056

### Learning and Resources (if applicable)
I noticed that the `instance_identifiers_idx_ft` is not particularly useful: it indexes a significant amount of unneeded data, which makes the index significantly larger and slower than it should be, and it's also tricky to actually use. Unless there's something that actually uses it, that index should probably be dropped. The alternative version added in this PR performs significantly better.
