### PR TITLE
fix(reindex): Extend s3 client configuration and cache client

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,7 @@
 * Fix Instace complete_updated_date update performance on item create/update  ([MODINVSTOR-1569](https://folio-org.atlassian.net/browse/MODINVSTOR-1569))
 * Add full-text index for `formerIds` to improve item lookup via `formerIds` field ([MODINVSTOR-1579](https://folio-org.atlassian.net/browse/MODINVSTOR-1579))
 * HttpClient leak: reuse shared client instead of creating per request ([MODINVSTOR-1583](https://folio-org.atlassian.net/browse/MODINVSTOR-1583))
+* Improve performance of /inventory-reindex-records/export api ([MSEARCH-1245](https://folio-org.atlassian.net/browse/MSEARCH-1245))
 
 ### Tech Dept
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))

--- a/README.MD
+++ b/README.MD
@@ -197,12 +197,18 @@ These environment variables configure the module interaction with S3-compatible 
 * `S3_MARC_MIGRATION_ACCESS_KEY_ID` (default value is an empty string - "")
 * `S3_MARC_MIGRATION_SECRET_ACCESS_KEY` (default value is an empty string - "")
 * `S3_MARC_MIGRATION_IS_AWS` (default value - `false`)
+* `S3_MARC_MIGRATION_IDLE_KEEP_ALIVE_SECONDS` — OkHttp idle connection keep-alive in seconds; set below the server-side idle timeout to prevent stale-connection errors (unset = OkHttp default of 5 minutes)
+* `S3_MARC_MIGRATION_MAX_IDLE_CONNECTIONS` — maximum idle connections retained in the OkHttp pool (unset = OkHttp default of 5)
+* `S3_MARC_MIGRATION_MAX_REQUESTS_PER_HOST` — maximum concurrent S3 requests per host (unset = OkHttp default of 5)
 * `S3_REINDEX_URL`
 * `S3_REINDEX_REGION`
 * `S3_REINDEX_BUCKET`
 * `S3_REINDEX_ACCESS_KEY_ID` (default value is an empty string - "")
 * `S3_REINDEX_SECRET_ACCESS_KEY` (default value is an empty string - "")
 * `S3_REINDEX_IS_AWS` (default value - `false`)
+* `S3_REINDEX_IDLE_KEEP_ALIVE_SECONDS` — OkHttp idle connection keep-alive in seconds; set below the server-side idle timeout to prevent stale-connection errors (unset = OkHttp default of 5 minutes)
+* `S3_REINDEX_MAX_IDLE_CONNECTIONS` — maximum idle connections retained in the OkHttp pool (unset = OkHttp default of 5)
+* `S3_REINDEX_MAX_REQUESTS_PER_HOST` — maximum concurrent S3 requests per host (unset = OkHttp default of 5)
 * `S3_LOCAL_SUB_PATH` (default value - `mod-inventory-storage`)
 * `ECS_TLR_FEATURE_ENABLED` (default value - `false`)
 

--- a/mod-inventory-storage-server/src/main/java/org/folio/services/s3storage/FolioS3ClientFactory.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/services/s3storage/FolioS3ClientFactory.java
@@ -3,7 +3,10 @@ package org.folio.services.s3storage;
 import static org.folio.utils.Environment.getBoolValue;
 import static org.folio.utils.Environment.getValueOrEmpty;
 import static org.folio.utils.Environment.getValueOrFail;
+import static org.folio.utils.Environment.parseOptionalInt;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import org.folio.s3.client.FolioS3Client;
 import org.folio.s3.client.S3ClientFactory;
 import org.folio.s3.client.S3ClientProperties;
@@ -20,18 +23,44 @@ public class FolioS3ClientFactory {
   private static final String S3_ACCESS_KEY_ID_CONFIG = "ACCESS_KEY_ID";
   private static final String S3_SECRET_ACCESS_KEY_CONFIG = "SECRET_ACCESS_KEY";
   private static final String S3_IS_AWS_CONFIG = "IS_AWS";
+  private static final String S3_IDLE_KEEP_ALIVE_SECONDS_CONFIG = "IDLE_KEEP_ALIVE_SECONDS";
+  private static final String S3_MAX_IDLE_CONNECTIONS_CONFIG = "MAX_IDLE_CONNECTIONS";
+  private static final String S3_MAX_REQUESTS_PER_HOST_CONFIG = "MAX_REQUESTS_PER_HOST";
+
   private static final Boolean S3_IS_AWS_DEFAULT = Boolean.FALSE;
 
+  // Null S3ConfigType (generic S3_ prefix) is stored under this sentinel key.
+  private static final String DEFAULT_CONFIG_KEY = "_DEFAULT_";
+  private static final Map<String, FolioS3Client> CLIENT_CACHE = new ConcurrentHashMap<>();
+
+  /**
+   * Returns a cached {@link FolioS3Client} for the given config type, creating it on first call.
+   *
+   * <p>Caching ensures a single OkHttp connection pool is reused across all requests of the same
+   * type, eliminating per-request TCP/TLS handshake overhead and enabling connection reuse.
+   */
   public static FolioS3Client getFolioS3Client(@Nullable S3ConfigType configType) {
+    String key = configType != null ? configType.name() : DEFAULT_CONFIG_KEY;
+    return CLIENT_CACHE.computeIfAbsent(key, k -> createClient(configType));
+  }
+
+  public static String getBucketName(@NonNull S3ConfigType configType) {
+    return getValueOrFail(getKey(S3_BUCKET_CONFIG, configType));
+  }
+
+  /**
+   * Clears the client cache. Intended for use in tests only.
+   */
+  static void clearCache() {
+    CLIENT_CACHE.clear();
+  }
+
+  private static FolioS3Client createClient(@Nullable S3ConfigType configType) {
     try {
       return S3ClientFactory.getS3Client(buildS3ClientProperties(configType));
     } catch (IllegalStateException e) {
       throw new S3ClientException(e.getMessage());
     }
-  }
-
-  public static String getBucketName(@NonNull S3ConfigType configType) {
-    return getValueOrFail(getKey(S3_BUCKET_CONFIG, configType));
   }
 
   private static S3ClientProperties buildS3ClientProperties(@Nullable S3ConfigType configType) {
@@ -46,6 +75,9 @@ public class FolioS3ClientFactory {
       .accessKey(getValueOrEmpty(getKey(S3_ACCESS_KEY_ID_CONFIG, configType)))
       .secretKey(getValueOrEmpty(getKey(S3_SECRET_ACCESS_KEY_CONFIG, configType)))
       .awsSdk(getBoolValue(getKey(S3_IS_AWS_CONFIG, configType), S3_IS_AWS_DEFAULT))
+      .idleKeepAliveSeconds(parseOptionalInt(getKey(S3_IDLE_KEEP_ALIVE_SECONDS_CONFIG, configType)))
+      .maxIdleConnections(parseOptionalInt(getKey(S3_MAX_IDLE_CONNECTIONS_CONFIG, configType)))
+      .maxRequestsPerHost(parseOptionalInt(getKey(S3_MAX_REQUESTS_PER_HOST_CONFIG, configType)))
       .build();
   }
 

--- a/mod-inventory-storage-server/src/main/java/org/folio/utils/Environment.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/utils/Environment.java
@@ -46,6 +46,11 @@ public record Environment() {
     return Integer.parseInt(value);
   }
 
+  public static Integer parseOptionalInt(@NonNull String key) {
+    var raw = getValue(key);
+    return raw != null ? Integer.parseInt(raw) : null;
+  }
+
   public static int getKafkaProducerMaxRequestSize() {
     return getIntValue(MAX_REQUEST_SIZE, 10485760); // 10MB
   }

--- a/mod-inventory-storage-server/src/test/java/org/folio/services/s3storage/FolioS3ClientFactoryTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/services/s3storage/FolioS3ClientFactoryTest.java
@@ -1,0 +1,55 @@
+package org.folio.services.s3storage;
+
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+
+import org.folio.services.s3storage.FolioS3ClientFactory.S3ConfigType;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+class FolioS3ClientFactoryTest {
+
+  private static final String ENDPOINT = "http://localhost:9000";
+  private static final String REGION = "us-east-1";
+  private static final String BUCKET = "test-bucket";
+
+  @BeforeEach
+  void setUpS3Properties() {
+    System.setProperty("S3_REINDEX_URL", ENDPOINT);
+    System.setProperty("S3_REINDEX_REGION", REGION);
+    System.setProperty("S3_REINDEX_BUCKET", BUCKET);
+    System.setProperty("S3_MARC_MIGRATION_URL", ENDPOINT);
+    System.setProperty("S3_MARC_MIGRATION_REGION", REGION);
+    System.setProperty("S3_MARC_MIGRATION_BUCKET", BUCKET);
+    // Clear the cache before each test so tests are independent.
+    FolioS3ClientFactory.clearCache();
+  }
+
+  @AfterEach
+  void clearS3Properties() {
+    System.clearProperty("S3_REINDEX_URL");
+    System.clearProperty("S3_REINDEX_REGION");
+    System.clearProperty("S3_REINDEX_BUCKET");
+    System.clearProperty("S3_MARC_MIGRATION_URL");
+    System.clearProperty("S3_MARC_MIGRATION_REGION");
+    System.clearProperty("S3_MARC_MIGRATION_BUCKET");
+    FolioS3ClientFactory.clearCache();
+  }
+
+  @Test
+  void sameInstanceReturnedForSameConfigType() {
+    var first = FolioS3ClientFactory.getFolioS3Client(S3ConfigType.REINDEX);
+    var second = FolioS3ClientFactory.getFolioS3Client(S3ConfigType.REINDEX);
+
+    assertSame(first, second, "getFolioS3Client must return the cached instance on repeated calls");
+  }
+
+  @Test
+  void differentInstancesReturnedForDifferentConfigTypes() {
+    var reindex = FolioS3ClientFactory.getFolioS3Client(S3ConfigType.REINDEX);
+    var marcMigration = FolioS3ClientFactory.getFolioS3Client(S3ConfigType.MARC_MIGRATION);
+
+    assertNotSame(reindex, marcMigration, "Different config types must produce different client instances");
+  }
+}

--- a/mod-inventory-storage-server/src/test/java/org/folio/utils/EnvironmentTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/utils/EnvironmentTest.java
@@ -104,6 +104,25 @@ class EnvironmentTest {
   }
 
   @Test
+  void parseOptionalInt_keyIsMissing_returnsNull() {
+    assertNull(Environment.parseOptionalInt(MISSING_TEST_KEY));
+  }
+
+  @Test
+  void parseOptionalInt_valueExists_returnsParsedInteger() {
+    System.setProperty(TEST_INT_KEY, "8192");
+
+    assertEquals(8192, Environment.parseOptionalInt(TEST_INT_KEY));
+  }
+
+  @Test
+  void parseOptionalInt_valueIsNonNumeric_throwsException() {
+    System.setProperty(TEST_KEY, "not-a-number");
+
+    assertThrows(NumberFormatException.class, () -> Environment.parseOptionalInt(TEST_KEY));
+  }
+
+  @Test
   void getKafkaProducerMaxRequestSize_propertyMissing_returnsDefaultValue() {
     assertEquals(10485760, Environment.getKafkaProducerMaxRequestSize());
   }

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <lombok.version>1.18.46</lombok.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
     <log4j.version>2.26.0</log4j.version>
-    <folio-s3-client.version>3.1.0-SNAPSHOT</folio-s3-client.version>
+    <folio-s3-client.version>3.0.2</folio-s3-client.version>
     <jackson.version>2.22.0</jackson.version>
 
     <!-- Test dependency versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
     <lombok.version>1.18.46</lombok.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
     <log4j.version>2.26.0</log4j.version>
-    <folio-s3-client.version>3.0.1</folio-s3-client.version>
+    <folio-s3-client.version>3.1.0-SNAPSHOT</folio-s3-client.version>
     <jackson.version>2.22.0</jackson.version>
 
     <!-- Test dependency versions -->


### PR DESCRIPTION
### Purpose
Extend s3 client configuration and cache client

### Approach
- Add connection pool configuration exposed via env variables
- Cache created s3 client instead re-creating it on every batch

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
TODO: Сreate a ticket and update NEWS with it
