### PR TITLE
fix: Fix isbn and normalize functions

### DIFF
--- a/mod-inventory-storage-server/src/main/resources/liquibase/tenant/scripts/v30.1.0/01-functions.xml
+++ b/mod-inventory-storage-server/src/main/resources/liquibase/tenant/scripts/v30.1.0/01-functions.xml
@@ -23,7 +23,7 @@
     </sql>
   </changeSet>
 
-  <changeSet id="MODINVSTOR-1051@@schema-create-function-jsonb-array-index-helpers" author="folio">
+  <changeSet id="MODINVSTOR-1051@@schema-create-function-jsonb-array-index-helpers" author="folio" runOnChange="true">
     <comment>Create JSONB array index helper functions</comment>
     <sql splitStatements="false">
       -- Convert text to lowercase and remove accents for consistent indexing
@@ -31,7 +31,7 @@
       CREATE OR REPLACE FUNCTION normalize_token(input_text text)
         RETURNS text AS
       $$
-      SELECT lower(f_unaccent(input_text))
+      SELECT lower(${database.defaultSchemaName}.f_unaccent(input_text))
       $$ LANGUAGE sql IMMUTABLE
                       PARALLEL SAFE;
 
@@ -40,7 +40,7 @@
       CREATE OR REPLACE FUNCTION normalize_jsonb_array(input_array jsonb)
         RETURNS jsonb AS
       $$
-      SELECT coalesce(jsonb_agg(normalize_token(val)), '[]' ::jsonb)
+      SELECT coalesce(jsonb_agg(${database.defaultSchemaName}.normalize_token(val)), '[]' ::jsonb)
       FROM jsonb_array_elements_text(input_array) AS val
       $$ LANGUAGE sql IMMUTABLE
                       PARALLEL SAFE;

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/create_isbn_functions.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/create_isbn_functions.sql
@@ -1,8 +1,8 @@
 -- Usage: SELECT normalize_isbns(jsonb->'identifiers') FROM instance
 -- This takes each ISBN, normalizes it using RMB's normalize_digits(text),
 -- and concatenates the results using a space as separator.
-CREATE OR REPLACE FUNCTION normalize_isbns(jsonb_array jsonb) RETURNS text AS $$
-  SELECT string_agg(normalize_digits(identifier->>'value'), ' ')
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.normalize_isbns(jsonb_array jsonb) RETURNS text AS $$
+  SELECT string_agg(${myuniversity}_${mymodule}.normalize_digits(identifier->>'value'), ' ')
   FROM jsonb_array_elements($1) as identifier
   WHERE identifier->>'identifierTypeId' = '8261054f-be78-422d-bd51-4ed9f33c3422';
 $$ LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT;
@@ -10,8 +10,8 @@ $$ LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT;
 -- Usage: SELECT normalize_invalid_isbns(jsonb->'identifiers') FROM instance
 -- This takes each invalid ISBN, normalizes it using RMB's normalize_digits(text),
 -- and concatenates the results using a space as separator.
-CREATE OR REPLACE FUNCTION normalize_invalid_isbns(jsonb_array jsonb) RETURNS text AS $$
-  SELECT string_agg(normalize_digits(identifier->>'value'), ' ')
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.normalize_invalid_isbns(jsonb_array jsonb) RETURNS text AS $$
+  SELECT string_agg(${myuniversity}_${mymodule}.normalize_digits(identifier->>'value'), ' ')
   FROM jsonb_array_elements($1) as identifier
   WHERE identifier->>'identifierTypeId' = 'fcca2643-406a-482a-b760-7a7f8aec640e';
 $$ LANGUAGE sql IMMUTABLE PARALLEL SAFE STRICT;


### PR DESCRIPTION
### Purpose
Fix isbn and normalize functions.
Isbn error when searching items via BulkEdit:
`ERROR: function normalize_digits(text) does not exist
  Hint: No function matches the given name and argument types. You might need to add explicit type casts.
  Where: SQL function "normalize_invalid_isbns" during inlining`
Same action in bulk edit after fixing isbn with error for normilize:
`ERROR: function normalize_token(text) does not exist\n  Hint: No function matches the given name and argument types. You might need to add explicit type casts.\n  Where: SQL function \"normalize_jsonb_array\" during inlining"`

### Approach
Add schema qualifiers

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [ ] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
[MODINVSTOR-1573](https://folio-org.atlassian.net/browse/MODINVSTOR-1573)