### PR TITLE
fix(holdings-storage): trigger holding items recalculation on instanceId change

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,7 +10,7 @@
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
 
 ### Bug fixes
-* Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
+* Trigger holding items recalculation on instanceId change ([MODINVSTOR-1548](https://folio-org.atlassian.net/browse/MODINVSTOR-1548))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/mod-inventory-storage-server/src/main/java/org/folio/services/holding/HoldingsService.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/services/holding/HoldingsService.java
@@ -320,6 +320,7 @@ public class HoldingsService {
 
   private boolean shouldUpdateItems(HoldingsRecord oldHoldings, HoldingsRecord newHoldings) {
     return oldHoldings == null
+      || !Objects.equals(oldHoldings.getInstanceId(), newHoldings.getInstanceId())
       || !Objects.equals(oldHoldings.getPermanentLocationId(), newHoldings.getPermanentLocationId())
       || !Objects.equals(oldHoldings.getTemporaryLocationId(), newHoldings.getTemporaryLocationId())
       || !Objects.equals(oldHoldings.getCallNumber(), newHoldings.getCallNumber())

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -436,6 +436,41 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   }
 
   @Test
+  @SneakyThrows
+  public void canMoveHoldingsToNewInstance_shouldUpdateItem() {
+    var instanceId = UUID.randomUUID();
+    var newInstanceId = UUID.randomUUID();
+
+    instancesClient.create(smallAngryPlanet(instanceId));
+    instancesClient.create(smallAngryPlanet(newInstanceId));
+    setHoldingsSequence(1);
+
+    var holdingResource = createHoldingRecord(new HoldingRequestBuilder()
+      .forInstance(instanceId)
+      .withSource(getPreparedHoldingSourceId())
+      .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID).create());
+
+    var holdingId = holdingResource.getId();
+    final var item = createItemForHolding(holdingId);
+
+    var replacement = holdingResource.copyJson()
+      .put("instanceId", newInstanceId.toString());
+    updateHoldingRecord(holdingId, replacement);
+
+    var getResponse = holdingsClient.getById(holdingId);
+    assertThat(getResponse.getStatusCode(), is(HttpURLConnection.HTTP_OK));
+
+    var holdingFromGet = getResponse.getJson();
+    assertThat(holdingFromGet.getString("instanceId"), is(newInstanceId.toString()));
+
+    holdingsMessageChecks.updatedMessagePublished(holdingResource.getJson(), holdingFromGet);
+
+    var newItem = item.copy().put("_version", 2);
+
+    itemMessageChecks.updatedMessagePublished(item, newItem, instanceId.toString());
+  }
+
+  @Test
   public void cannotCreateHoldingWithInvalidStatisticalCodeIds() {
     var instanceId = UUID.randomUUID();
 


### PR DESCRIPTION
### Purpose
Wrong instance is found when searching by item barcode after Holdings was moved to another instance

### Approach
- trigger holding items recalculation on `instanceId` change

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINVSTOR-1548](https://folio-org.atlassian.net/browse/MODINVSTOR-1548)
[MODINVSTOR-1533](https://folio-org.atlassian.net/browse/MODINVSTOR-1533)


