### PR TITLE
CI: fix-items-and-holdings-hrid-case (mirror of #1382)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,7 @@
 * Create feature flag for enabling optimization to prevent redundant updates in Inventory (Instance,Holding,Item) ([MODINVSTOR-1577](https://folio-org.atlassian.net/browse/MODINVSTOR-1577))
 
 ### Bug fixes
+* Populate item and holdings `hrId` in the items-and-holdings view ([MODINVSTOR-1587](https://folio-org.atlassian.net/browse/MODINVSTOR-1587))
 * Trigger holding items recalculation on instanceId change ([MODINVSTOR-1548](https://folio-org.atlassian.net/browse/MODINVSTOR-1548))
 * Fix item order value calculation under concurrent execution to avoid race conditions. ([MODINVSTOR-1547](https://folio-org.atlassian.net/browse/MODINVSTOR-1547))
 * Update Instance complete_updated_date when items/holdings are moved between instances ([MODINVSTOR-1542](https://folio-org.atlassian.net/browse/MODINVSTOR-1542))

--- a/mod-inventory-storage-server/src/main/resources/liquibase/tenant/scripts/v30.1.0/sql/inventory-hierarchy/create_get_items_and_holdings_view_function.sql
+++ b/mod-inventory-storage-server/src/main/resources/liquibase/tenant/scripts/v30.1.0/sql/inventory-hierarchy/create_get_items_and_holdings_view_function.sql
@@ -27,7 +27,7 @@ WITH
       hr.instanceid,
       jsonb_strip_nulls(jsonb_build_object(
         'id', hr.id,
-        'hrId', hr.jsonb ->> 'hrId',
+        'hrId', hr.jsonb ->> 'hrid',
         'suppressFromDiscovery', COALESCE((i.jsonb ->> 'discoverySuppress')::bool, false) OR COALESCE((hr.jsonb ->> 'discoverySuppress')::bool, false),
         'holdingsType', ht.jsonb ->> 'name',
         'formerIds', hr.jsonb -> 'formerIds',
@@ -79,7 +79,7 @@ WITH
           hr.instanceid,
           jsonb_strip_nulls(jsonb_build_object(
             'id', item.id,
-            'hrId', item.jsonb ->> 'hrId',
+            'hrId', item.jsonb ->> 'hrid',
             'holdingsRecordId', (item.jsonb ->> 'holdingsRecordId')::UUID,
             'order', (item.jsonb ->> 'order')::int,
             'suppressFromDiscovery', COALESCE((i.jsonb ->> 'discoverySuppress')::bool, false) OR COALESCE((hr.jsonb ->> 'discoverySuppress')::bool, false) OR COALESCE((item.jsonb ->> 'discoverySuppress')::bool, false),
@@ -133,7 +133,7 @@ WITH
           hr.instanceid,
           jsonb_strip_nulls(jsonb_build_object(
             'id', item.id,
-            'hrId', item.jsonb ->> 'hrId',
+            'hrId', item.jsonb ->> 'hrid',
             'holdingsRecordId', (bwp.holdingsrecordid)::UUID,
             'suppressFromDiscovery', COALESCE((i.jsonb ->> 'discoverySuppress')::bool, false) OR COALESCE((hr.jsonb ->> 'discoverySuppress')::bool, false) OR COALESCE((item.jsonb ->> 'discoverySuppress')::bool, false),
             'status', item.jsonb #>> '{status, name}',

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/InventoryHierarchyViewTest.java
@@ -36,6 +36,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -458,6 +459,26 @@ public class InventoryHierarchyViewTest extends TestBaseWithInventoryUtil {
       var holdings = response.getJson().getJsonArray("holdings");
       verifyItemsLocationNames(items);
       verifyHoldingsLocationNames(holdings);
+    });
+  }
+
+  @Test
+  @SneakyThrows
+  public void shouldHaveHrIdInItemsAndHoldings() {
+    var instanceId = UUID.fromString(predefinedInstance.getString("id"));
+    var expectedHoldingsHrid = predefinedHoldings.getString("hrid");
+
+    requestInventoryHierarchyItemsAndHoldingsViewInstance(new UUID[] {instanceId}, false, response -> {
+      assertThat(response.getStatusCode(), is(HttpStatus.HTTP_OK.toInt()));
+      var items = response.getJson().getJsonArray("items");
+      var holdings = response.getJson().getJsonArray("holdings");
+      assertThat(items.size(), is(2));
+      assertThat(holdings.size(), is(1));
+      items.stream().map(JsonObject.class::cast).forEach(
+        item -> assertThat("item hrId is declared by the response schema and should be populated",
+          item.getString("hrId"), notNullValue()));
+      assertThat("holdings hrId is declared by the response schema and should match the stored record",
+        holdings.getJsonObject(0).getString("hrId"), is(expectedHoldingsHrid));
     });
   }
 


### PR DESCRIPTION
Draft PR to trigger CI for the commit from #1382 (external PR from wellcomecollection/mod-inventory-storage#fix-items-and-holdings-hrid-case). GitHub reuses check results by commit SHA, so once this passes, #1382 will show green checks too. Safe to close once #1382 is merged/closed.