### PR TITLE
fix: add full-text index for formerIds to improve item lookup via formerIds field

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,7 @@
 * Update Instance complete_updated_date when items/holdings are moved between instances ([MODINVSTOR-1542](https://folio-org.atlassian.net/browse/MODINVSTOR-1542))
 * Add MATERIALIZED to bound_instances CTE in reindexInstances query ([MODINVSTOR-1566](https://folio-org.atlassian.net/browse/MODINVSTOR-1566))
 * Fix Instace complete_updated_date update performance on item create/update  ([MODINVSTOR-1569](https://folio-org.atlassian.net/browse/MODINVSTOR-1569))
+* Add full-text index for `formerIds` to improve item lookup via `formerIds` field ([MODINVSTOR-1579](https://folio-org.atlassian.net/browse/MODINVSTOR-1579))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/item/createItemFormerIdsIndex.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/item/createItemFormerIdsIndex.sql
@@ -1,0 +1,6 @@
+CREATE INDEX IF NOT EXISTS item_formerids_idx_ft ON ${myuniversity}_${mymodule}.item
+USING gin (
+  ${myuniversity}_${mymodule}.get_tsvector(
+    ${myuniversity}_${mymodule}.f_unaccent(jsonb ->> 'formerIds')
+  )
+);

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -1356,7 +1356,7 @@
     {
       "run": "after",
       "snippetPath": "item/createItemFormerIdsIndex.sql",
-      "fromModuleVersion": "30.1.0"
+      "fromModuleVersion": "30.0.4"
     }
   ]
 }

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -1352,6 +1352,11 @@
       "run": "after",
       "snippetPath": "oaipmh/updateCompleteUpdatedDateFunctionsToHandleMove.sql",
       "fromModuleVersion": "30.0.3"
+    },
+    {
+      "run": "after",
+      "snippetPath": "item/createItemFormerIdsIndex.sql",
+      "fromModuleVersion": "30.0.3"
     }
   ]
 }

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -1356,7 +1356,7 @@
     {
       "run": "after",
       "snippetPath": "item/createItemFormerIdsIndex.sql",
-      "fromModuleVersion": "30.0.3"
+      "fromModuleVersion": "30.1.0"
     }
   ]
 }


### PR DESCRIPTION
### Purpose
Improve performance of item record upload in Bulk Edit via file using Former Identifiers

### Approach
- add full-text index for `formerIds` field

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINVSTOR-1579](https://folio-org.atlassian.net/browse/MODINVSTOR-1579)

### Screenshots (if applicable)
<img width="990" height="686" alt="image" src="https://github.com/user-attachments/assets/66b2e376-037f-4469-a6d9-902271fba810" />
