### PR TITLE
fix(item-order): update  create-set-order-trigger script to ensure tracker row exists before locking to avoid race condition

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
 
 ### Bug fixes
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Fix item order value calculation under concurrent execution to avoid race conditions. ([MODINV-1362](https://folio-org.atlassian.net/browse/MODINV-1362))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
 
 ### Bug fixes
-* Fix item order value calculation under concurrent execution to avoid race conditions. ([MODINV-1362](https://folio-org.atlassian.net/browse/MODINV-1362))
+* Fix item order value calculation under concurrent execution to avoid race conditions. ([MODINVSTOR-1547](https://folio-org.atlassian.net/browse/MODINVSTOR-1547))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/item/create-set-order-trigger-safe.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/item/create-set-order-trigger-safe.sql
@@ -1,0 +1,81 @@
+-- Create a new table to store holdings_id and max item order value
+CREATE TABLE IF NOT EXISTS ${myuniversity}_${mymodule}.item_order_tracker (
+                                                                holdings_id UUID PRIMARY KEY,
+                                                                max_order INT NOT NULL DEFAULT 1
+);
+
+-- Create or replace the function to calculate and set the order field
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.set_order()
+    RETURNS trigger AS
+$$
+DECLARE
+    income_order text;
+    holding_record_id UUID;
+    new_order INT;
+BEGIN
+    holding_record_id := (NEW.jsonb ->> 'holdingsRecordId')::uuid;
+    income_order := NEW.jsonb ->> 'order';
+
+    IF holding_record_id IS NOT NULL THEN
+        -- Ensure the tracker row exists (prevents race condition)
+        INSERT INTO ${myuniversity}_${mymodule}.item_order_tracker (holdings_id)
+        VALUES (holding_record_id)
+        ON CONFLICT (holdings_id) DO NOTHING;
+
+        -- Lock the row in the item_order_tracker table for the given holdings_id
+        PERFORM 1 FROM ${myuniversity}_${mymodule}.item_order_tracker
+        WHERE holdings_id = holding_record_id
+            FOR UPDATE;
+
+        -- Check if the order field is null
+        IF income_order IS NULL THEN
+            -- Check if there is at least one item for this holdings record
+            IF EXISTS (
+              SELECT 1
+              FROM ${myuniversity}_${mymodule}.item
+              WHERE holdingsrecordid = holding_record_id
+              LIMIT 1
+            ) THEN
+                -- Update or insert the max order value in the tracker table
+                INSERT INTO ${myuniversity}_${mymodule}.item_order_tracker (holdings_id)
+                VALUES (holding_record_id)
+                ON CONFLICT (holdings_id) DO UPDATE
+                    SET max_order = ${myuniversity}_${mymodule}.item_order_tracker.max_order + 1
+                RETURNING max_order INTO new_order;
+            ELSE
+                -- This is the first item for this holdings record, set max_order to 1 by default
+                new_order := 1;
+                INSERT INTO ${myuniversity}_${mymodule}.item_order_tracker (holdings_id)
+                VALUES (holding_record_id)
+                ON CONFLICT (holdings_id) DO UPDATE
+                    SET max_order = 1;
+            END IF;
+
+            -- Set the new order value in the item
+            NEW.jsonb := jsonb_set(
+                            NEW.jsonb,
+                            '{order}',
+                            to_jsonb(new_order)
+                        );
+        ELSE
+            -- Update item_order_tracker if the incoming order is greater than the current max_order
+            INSERT INTO ${myuniversity}_${mymodule}.item_order_tracker (holdings_id, max_order)
+            VALUES (holding_record_id, income_order::int)
+            ON CONFLICT (holdings_id) DO UPDATE
+                SET max_order = GREATEST(${myuniversity}_${mymodule}.item_order_tracker.max_order, income_order::int);
+        END IF;
+    END IF;
+
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Drop the trigger if it already exists
+DROP TRIGGER IF EXISTS set_order_trigger ON ${myuniversity}_${mymodule}.item;
+
+-- Create the trigger
+CREATE TRIGGER set_order_trigger
+    BEFORE INSERT OR UPDATE
+    ON ${myuniversity}_${mymodule}.item
+    FOR EACH ROW
+EXECUTE FUNCTION ${myuniversity}_${mymodule}.set_order();

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -1342,6 +1342,11 @@
       "run": "after",
       "snippetPath": "instance/createInstanceNotesNoteTypeIdIndex.sql",
       "fromModuleVersion": "30.0.0"
+    },
+    {
+      "run": "after",
+      "snippetPath": "item/create-set-order-trigger-safe.sql",
+      "fromModuleVersion": "30.1.0"
     }
   ]
 }

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -1346,7 +1346,7 @@
     {
       "run": "after",
       "snippetPath": "item/create-set-order-trigger-safe.sql",
-      "fromModuleVersion": "30.1.0"
+      "fromModuleVersion": "30.0.1"
     }
   ]
 }

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -72,8 +72,11 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CyclicBarrier;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
@@ -285,6 +288,64 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(getResponse1.getJson().getInteger(ORDER_FIELD), anyOf(is(1), is(2)));
     assertThat(getResponse2.getJson().getInteger(ORDER_FIELD), anyOf(is(1), is(2)));
     assertThat(getResponse2.getJson().getInteger(ORDER_FIELD), not(is(getResponse1.getJson().getInteger(ORDER_FIELD))));
+  }
+
+  @SneakyThrows
+  @Test
+  public void shouldHandleConcurrentItemCreationWithAutoOrder() {
+    var holdingsRecordId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
+
+    var id1 = UUID.randomUUID();
+    var id2 = UUID.randomUUID();
+
+    var items = Map.of(id1, minimalItem(id1, holdingsRecordId), id2, minimalItem(id2, holdingsRecordId));
+    var responses = runConcurrentPosts(items);
+
+    assertThat(responses.get(0).getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+    assertThat(responses.get(1).getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+
+    var order1 = getById(id1).getJson().getInteger(ORDER_FIELD);
+    var order2 = getById(id2).getJson().getInteger(ORDER_FIELD);
+
+    assertThat(order1, anyOf(is(1), is(2)));
+    assertThat(order2, anyOf(is(1), is(2)));
+    assertThat(order1, not(is(order2)));
+  }
+
+  @SneakyThrows
+  @Test
+  public void shouldHandleConcurrentItemCreationWithManualAndAutoOrder() {
+    var holdingsRecordId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
+
+    var id1 = UUID.randomUUID();
+    var id2 = UUID.randomUUID();
+    var id3 = UUID.randomUUID();
+
+    var item2 = minimalItem(id2, holdingsRecordId);
+    item2.put(ORDER_FIELD, 6);
+    var items = Map.of(id1, minimalItem(id1, holdingsRecordId), id2, item2, id3, minimalItem(id3, holdingsRecordId));
+    var responses = runConcurrentPosts(items);
+
+    assertThat(responses.get(0).getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+    assertThat(responses.get(1).getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+
+    var order1 = getById(id1).getJson().getInteger(ORDER_FIELD);
+    var order3 = getById(id3).getJson().getInteger(ORDER_FIELD);
+
+    assertEquals(6, getById(id2).getJson().getInteger(ORDER_FIELD).intValue());
+    assertThat(order1, anyOf(is(1), is(2), is(7), is(8)));
+    assertThat(order3, anyOf(is(1), is(2), is(7), is(8)));
+    assertThat(order1, not(is(order3)));
+
+    var item4 = minimalItem(randomUUID(), holdingsRecordId);
+    var response = saveItemAndExpectJson(item4);
+    assertThat(response.getStatusCode(), is(HttpURLConnection.HTTP_CREATED));
+
+    var order4 = response.getJson().getInteger(ORDER_FIELD);
+
+    assertThat(order4, anyOf(is(7), is(8), is(9)));
+    assertThat(order4, not(is(order1)));
+    assertThat(order4, not(is(order3)));
   }
 
   @SneakyThrows
@@ -4297,5 +4358,31 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     CompletableFuture<Response> completed = new CompletableFuture<>();
     getClient().put(itemsStorageUrl("/" + itemId), item, TENANT_ID, ResponseHandler.empty(completed));
     return completed.get(TIMEOUT, TimeUnit.SECONDS);
+  }
+
+  @SneakyThrows
+  private List<Response> runConcurrentPosts(Map<UUID, JsonObject> items) {
+    var executor = Executors.newFixedThreadPool(items.size());
+    var barrier = new CyclicBarrier(items.size());
+
+    List<Callable<Response>> tasks = items.entrySet().stream()
+      .map(entry -> (Callable<Response>) () -> {
+        barrier.await();
+        var future = new CompletableFuture<Response>();
+        getClient().post(itemsStorageUrl(""), entry.getValue(), TENANT_ID, ResponseHandler.json(future));
+        return future.get(TIMEOUT, TimeUnit.SECONDS);
+      }).toList();
+
+    var futures = tasks.stream()
+      .map(executor::submit)
+      .toList();
+
+    var results = new ArrayList<Response>();
+    for (var f : futures) {
+      results.add(f.get());
+    }
+
+    executor.shutdown();
+    return results;
   }
 }


### PR DESCRIPTION
### Purpose
Item's `order` field is populated with wrong value when multiple Items are created via `Orders` app

### Approach
- create new script `create-set-order-trigger-safe.sql`, based on `create-set-order-trigger.sql`.
- new script introduces a pre-lock safeguard:
`INSERT INTO ${myuniversity}_${mymodule}.item_order_tracker (holdings_id)
VALUES (holding_record_id)
ON CONFLICT (holdings_id) DO NOTHING;`

The additional INSERT ... ON CONFLICT DO NOTHING ensures that a corresponding **row exists in `item_order_tracker` before attempting to lock it.** This prevents a race condition where concurrent transactions try to lock or operate on a row that hasn’t been created yet.

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINVSTOR-1547](https://folio-org.atlassian.net/browse/MODINVSTOR-1547)

### Screenshots (if applicable)
<img width="1705" height="586" alt="image" src="https://github.com/user-attachments/assets/d33672d7-babc-49f6-9530-9e32479b2a57" />


