### PR TITLE
MODINVSTOR-1512 Implement Kafka events publishing for Material type CRUD

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -51,6 +51,7 @@
 * Add `/inventory-reindex-records/export` API to export reindex record ranges to S3 and publish `reindex.file-ready` events ([MODINVSTOR-1519](https://folio-org.atlassian.net/browse/MODINVSTOR-1519))
 * Implement of PATCH requests for holdings records ([MODINVSTOR-1507](https://folio-org.atlassian.net/browse/MODINVSTOR-1507))
 * Implement Kafka events publishing for Loan type CRUD ([MODINVSTOR-1513](https://folio-org.atlassian.net/browse/MODINVSTOR-1513))
+* Implement Kafka events publishing for Material type CRUD ([MODINVSTOR-1512](https://folio-org.atlassian.net/browse/MODINVSTOR-1512))
 
 ### Bug fixes
 * Fix ordering of electronic access items for inventory-hierarchy, oai-pmh-view ([MODINVSTOR-1224](https://folio-org.atlassian.net/browse/MODINVSTOR-1224))

--- a/README.MD
+++ b/README.MD
@@ -115,6 +115,7 @@ These properties can be changed by setting env variable.
 * `KAFKA_REINDEX_RECORDS_TOPIC_NUM_PARTITIONS` Default value - `16`
 * `KAFKA_REINDEX_FILE_READY_TOPIC_NUM_PARTITIONS` Default value - `16`
 * `KAFKA_SUBJECT_SOURCE_TOPIC_NUM_PARTITIONS` Default value - `1`
+* `KAFKA_MATERIAL_TYPE_TOPIC_NUM_PARTITIONS` Default value - `1`
 
 There is also possibility for customizing through properties the Kafka Topic
 `message retention` (in milliseconds) and `maximum message size` (in bytes). The default values of these configurations
@@ -150,6 +151,7 @@ These environment variables configure Kafka, for details see [Kafka](#kafka):
 * `KAFKA_REINDEX_RECORDS_TOPIC_NUM_PARTITIONS`
 * `KAFKA_REINDEX_FILE_READY_TOPIC_NUM_PARTITIONS`
 * `KAFKA_SUBJECT_SOURCE_TOPIC_NUM_PARTITIONS`
+* `KAFKA_MATERIAL_TYPE_TOPIC_NUM_PARTITIONS`
 
 
 These environment variables configure Kafka topic for specific business-related topics
@@ -164,6 +166,7 @@ These environment variables configure Kafka topic for specific business-related 
 * `KAFKA_REINDEX_RECORDS_TOPIC_NUM_PARTITIONS`
 * `KAFKA_REINDEX_FILE_READY_TOPIC_NUM_PARTITIONS`
 * `KAFKA_SUBJECT_SOURCE_TOPIC_NUM_PARTITIONS`
+* `KAFKA_MATERIAL_TYPE_TOPIC_NUM_PARTITIONS`
 * `KAFKA_REINDEX_RECORDS_TOPIC_MESSAGE_RETENTION`
 * `KAFKA_REINDEX_RECORDS_TOPIC_MAX_MESSAGE_SIZE`
 

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -2952,6 +2952,7 @@
       { "name": "KAFKA_INSTITUTION_TOPIC_NUM_PARTITIONS", "value": "1"},
       { "name": "KAFKA_SUBJECT_TYPE_TOPIC_NUM_PARTITIONS", "value": "1"},
       { "name": "KAFKA_SUBJECT_SOURCE_TOPIC_NUM_PARTITIONS", "value": "1"},
+      { "name": "KAFKA_MATERIAL_TYPE_TOPIC_NUM_PARTITIONS", "value": "1"},
       { "name": "KAFKA_REINDEX_RECORDS_TOPIC_NUM_PARTITIONS", "value": "16"},
       { "name": "KAFKA_REINDEX_FILE_READY_TOPIC_NUM_PARTITIONS", "value": "16"},
       { "name": "KAFKA_REINDEX_RECORDS_TOPIC_MESSAGE_RETENTION", "value": "86400000"},

--- a/mod-inventory-storage-server/src/main/java/org/folio/InventoryKafkaTopic.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/InventoryKafkaTopic.java
@@ -30,7 +30,8 @@ public enum InventoryKafkaTopic implements KafkaTopic {
   REINDEX_FILE_READY("reindex.file-ready"),
   SERVICE_POINT("service-point"),
   SUBJECT_SOURCE("subject-source"),
-  SUBJECT_TYPE("subject-type");
+  SUBJECT_TYPE("subject-type"),
+  MATERIAL_TYPE("material-type");
 
   private static final String DEFAULT_NUM_PARTITIONS_PROPERTY = "KAFKA_DOMAIN_TOPIC_NUM_PARTITIONS";
   private static final int DEFAULT_NUM_PARTITIONS_VALUE = 50;
@@ -63,6 +64,7 @@ public enum InventoryKafkaTopic implements KafkaTopic {
     map.put(REINDEX_FILE_READY, Pair.of("KAFKA_REINDEX_FILE_READY_TOPIC_NUM_PARTITIONS", 16));
     map.put(SUBJECT_SOURCE, Pair.of("KAFKA_SUBJECT_SOURCE_TOPIC_NUM_PARTITIONS", 1));
     map.put(INSTANCE_DATE_TYPE, Pair.of("KAFKA_SUBJECT_SOURCE_TOPIC_NUM_PARTITIONS", 1));
+    map.put(MATERIAL_TYPE, Pair.of("KAFKA_MATERIAL_TYPE_TOPIC_NUM_PARTITIONS", 1));
     TOPIC_PARTITION_MAP = Collections.unmodifiableMap(map);
   }
 

--- a/mod-inventory-storage-server/src/main/java/org/folio/persist/MaterialTypeRepository.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/persist/MaterialTypeRepository.java
@@ -1,0 +1,15 @@
+package org.folio.persist;
+
+import static org.folio.rest.impl.MaterialTypeApi.MATERIAL_TYPE_TABLE;
+import static org.folio.rest.persist.PgUtil.postgresClient;
+
+import io.vertx.core.Context;
+import java.util.Map;
+import org.folio.rest.jaxrs.model.MaterialType;
+
+public class MaterialTypeRepository extends AbstractRepository<MaterialType> {
+
+  public MaterialTypeRepository(Context context, Map<String, String> okapiHeaders) {
+    super(postgresClient(context, okapiHeaders), MATERIAL_TYPE_TABLE, MaterialType.class);
+  }
+}

--- a/mod-inventory-storage-server/src/main/java/org/folio/rest/impl/MaterialTypeApi.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/rest/impl/MaterialTypeApi.java
@@ -1,5 +1,8 @@
 package org.folio.rest.impl;
 
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.rest.support.EndpointFailureHandler.handleFailure;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Handler;
@@ -7,10 +10,9 @@ import java.util.Map;
 import javax.ws.rs.core.Response;
 import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.MaterialType;
-import org.folio.rest.jaxrs.model.MaterialTypes;
+import org.folio.services.materialtype.MaterialTypeService;
 
-public class MaterialTypeApi extends BaseApi<MaterialType, MaterialTypes>
-  implements org.folio.rest.jaxrs.resource.MaterialTypes {
+public class MaterialTypeApi implements org.folio.rest.jaxrs.resource.MaterialTypes {
 
   public static final String MATERIAL_TYPE_TABLE = "material_type";
 
@@ -19,22 +21,30 @@ public class MaterialTypeApi extends BaseApi<MaterialType, MaterialTypes>
   public void getMaterialTypes(String query, String totalRecords, int offset, int limit,
                                Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
                                Context vertxContext) {
-    getEntities(query, totalRecords, offset, limit, okapiHeaders, asyncResultHandler, vertxContext,
-      GetMaterialTypesResponse.class);
+    new MaterialTypeService(vertxContext, okapiHeaders)
+      .getByQuery(query, offset, limit)
+      .onSuccess(response -> asyncResultHandler.handle(succeededFuture(response)))
+      .onFailure(handleFailure(asyncResultHandler));
   }
 
   @Validate
   @Override
   public void postMaterialTypes(MaterialType entity, Map<String, String> okapiHeaders,
                                 Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    postEntity(entity, okapiHeaders, asyncResultHandler, vertxContext, PostMaterialTypesResponse.class);
+    new MaterialTypeService(vertxContext, okapiHeaders)
+      .create(entity)
+      .onSuccess(response -> asyncResultHandler.handle(succeededFuture(response)))
+      .onFailure(handleFailure(asyncResultHandler));
   }
 
   @Validate
   @Override
   public void deleteMaterialTypes(Map<String, String> okapiHeaders,
                                   Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
-    deleteEntities(okapiHeaders, asyncResultHandler, vertxContext);
+    new MaterialTypeService(vertxContext, okapiHeaders)
+      .deleteAll()
+      .onSuccess(response -> asyncResultHandler.handle(succeededFuture(response)))
+      .onFailure(handleFailure(asyncResultHandler));
   }
 
   @Validate
@@ -43,7 +53,10 @@ public class MaterialTypeApi extends BaseApi<MaterialType, MaterialTypes>
                                                Map<String, String> okapiHeaders,
                                                Handler<AsyncResult<Response>> asyncResultHandler,
                                                Context vertxContext) {
-    getEntityById(id, okapiHeaders, asyncResultHandler, vertxContext, GetMaterialTypesByMaterialtypeIdResponse.class);
+    new MaterialTypeService(vertxContext, okapiHeaders)
+      .getById(id)
+      .onSuccess(response -> asyncResultHandler.handle(succeededFuture(response)))
+      .onFailure(handleFailure(asyncResultHandler));
   }
 
   @Validate
@@ -52,8 +65,10 @@ public class MaterialTypeApi extends BaseApi<MaterialType, MaterialTypes>
                                                   Map<String, String> okapiHeaders,
                                                   Handler<AsyncResult<Response>> asyncResultHandler,
                                                   Context vertxContext) {
-    deleteEntityById(id, okapiHeaders, asyncResultHandler, vertxContext,
-      DeleteMaterialTypesByMaterialtypeIdResponse.class);
+    new MaterialTypeService(vertxContext, okapiHeaders)
+      .delete(id)
+      .onSuccess(response -> asyncResultHandler.handle(succeededFuture(response)))
+      .onFailure(handleFailure(asyncResultHandler));
   }
 
   @Validate
@@ -62,22 +77,9 @@ public class MaterialTypeApi extends BaseApi<MaterialType, MaterialTypes>
                                                Map<String, String> okapiHeaders,
                                                Handler<AsyncResult<Response>> asyncResultHandler,
                                                Context vertxContext) {
-    putEntityById(id, entity, okapiHeaders, asyncResultHandler, vertxContext,
-      PutMaterialTypesByMaterialtypeIdResponse.class);
-  }
-
-  @Override
-  protected String getReferenceTable() {
-    return MATERIAL_TYPE_TABLE;
-  }
-
-  @Override
-  protected Class<MaterialType> getEntityClass() {
-    return MaterialType.class;
-  }
-
-  @Override
-  protected Class<MaterialTypes> getEntityCollectionClass() {
-    return MaterialTypes.class;
+    new MaterialTypeService(vertxContext, okapiHeaders)
+      .update(id, entity)
+      .onSuccess(response -> asyncResultHandler.handle(succeededFuture(response)))
+      .onFailure(handleFailure(asyncResultHandler));
   }
 }

--- a/mod-inventory-storage-server/src/main/java/org/folio/services/domainevent/MaterialTypeDomainEventPublisher.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/services/domainevent/MaterialTypeDomainEventPublisher.java
@@ -1,0 +1,40 @@
+package org.folio.services.domainevent;
+
+import static io.vertx.core.Future.succeededFuture;
+import static org.folio.InventoryKafkaTopic.MATERIAL_TYPE;
+import static org.folio.rest.tools.utils.TenantTool.tenantId;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
+import org.folio.persist.MaterialTypeRepository;
+import org.folio.rest.jaxrs.model.MaterialType;
+
+public class MaterialTypeDomainEventPublisher extends AbstractDomainEventPublisher<MaterialType, MaterialType> {
+
+  public MaterialTypeDomainEventPublisher(Context context, Map<String, String> okapiHeaders) {
+    super(new MaterialTypeRepository(context, okapiHeaders),
+      new CommonDomainEventPublisher<>(context, okapiHeaders, MATERIAL_TYPE.fullTopicName(tenantId(okapiHeaders))));
+  }
+
+  @Override
+  protected Future<List<Pair<String, MaterialType>>> getRecordIds(Collection<MaterialType> materialTypes) {
+    return succeededFuture(materialTypes.stream()
+      .map(materialType -> pair(materialType.getId(), materialType))
+      .toList()
+    );
+  }
+
+  @Override
+  protected MaterialType convertDomainToEvent(String instanceId, MaterialType materialType) {
+    return materialType;
+  }
+
+  @Override
+  protected String getId(MaterialType materialType) {
+    return materialType.getId();
+  }
+}

--- a/mod-inventory-storage-server/src/main/java/org/folio/services/materialtype/MaterialTypeService.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/services/materialtype/MaterialTypeService.java
@@ -1,0 +1,94 @@
+package org.folio.services.materialtype;
+
+import static org.folio.rest.persist.PgUtil.deleteById;
+import static org.folio.rest.persist.PgUtil.get;
+import static org.folio.rest.persist.PgUtil.post;
+import static org.folio.rest.persist.PgUtil.put;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import java.util.Map;
+import javax.ws.rs.core.Response;
+import org.folio.persist.MaterialTypeRepository;
+import org.folio.rest.exceptions.NotFoundException;
+import org.folio.rest.jaxrs.model.MaterialType;
+import org.folio.rest.jaxrs.model.MaterialTypes;
+import org.folio.rest.jaxrs.resource.MaterialTypes.DeleteMaterialTypesByMaterialtypeIdResponse;
+import org.folio.rest.jaxrs.resource.MaterialTypes.GetMaterialTypesByMaterialtypeIdResponse;
+import org.folio.rest.jaxrs.resource.MaterialTypes.GetMaterialTypesResponse;
+import org.folio.rest.jaxrs.resource.MaterialTypes.PutMaterialTypesByMaterialtypeIdResponse;
+import org.folio.rest.jaxrs.resource.SubjectTypes.PostSubjectTypesResponse;
+import org.folio.rest.persist.Criteria.Criterion;
+import org.folio.rest.persist.PgUtil;
+import org.folio.rest.support.PostgresClientFactory;
+import org.folio.services.domainevent.MaterialTypeDomainEventPublisher;
+
+public class MaterialTypeService {
+  public static final String MATERIAL_TYPE_TABLE = "material_type";
+
+  private final Context context;
+  private final Map<String, String> okapiHeaders;
+  private final MaterialTypeRepository repository;
+  private final MaterialTypeDomainEventPublisher domainEventService;
+
+  public MaterialTypeService(Context context, Map<String, String> okapiHeaders) {
+    this.context = context;
+    this.okapiHeaders = okapiHeaders;
+    this.repository = new MaterialTypeRepository(context, okapiHeaders);
+    this.domainEventService = new MaterialTypeDomainEventPublisher(context, okapiHeaders);
+  }
+
+  public Future<Response> getByQuery(String cql, int offset, int limit) {
+    return get(MATERIAL_TYPE_TABLE, MaterialType.class, MaterialTypes.class,
+      cql, offset, limit, okapiHeaders, context, GetMaterialTypesResponse.class);
+  }
+
+  public Future<Response> getById(String id) {
+    return PgUtil.getById(MATERIAL_TYPE_TABLE, MaterialType.class, id, okapiHeaders, context,
+      GetMaterialTypesByMaterialtypeIdResponse.class);
+  }
+
+  public Future<Response> create(MaterialType materialType) {
+    return createMaterialType(materialType);
+  }
+
+  public Future<Response> update(String id, MaterialType materialType) {
+    if (materialType.getId() == null) {
+      materialType.setId(id);
+    }
+
+    return repository.getById(id)
+      .compose(oldMaterialType -> {
+        if (oldMaterialType != null) {
+          return put(MATERIAL_TYPE_TABLE, materialType, id, okapiHeaders, context,
+            PutMaterialTypesByMaterialtypeIdResponse.class)
+            .onSuccess(domainEventService.publishUpdated(oldMaterialType));
+        }
+        return Future.failedFuture(new NotFoundException("MaterialType was not found"));
+      });
+  }
+
+  public Future<Response> delete(String id) {
+    return repository.getById(id)
+      .compose(oldSubjectType -> {
+        if (oldSubjectType != null) {
+          return deleteById(MATERIAL_TYPE_TABLE, id, okapiHeaders, context,
+            DeleteMaterialTypesByMaterialtypeIdResponse.class)
+            .onSuccess(domainEventService.publishRemoved(oldSubjectType));
+        }
+        return Future.failedFuture(new NotFoundException("MaterialType was not found"));
+      });
+  }
+
+  public Future<Response> deleteAll() {
+    return  PostgresClientFactory.getInstance(context, okapiHeaders)
+      .delete(MATERIAL_TYPE_TABLE, new Criterion())
+      .compose(notUsed -> domainEventService.publishAllRemoved())
+      .map(notUsed -> Response.noContent().build());
+  }
+
+  private Future<Response> createMaterialType(MaterialType materialType) {
+    return post(MATERIAL_TYPE_TABLE, materialType, okapiHeaders, context, PostSubjectTypesResponse.class)
+      .onSuccess(domainEventService.publishCreated());
+  }
+}

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/MaterialTypeKafkaEventTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/MaterialTypeKafkaEventTest.java
@@ -1,0 +1,72 @@
+package org.folio.rest.api;
+
+import static java.util.UUID.randomUUID;
+import static org.folio.utility.ModuleUtility.getClient;
+
+import io.vertx.core.json.JsonObject;
+import java.util.UUID;
+import junitparams.JUnitParamsRunner;
+import lombok.SneakyThrows;
+import org.folio.rest.support.http.ResourceClient;
+import org.folio.rest.support.messages.MaterialTypeEventMessageChecks;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(JUnitParamsRunner.class)
+public class MaterialTypeKafkaEventTest extends TestBaseWithInventoryUtil {
+  static ResourceClient materialTypesClient = ResourceClient.forMaterialTypes(getClient());
+
+  private final MaterialTypeEventMessageChecks materialTypeEventMessageChecks
+    = new MaterialTypeEventMessageChecks(KAFKA_CONSUMER);
+
+  @SneakyThrows
+  @Before
+  public void beforeEach() {
+    removeAllEvents();
+  }
+
+  @Test
+  public void shouldPublishKafkaEvent_whenMaterialTypeIsCreated() {
+    var createdMaterialType = materialTypesClient.create(createMaterialTypeJson()).getJson();
+
+    materialTypeEventMessageChecks.createdMessagePublished(createdMaterialType);
+  }
+
+  @Test
+  public void shouldPublishKafkaEvent_whenMaterialTypeIsUpdated() {
+    var createdMaterialType = materialTypesClient.create(createMaterialTypeJson()).getJson();
+    var materialTypeId = createdMaterialType.getString("id");
+
+    var updateRequestBody = createUpdateRequestBody(materialTypeId);
+    materialTypesClient.attemptToReplace(materialTypeId, updateRequestBody);
+
+    var updatedMaterialType = materialTypesClient.getByIdIfPresent(materialTypeId).getJson();
+    materialTypeEventMessageChecks.updatedMessagePublished(createdMaterialType, updatedMaterialType);
+  }
+
+  @Test
+  public void shouldPublishKafkaEvent_whenMaterialTypeIsDeleted() {
+    var createdMaterialType = materialTypesClient.create(createMaterialTypeJson()).getJson();
+    var materialTypeId = createdMaterialType.getString("id");
+
+    materialTypesClient.attemptToDelete(UUID.fromString(materialTypeId));
+
+    materialTypeEventMessageChecks.deletedMessagePublished(createdMaterialType);
+  }
+
+  private JsonObject createMaterialTypeJson() {
+    JsonObject boundWithPart = new JsonObject();
+    boundWithPart.put("name", "created-" + randomUUID());
+    boundWithPart.put("source", "local");
+    return boundWithPart;
+  }
+
+  private JsonObject createUpdateRequestBody(String id) {
+    JsonObject boundWithPart = new JsonObject();
+    boundWithPart.put("id", id);
+    boundWithPart.put("name", "updated-" + randomUUID());
+    boundWithPart.put("source", "local");
+    return boundWithPart;
+  }
+}

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/MaterialTypeKafkaEventTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/MaterialTypeKafkaEventTest.java
@@ -2,8 +2,12 @@ package org.folio.rest.api;
 
 import static java.util.UUID.randomUUID;
 import static org.folio.utility.ModuleUtility.getClient;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.notNullValue;
 
 import io.vertx.core.json.JsonObject;
+import java.net.HttpURLConnection;
 import java.util.UUID;
 import junitparams.JUnitParamsRunner;
 import lombok.SneakyThrows;
@@ -28,18 +32,21 @@ public class MaterialTypeKafkaEventTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void shouldPublishKafkaEvent_whenMaterialTypeIsCreated() {
-    var createdMaterialType = materialTypesClient.create(createMaterialTypeJson()).getJson();
+    var createdMaterialType = materialTypesClient.create(getCreateMaterialTypeRequestBody()).getJson();
+    assertThat(createdMaterialType, notNullValue());
 
     materialTypeEventMessageChecks.createdMessagePublished(createdMaterialType);
   }
 
   @Test
   public void shouldPublishKafkaEvent_whenMaterialTypeIsUpdated() {
-    var createdMaterialType = materialTypesClient.create(createMaterialTypeJson()).getJson();
+    var createdMaterialType = materialTypesClient.create(getCreateMaterialTypeRequestBody()).getJson();
+    assertThat(createdMaterialType, notNullValue());
     var materialTypeId = createdMaterialType.getString("id");
 
-    var updateRequestBody = createUpdateRequestBody(materialTypeId);
-    materialTypesClient.attemptToReplace(materialTypeId, updateRequestBody);
+    var updateRequestBody = getUpdateMaterialTypeRequestBody(materialTypeId);
+    var updateResponse = materialTypesClient.attemptToReplace(materialTypeId, updateRequestBody);
+    assertThat(updateResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
 
     var updatedMaterialType = materialTypesClient.getByIdIfPresent(materialTypeId).getJson();
     materialTypeEventMessageChecks.updatedMessagePublished(createdMaterialType, updatedMaterialType);
@@ -47,22 +54,24 @@ public class MaterialTypeKafkaEventTest extends TestBaseWithInventoryUtil {
 
   @Test
   public void shouldPublishKafkaEvent_whenMaterialTypeIsDeleted() {
-    var createdMaterialType = materialTypesClient.create(createMaterialTypeJson()).getJson();
+    var createdMaterialType = materialTypesClient.create(getCreateMaterialTypeRequestBody()).getJson();
+    assertThat(createdMaterialType, notNullValue());
     var materialTypeId = createdMaterialType.getString("id");
 
-    materialTypesClient.attemptToDelete(UUID.fromString(materialTypeId));
+    var deleteResponse = materialTypesClient.attemptToDelete(UUID.fromString(materialTypeId));
+    assertThat(deleteResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
 
     materialTypeEventMessageChecks.deletedMessagePublished(createdMaterialType);
   }
 
-  private JsonObject createMaterialTypeJson() {
+  private JsonObject getCreateMaterialTypeRequestBody() {
     JsonObject boundWithPart = new JsonObject();
     boundWithPart.put("name", "created-" + randomUUID());
     boundWithPart.put("source", "local");
     return boundWithPart;
   }
 
-  private JsonObject createUpdateRequestBody(String id) {
+  private JsonObject getUpdateMaterialTypeRequestBody(String id) {
     JsonObject boundWithPart = new JsonObject();
     boundWithPart.put("id", id);
     boundWithPart.put("name", "updated-" + randomUUID());

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/support/kafka/FakeKafkaConsumer.java
@@ -20,6 +20,7 @@ public final class FakeKafkaConsumer {
   static final String LOAN_TYPE_TOPIC_NAME = "folio.test.inventory.loan-type";
   static final String BOUND_WITH_TOPIC_NAME = "folio.test.inventory.bound-with";
   static final String SERVICE_POINT_TOPIC_NAME = "folio.test.inventory.service-point";
+  static final String MATERIAL_TYPE_TOPIC_NAME = "folio.test.inventory.material-type";
   static final String REINDEX_RECORDS_TOPIC_NAME = "folio.test.inventory.reindex-records";
   static final String REINDEX_FILE_READY_TOPIC_NAME = "folio.test.inventory.reindex.file-ready";
 
@@ -32,6 +33,7 @@ public final class FakeKafkaConsumer {
   private final GroupedCollectedMessages collectedLoanTypeMessages = new GroupedCollectedMessages();
   private final GroupedCollectedMessages collectedBoundWithMessages = new GroupedCollectedMessages();
   private final GroupedCollectedMessages collectedServicePointMessages = new GroupedCollectedMessages();
+  private final GroupedCollectedMessages collectedMaterialTypeMessages = new GroupedCollectedMessages();
   private final GroupedCollectedMessages collectedReindexRecordsMessages = new GroupedCollectedMessages();
   private final GroupedCollectedMessages collectedReindexFileReadyMessages = new GroupedCollectedMessages();
 
@@ -66,6 +68,7 @@ public final class FakeKafkaConsumer {
     collectedLoanTypeMessages.empty();
     collectedBoundWithMessages.empty();
     collectedServicePointMessages.empty();
+    collectedMaterialTypeMessages.empty();
     collectedReindexRecordsMessages.empty();
     collectedReindexFileReadyMessages.empty();
   }
@@ -121,6 +124,10 @@ public final class FakeKafkaConsumer {
     return collectedServicePointMessages.messagesByGroupKey(servicePointId);
   }
 
+  public Collection<EventMessage> getMessagesForMaterialType(String materialTypeId) {
+    return collectedMaterialTypeMessages.messagesByGroupKey(materialTypeId);
+  }
+
   private VertxMessageCollectingTopicConsumer createConsumer() {
     return new VertxMessageCollectingTopicConsumer(
       subscribedTopics(),
@@ -148,6 +155,8 @@ public final class FakeKafkaConsumer {
         KafkaConsumerRecord::key, collectedBoundWithMessages),
       filteredAndGroupedCollector(SERVICE_POINT_TOPIC_NAME,
         KafkaConsumerRecord::key, collectedServicePointMessages),
+      filteredAndGroupedCollector(MATERIAL_TYPE_TOPIC_NAME,
+        KafkaConsumerRecord::key, collectedMaterialTypeMessages),
       filteredAndGroupedCollector(HOLDINGS_TOPIC_NAME_CONSORTIUM_MEMBER_TENANT,
         FakeKafkaConsumer::instanceAndIdKey, collectedHoldingsMessages),
       filteredAndGroupedCollector(REINDEX_RECORDS_TOPIC_NAME,

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/MaterialTypeEventMessageChecks.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/MaterialTypeEventMessageChecks.java
@@ -1,0 +1,40 @@
+package org.folio.rest.support.messages;
+
+import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
+import static org.folio.utility.ModuleUtility.vertxUrl;
+import static org.folio.utility.RestUtility.TENANT_ID;
+
+import io.vertx.core.json.JsonObject;
+import org.folio.rest.support.kafka.FakeKafkaConsumer;
+import org.folio.rest.support.messages.matchers.EventMessageMatchers;
+
+public class MaterialTypeEventMessageChecks {
+
+  private final FakeKafkaConsumer kafkaConsumer;
+  private final EventMessageMatchers eventMessageMatchers = new EventMessageMatchers(
+    TENANT_ID, vertxUrl(""));
+
+  public MaterialTypeEventMessageChecks(FakeKafkaConsumer kafkaConsumer) {
+    this.kafkaConsumer = kafkaConsumer;
+  }
+
+  public void createdMessagePublished(JsonObject materialType) {
+    final var materialTypeId = materialType.getString("id");
+    awaitAtMost().until(() -> kafkaConsumer.getMessagesForMaterialType(materialTypeId),
+      eventMessageMatchers.hasCreateEventMessageFor(materialType));
+  }
+
+  public void updatedMessagePublished(JsonObject oldMaterialType, JsonObject newMaterialType) {
+    final var materialTypeId = oldMaterialType.getString("id");
+
+    awaitAtMost().until(() -> kafkaConsumer.getMessagesForMaterialType(materialTypeId),
+      eventMessageMatchers.hasUpdateEventMessageFor(oldMaterialType, newMaterialType));
+  }
+
+  public void deletedMessagePublished(JsonObject oldMaterialType) {
+    final var materialTypeId = oldMaterialType.getString("id");
+
+    awaitAtMost().until(() -> kafkaConsumer.getMessagesForMaterialType(materialTypeId),
+      eventMessageMatchers.hasDeleteEventMessageFor(oldMaterialType));
+  }
+}

--- a/mod-inventory-storage-server/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/services/kafka/topic/KafkaAdminClientServiceTest.java
@@ -43,6 +43,7 @@ public class KafkaAdminClientServiceTest {
     "folio.foo-tenant.inventory.bound-with",
     "folio.foo-tenant.inventory.async-migration",
     "folio.foo-tenant.inventory.service-point",
+    "folio.foo-tenant.inventory.material-type",
     "folio.foo-tenant.inventory.classification-type",
     "folio.foo-tenant.inventory.location",
     "folio.foo-tenant.inventory.library",


### PR DESCRIPTION
## Purpose

https://folio-org.atlassian.net/browse/MODINVSTOR-1512

Implement CRUD Kafka events publishing for MaterialType entity to inventory.material-type topic

## Approach

-   Implement MaterialTypeService to handle CRUD operations.
-   Implement MaterialTypeEventPublisher to publish CREATE, UPDATE, and DELETE events.
-   Implement support of inventory.material-type topic in InventoryKafkaTopic
-   Cover changes with integration tests
