### PR TITLE
MODINVSTOR-1528 Add indexes for instance note fields

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -47,7 +47,7 @@
 * Implement of PATCH requests for instances ([MODINVSTOR-1456](https://folio-org.atlassian.net/browse/MODINVSTOR-1456))
 * Improve batch results of the PATCH /item-storage/items endpoint ([MODINVSTOR-1514](https://folio-org.atlassian.net/browse/MODINVSTOR-1514))
 * Implement of PATCH requests for items ([MODINVSTOR-1506](https://folio-org.atlassian.net/browse/MODINVSTOR-1506))
-* Add several new indexes to the instance table for use by FQM ([MODINVSTOR-1520](https://folio-org.atlassian.net/browse/MODINVSTOR-1520))
+* Add several new indexes to the instance table for use by FQM ([MODINVSTOR-1520](https://folio-org.atlassian.net/browse/MODINVSTOR-1520), [MODINVSTOR-1528](https://folio-org.atlassian.net/browse/MODINVSTOR-1528))
 * Add `/inventory-reindex-records/export` API to export reindex record ranges to S3 and publish `reindex.file-ready` events ([MODINVSTOR-1519](https://folio-org.atlassian.net/browse/MODINVSTOR-1519))
 
 ### Bug fixes

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceAdministrativeNotesIndex.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceAdministrativeNotesIndex.sql
@@ -1,0 +1,5 @@
+CREATE INDEX IF NOT EXISTS instance_administrativenotes_idx ON ${myuniversity}_${mymodule}.instance
+  USING gin (
+             ${myuniversity}_${mymodule}.normalize_jsonb_array(jsonb -> 'administrativeNotes')
+             jsonb_path_ops
+    );

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceNotesNoteIndex.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceNotesNoteIndex.sql
@@ -1,0 +1,6 @@
+CREATE INDEX IF NOT EXISTS instance_notes_note_idx ON ${myuniversity}_${mymodule}.instance
+  USING gin (
+             ${myuniversity}_${mymodule}.normalize_jsonb_array(
+               ${myuniversity}_${mymodule}.extract_values(jsonb, 'notes', 'note'))
+             jsonb_path_ops
+    );

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceNotesNoteTypeIdIndex.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceNotesNoteTypeIdIndex.sql
@@ -1,0 +1,6 @@
+CREATE INDEX IF NOT EXISTS instance_notes_instancenotesnotetypeid_idx ON ${myuniversity}_${mymodule}.instance
+  USING gin (
+             ${myuniversity}_${mymodule}.normalize_jsonb_array(
+               ${myuniversity}_${mymodule}.extract_values(jsonb, 'notes', 'instanceNoteTypeId'))
+             jsonb_path_ops
+    );

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceNotesStaffOnlyIndex.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceNotesStaffOnlyIndex.sql
@@ -1,0 +1,6 @@
+CREATE INDEX IF NOT EXISTS instance_notes_staffonly_idx ON ${myuniversity}_${mymodule}.instance
+  USING gin (
+             ${myuniversity}_${mymodule}.normalize_jsonb_array(
+               ${myuniversity}_${mymodule}.extract_values(jsonb, 'notes', 'staffOnly'))
+             jsonb_path_ops
+    );

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -1342,6 +1342,26 @@
       "run": "after",
       "snippetPath": "instance/createInstanceFormatIdsIndex.sql",
       "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "instance/createInstanceAdministrativeNotesIndex.sql",
+      "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "instance/createInstanceNotesNoteIndex.sql",
+      "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "instance/createInstanceNotesNoteTypeIdIndex.sql",
+      "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "instance/createInstanceNotesStaffOnlyIndex.sql",
+      "fromModuleVersion": "30.0.0"
     }
   ]
 }


### PR DESCRIPTION
Similar to #1309, this commit adds new indexes for the sub-fields within instance notes and for instance administrative notes. These indexes will be used for querying by FQM (MODFQMMGR-1057).

### Purpose
This PR adds indexes for several instance fields. This will enable FQM to efficiently run queries based on these fields. They were identified as commonly used fields in FQM, but none of them have (useful) indexes available right now.

### Approach
FQM works by accessing live data via DB views. This means that indexes in the source schema can be used directly by FQM to improve its query performance.

### Changes Checklist
- [X] **Database Schema Changes**: This adds several DB functions and indexes via SQL scripts. In an upgrade, sysops will probably want to manually run these scripts. If they don't, then the DB objects will still be created, but the upgrade process will hang for a potentially very long time as the indexes are created.
- [X] **Manual Testing**: This has been tested in the Corsair eperf rancher environment. I'll be doing further testing before merging, too.
- [X] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
MODINVSTOR-1528
MODFQMMGR-1057