### PR TITLE
fix: update instance complete_updated_date when items/holdings are moved between instances

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 ### Bug fixes
 * Trigger holding items recalculation on instanceId change ([MODINVSTOR-1548](https://folio-org.atlassian.net/browse/MODINVSTOR-1548))
 * Fix item order value calculation under concurrent execution to avoid race conditions. ([MODINVSTOR-1547](https://folio-org.atlassian.net/browse/MODINVSTOR-1547))
+* Update Instance complete_updated_date when items/holdings are moved between instances ([MODINVSTOR-1542](https://folio-org.atlassian.net/browse/MODINVSTOR-1542))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/oaipmh/updateCompleteUpdatedDateFunctionsToHandleMove.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/oaipmh/updateCompleteUpdatedDateFunctionsToHandleMove.sql
@@ -42,26 +42,12 @@
      WHERE inst.id IN (
          SELECT instanceid
          FROM ${myuniversity}_${mymodule}.holdings_record hold_rec
-         WHERE hold_rec.id = NEW.holdingsrecordid);
-
-     -- When item is moved to a different holdings record, also update the source instance
-     IF TG_OP = 'UPDATE' AND OLD.holdingsrecordid <> NEW.holdingsrecordid THEN
-         UPDATE ${myuniversity}_${mymodule}.instance inst SET complete_updated_date = NOW()
-         WHERE inst.id IN (
-             SELECT instanceid
-             FROM ${myuniversity}_${mymodule}.holdings_record hold_rec
-             WHERE hold_rec.id = OLD.holdingsrecordid);
-     END IF;
-
-     -- Update instances linked via bound-with parts
-     UPDATE ${myuniversity}_${mymodule}.instance inst SET complete_updated_date = NOW()
-     WHERE inst.id IN (
-         SELECT instanceid
-         FROM ${myuniversity}_${mymodule}.holdings_record hold_rec
-         WHERE hold_rec.id IN (
-             SELECT holdingsrecordid
-             FROM ${myuniversity}_${mymodule}.bound_with_part bwp
-             WHERE bwp.itemid = NEW.id));
+         WHERE hold_rec.id = NEW.holdingsrecordid
+            OR (TG_OP = 'UPDATE' AND hold_rec.id = OLD.holdingsrecordid AND OLD.holdingsrecordid <> NEW.holdingsrecordid)
+            OR hold_rec.id IN (
+                SELECT holdingsrecordid
+                FROM ${myuniversity}_${mymodule}.bound_with_part bwp
+                WHERE bwp.itemid = NEW.id));
      RETURN NEW;
  END;
  $BODY$;

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/oaipmh/updateCompleteUpdatedDateFunctionsToHandleMove.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/oaipmh/updateCompleteUpdatedDateFunctionsToHandleMove.sql
@@ -1,0 +1,73 @@
+ -- Fix completeUpdatedDate_for_holdings_insert_update to also update the source instance
+ -- when a holdings record is moved from one instance to another (instanceid changes).
+
+ DROP TRIGGER IF EXISTS updateCompleteUpdatedDate_holdings_record_insert_update
+ ON ${myuniversity}_${mymodule}.holdings_record;
+
+ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.completeUpdatedDate_for_holdings_insert_update()
+    RETURNS trigger
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE NOT LEAKPROOF
+ AS $BODY$
+ BEGIN
+     UPDATE ${myuniversity}_${mymodule}.instance inst SET complete_updated_date = NOW()
+     WHERE inst.id = NEW.instanceid
+        OR (TG_OP = 'UPDATE' AND inst.id = OLD.instanceid AND OLD.instanceid <> NEW.instanceid);
+  RETURN NEW;
+ END;
+ $BODY$;
+
+ CREATE TRIGGER updateCompleteUpdatedDate_holdings_record_insert_update
+     BEFORE UPDATE OR INSERT
+     ON ${myuniversity}_${mymodule}.holdings_record
+     FOR EACH ROW
+     EXECUTE FUNCTION ${myuniversity}_${mymodule}.completeUpdatedDate_for_holdings_insert_update();
+
+ -- Fix completeUpdatedDate_for_item_insert_update to also update the source instance
+ -- when an item is moved from one holdings record to another (holdingsrecordid changes),
+ -- which may result in a different parent instance.
+
+ DROP TRIGGER IF EXISTS updateCompleteUpdatedDate_item_insert_update
+ ON ${myuniversity}_${mymodule}.item;
+
+ CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.completeUpdatedDate_for_item_insert_update()
+    RETURNS trigger
+    LANGUAGE 'plpgsql'
+    COST 100
+    VOLATILE NOT LEAKPROOF
+ AS $BODY$
+ BEGIN
+     UPDATE ${myuniversity}_${mymodule}.instance inst SET complete_updated_date = NOW()
+     WHERE inst.id IN (
+         SELECT instanceid
+         FROM ${myuniversity}_${mymodule}.holdings_record hold_rec
+         WHERE hold_rec.id = NEW.holdingsrecordid);
+
+     -- When item is moved to a different holdings record, also update the source instance
+     IF TG_OP = 'UPDATE' AND OLD.holdingsrecordid <> NEW.holdingsrecordid THEN
+         UPDATE ${myuniversity}_${mymodule}.instance inst SET complete_updated_date = NOW()
+         WHERE inst.id IN (
+             SELECT instanceid
+             FROM ${myuniversity}_${mymodule}.holdings_record hold_rec
+             WHERE hold_rec.id = OLD.holdingsrecordid);
+     END IF;
+
+     -- Update instances linked via bound-with parts
+     UPDATE ${myuniversity}_${mymodule}.instance inst SET complete_updated_date = NOW()
+     WHERE inst.id IN (
+         SELECT instanceid
+         FROM ${myuniversity}_${mymodule}.holdings_record hold_rec
+         WHERE hold_rec.id IN (
+             SELECT holdingsrecordid
+             FROM ${myuniversity}_${mymodule}.bound_with_part bwp
+             WHERE bwp.itemid = NEW.id));
+     RETURN NEW;
+ END;
+ $BODY$;
+
+ CREATE TRIGGER updateCompleteUpdatedDate_item_insert_update
+     BEFORE UPDATE OR INSERT
+     ON ${myuniversity}_${mymodule}.item
+     FOR EACH ROW
+     EXECUTE FUNCTION ${myuniversity}_${mymodule}.completeUpdatedDate_for_item_insert_update();

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -1351,7 +1351,7 @@
     {
       "run": "after",
       "snippetPath": "oaipmh/updateCompleteUpdatedDateFunctionsToHandleMove.sql",
-      "fromModuleVersion": "30.0.2"
+      "fromModuleVersion": "30.1.0"
     }
   ]
 }

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -1347,6 +1347,11 @@
       "run": "after",
       "snippetPath": "item/create-set-order-trigger-safe.sql",
       "fromModuleVersion": "30.0.1"
+    },
+    {
+      "run": "after",
+      "snippetPath": "oaipmh/updateCompleteUpdatedDateFunctionsToHandleMove.sql",
+      "fromModuleVersion": "30.0.2"
     }
   ]
 }

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -1351,7 +1351,7 @@
     {
       "run": "after",
       "snippetPath": "oaipmh/updateCompleteUpdatedDateFunctionsToHandleMove.sql",
-      "fromModuleVersion": "30.1.0"
+      "fromModuleVersion": "30.0.2"
     }
   ]
 }

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/OaiPmhTriggersTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/OaiPmhTriggersTest.java
@@ -9,6 +9,8 @@ import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
 import static org.folio.utility.ModuleUtility.getVertx;
 import static org.folio.utility.RestUtility.TENANT_ID;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -149,6 +151,68 @@ public class OaiPmhTriggersTest extends TestBaseWithInventoryUtil {
     var dateBeforeDeletingHolding = futureDateBefore.get(80, TimeUnit.SECONDS);
     deleteAll(holdingsStorageUrl(""));
     verifyCompleteUpdatedDate(dateBeforeDeletingHolding);
+  }
+
+  @SneakyThrows
+  @Test
+  public void moveHoldingsRecordToAnotherInstanceTest() {
+    var sourceInstanceId = UUID.randomUUID();
+    var targetInstanceId = UUID.randomUUID();
+    instancesClient.create(instance(sourceInstanceId));
+    instancesClient.create(instance(targetInstanceId));
+    var holdingId = createHolding(sourceInstanceId, MAIN_LIBRARY_LOCATION_ID, null);
+
+    var futureDates = new CompletableFuture<Map<String, LocalDateTime>>();
+    getCompleteUpdatedDates(futureDates);
+    final var datesBefore = futureDates.get(80, TimeUnit.SECONDS);
+
+    // Move the holding to the target instance
+    var holdingJson = holdingsClient.getById(holdingId).getJson();
+    holdingJson.put("instanceId", targetInstanceId.toString());
+    updateHoldingRecord(holdingId, holdingJson);
+
+    futureDates = new CompletableFuture<>();
+    getCompleteUpdatedDates(futureDates);
+    var datesAfter = futureDates.get(80, TimeUnit.SECONDS);
+
+    assertEquals(datesBefore.keySet(), datesAfter.keySet());
+    assertTrue("Source instance complete_updated_date should have been updated",
+      datesBefore.get(sourceInstanceId.toString()).isBefore(datesAfter.get(sourceInstanceId.toString())));
+    assertTrue("Target instance complete_updated_date should have been updated",
+      datesBefore.get(targetInstanceId.toString()).isBefore(datesAfter.get(targetInstanceId.toString())));
+  }
+
+  @SneakyThrows
+  @Test
+  public void moveItemToAnotherHoldingsRecordTest() {
+    var sourceHoldingId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
+    var targetHoldingId = createInstanceAndHolding(MAIN_LIBRARY_LOCATION_ID);
+    var itemJson = createItem(journalMaterialTypeId, sourceHoldingId);
+
+    var futureDates = new CompletableFuture<Map<String, LocalDateTime>>();
+    getCompleteUpdatedDates(futureDates);
+    final var datesBefore = futureDates.get(80, TimeUnit.SECONDS);
+
+    // Move the item to the target holding
+    itemJson.put("holdingsRecordId", targetHoldingId.toString());
+    var itemId = itemJson.getString("id");
+    var putResponse = itemsClient.attemptToReplace(itemId, itemJson);
+    assertThat("Failed to move item: " + putResponse.getBody(),
+      putResponse.getStatusCode(), is(204));
+
+    futureDates = new CompletableFuture<>();
+    getCompleteUpdatedDates(futureDates);
+    var datesAfter = futureDates.get(80, TimeUnit.SECONDS);
+
+    // Resolve parent instance IDs from holdings
+    var sourceInstanceId = holdingsClient.getById(sourceHoldingId).getJson().getString("instanceId");
+    var targetInstanceId = holdingsClient.getById(targetHoldingId).getJson().getString("instanceId");
+
+    assertEquals(datesBefore.keySet(), datesAfter.keySet());
+    assertTrue("Source instance complete_updated_date should have been updated after item move",
+      datesBefore.get(sourceInstanceId).isBefore(datesAfter.get(sourceInstanceId)));
+    assertTrue("Target instance complete_updated_date should have been updated after item move",
+      datesBefore.get(targetInstanceId).isBefore(datesAfter.get(targetInstanceId)));
   }
 
   @SneakyThrows


### PR DESCRIPTION
### Purpose
Update Instance complete_updated_date when items/holdings are moved between instances

### Approach
- update trigger functions to update old instances

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINVSTOR-1542](https://folio-org.atlassian.net/browse/MODINVSTOR-1542)

### Manual testing
#### Non-ecs
- [x] move item to another instance
- [x] move holdings to another instance
#### Ecs
- Create shared instance
- Create holdings with 2 items in member1
- Create holdings in member2
- Update ownership of item2 from member1 to member2
- [x] complete_updated_date for shadow instance in both members updated
- Update ownership of holdings from member1 to member 2
- [x] complete_updated_date for shadow instance in both members updated