### PR TITLE
test: Fix unstable test with wrong assertions

### DIFF
--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -787,11 +787,10 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     assertThat(update(holding).getStatusCode(), is(204));
 
     var updatedHolding = getById(holdingId).getJson();
-    //assert that there was no update in database
+    //assert that there was an update in database
     assertThat(updatedHolding.getString("_version"), is("2"));
-    var kafkaEvents = KAFKA_CONSUMER.getMessagesForHoldings(holdingId);
-    //assert that there's only CREATE kafka message, no updates
-    assertThat(kafkaEvents.size(), is(1));
+    //assert that UPDATE kafka message was published
+    holdingsMessageChecks.updatedMessagePublished(holding, updatedHolding);
   }
 
   @Test

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -130,10 +130,10 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     INVALID_VALUE);
 
   private final HoldingsEventMessageChecks holdingsMessageChecks
-    = new HoldingsEventMessageChecks(KAFKA_CONSUMER, mockServer.baseUrl());
+    = new HoldingsEventMessageChecks(KAFKA_CONSUMER);
 
   private final ItemEventMessageChecks itemMessageChecks
-    = new ItemEventMessageChecks(KAFKA_CONSUMER, mockServer.baseUrl());
+    = new ItemEventMessageChecks(KAFKA_CONSUMER);
 
   @SneakyThrows
   @BeforeClass

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/HoldingsStorageTest.java
@@ -79,7 +79,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.HttpStatus;
-import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.jaxrs.model.EffectiveCallNumberComponents;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.HoldingsNote;
@@ -114,7 +113,6 @@ import org.junit.runners.MethodSorters;
 public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   private static final Logger log = LogManager.getLogger();
   private static final String TAG_VALUE = "test-tag";
-  private static final String X_OKAPI_URL = "X-Okapi-Url";
   private static final String X_OKAPI_TENANT = "X-Okapi-Tenant";
   private static final String CONSORTIUM_MEMBER_TENANT = "consortium";
   private static final String TENANT_WITHOUT_USER_TENANTS_PERMISSIONS = "nopermissions";
@@ -433,8 +431,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       .create();
     holdingToCreate.put(STATISTICAL_CODE_IDS_KEY, Set.of(INVALID_VALUE));
 
-    var response = holdingsClient.attemptToCreate("", holdingToCreate, TENANT_ID,
-      Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+    var response = holdingsClient.attemptToCreate("", holdingToCreate, TENANT_ID);
     assertThat(response.getStatusCode(), is(400));
     assertThat(response.getBody(), containsString(INVALID_TYPE_ERROR_MESSAGE));
   }
@@ -457,8 +454,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
     var holding = holdingToUpdate.getJson();
     holding.put(STATISTICAL_CODE_IDS_KEY, Set.of(INVALID_VALUE));
 
-    var response = holdingsClient.attemptToReplace(holdingId.toString(), holding, TENANT_ID,
-      Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+    var response = holdingsClient.attemptToReplace(holdingId.toString(), holding);
 
     assertThat(response.getStatusCode(), is(400));
     assertThat(response.getBody(), containsString(INVALID_TYPE_ERROR_MESSAGE));
@@ -474,8 +470,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID)
       .create();
 
-    var response = holdingsClient.attemptToCreate("", holdingToCreate, TENANT_ID,
-      Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+    var response = holdingsClient.attemptToCreate("", holdingToCreate, TENANT_ID);
     assertThat(response.getStatusCode(), is(422));
     assertTrue(response.getBody().contains(String.format(
       "Cannot set holdings_record.instanceid = %s because it does not exist in instance.id.", instanceId)));
@@ -494,7 +489,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     UUID holdingId = holdingResource.getId();
 
-    holdingsClient.delete(holdingId, Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+    holdingsClient.delete(holdingId);
 
     Response getResponse = holdingsClient.getById(holdingId);
 
@@ -641,7 +636,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
       .withSource(getPreparedHoldingSourceId())
       .withPermanentLocation(MAIN_LIBRARY_LOCATION_ID).create());
 
-    holdingsClient.deleteAll(Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+    holdingsClient.deleteAll();
 
     List<JsonObject> allHoldings = holdingsClient.getAll();
 
@@ -660,7 +655,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
 
     var holdings = createFiveHoldingsWithHrids(instanceId1, instanceId2);
 
-    holdingsClient.deleteByQuery("hrid==12*", Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+    holdingsClient.deleteByQuery("hrid==12*", Map.of());
 
     assertHoldingsExistence(holdings);
     assertDeletedMessagesPublished(holdings[0], holdings[2], holdings[4]);
@@ -4044,7 +4039,7 @@ public class HoldingsStorageTest extends TestBaseWithInventoryUtil {
   private Response postSynchronousBatch(URL url, JsonArray holdingsArray, String tenantId) {
     JsonObject holdingsCollection = new JsonObject().put("holdingsRecords", holdingsArray);
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
-    getClient().post(url, holdingsCollection, Map.of(X_OKAPI_URL, mockServer.baseUrl()), tenantId,
+    getClient().post(url, holdingsCollection, tenantId,
       ResponseHandler.any(createCompleted));
     try {
       return createCompleted.get(10, SECONDS);

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -545,11 +545,10 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
     assertThat(update(instance).getStatusCode(), is(204));
 
     var updatedInstance = getById(id).getJson();
-    //assert that there was no update in database
+    //assert that there was an update in database
     assertThat(updatedInstance.getString("_version"), is("2"));
-    var kafkaEvents = KAFKA_CONSUMER.getMessagesForInstance(id.toString());
-    //assert that there's only CREATE kafka message, no updates
-    assertThat(kafkaEvents.size(), is(1));
+    //assert that UPDATE kafka message was published
+    instanceMessageChecks.updatedMessagePublished(instance, updatedInstance);
   }
 
   @Test

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/InstanceStorageTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/InstanceStorageTest.java
@@ -84,7 +84,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.HttpStatus;
-import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.Instance;
 import org.folio.rest.jaxrs.model.InstanceDates;
@@ -2608,8 +2607,7 @@ public class InstanceStorageTest extends TestBaseWithInventoryUtil {
 
     CompletableFuture<Response> createCompleted = new CompletableFuture<>();
 
-    getClient().post(holdingsStorageUrl(""), holdingsToCreate,
-      Map.of(XOkapiHeaders.URL, mockServer.baseUrl()), TENANT_ID, json(createCompleted));
+    getClient().post(holdingsStorageUrl(""), holdingsToCreate, TENANT_ID, json(createCompleted));
 
     Response response = createCompleted.get(2, SECONDS);
 

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/ItemEffectiveCallNumberComponentsTest.java
@@ -14,14 +14,12 @@ import static org.junit.Assert.assertNotNull;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import java.net.HttpURLConnection;
-import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import junitparams.JUnitParamsRunner;
 import junitparams.Parameters;
 import junitparams.naming.TestCaseName;
 import org.apache.commons.lang3.StringUtils;
-import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.api.testdata.ItemEffectiveCallNumberComponentsTestData;
 import org.folio.rest.api.testdata.ItemEffectiveCallNumberComponentsTestData.CallNumberComponentPropertyNames;
 import org.folio.rest.support.IndividualResource;
@@ -304,7 +302,7 @@ public class ItemEffectiveCallNumberComponentsTest extends TestBaseWithInventory
     if (!Objects.equals(itemInitValue, itemTargetValue)) {
       var itemAfterHoldingsUpdate = getById(createdItem.getJson());
       itemsClient.replace(createdItem.getId(), itemAfterHoldingsUpdate.copy()
-        .put(itemPropertyName, itemTargetValue), Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+        .put(itemPropertyName, itemTargetValue));
 
       itemMessageChecks.updatedMessagePublished(itemAfterHoldingsUpdate,
         itemsClient.getById(createdItem.getId()).getJson());

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/ItemStorageTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/ItemStorageTest.java
@@ -579,11 +579,10 @@ public class ItemStorageTest extends TestBaseWithInventoryUtil {
     assertThat(update(item).getStatusCode(), is(204));
 
     var updatedItem = getById(itemId).getJson();
-    //assert that there was no update in database
+    //assert that there was an update in database
     assertThat(updatedItem.getString("_version"), is("2"));
-    var kafkaEvents = KAFKA_CONSUMER.getMessagesForItem(itemId.toString());
-    //assert that there's only CREATE kafka message, no updates
-    assertThat(kafkaEvents.size(), is(1));
+    //assert that UPDATE kafka message was published
+    itemMessageChecks.updatedMessagePublished(item, updatedItem);
   }
 
   @Test

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/SampleDataTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/SampleDataTest.java
@@ -20,13 +20,11 @@ import static org.hamcrest.MatcherAssert.assertThat;
 
 import io.vertx.core.json.JsonObject;
 import java.net.URL;
-import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Predicate;
 import junitparams.JUnitParamsRunner;
 import lombok.SneakyThrows;
-import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.support.Response;
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -46,8 +44,7 @@ public class SampleDataTest extends TestBaseWithInventoryUtil {
     TestBase.beforeAll();
 
     removeTenant(TENANT_ID);
-    prepareTenant(TENANT_ID, null, "mod-inventory-storage-1.0.0", true,
-      Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+    prepareTenant(TENANT_ID, null, "mod-inventory-storage-1.0.0", true);
   }
 
   private static Predicate<JsonObject> hasId(String id) {

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/SettingStorageTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/SettingStorageTest.java
@@ -130,7 +130,6 @@ public class SettingStorageTest extends TestBaseWithInventoryUtil {
       .withValue("not a boolean")).encode());
     var headers = new HashMap<String, String>();
     headers.put(XOkapiHeaders.TENANT, TENANT_ID);
-    headers.put(XOkapiHeaders.URL, mockServer.baseUrl());
     var updateResponse = settingsClient.attemptToUpdate(INVENTORY_OPTIMIZE_UPDATES_ENABLED.getValue(),
       settingRequest, TENANT_ID, headers);
 
@@ -254,7 +253,6 @@ public class SettingStorageTest extends TestBaseWithInventoryUtil {
       .withValue(true)).encode());
     var headers = new HashMap<String, String>();
     headers.put(XOkapiHeaders.TENANT, TENANT_ID);
-    headers.put(XOkapiHeaders.URL, mockServer.baseUrl());
 
     var response = settingsClient.attemptToUpdate("non.existent.setting.key",
       settingRequest, TENANT_ID, headers);
@@ -268,7 +266,6 @@ public class SettingStorageTest extends TestBaseWithInventoryUtil {
     var settingRequest = new JsonObject().putNull("value");
     var headers = new HashMap<String, String>();
     headers.put(XOkapiHeaders.TENANT, TENANT_ID);
-    headers.put(XOkapiHeaders.URL, mockServer.baseUrl());
 
     var response = settingsClient.attemptToUpdate(INVENTORY_OPTIMIZE_UPDATES_ENABLED.getValue(),
       settingRequest, TENANT_ID, headers);
@@ -428,7 +425,6 @@ public class SettingStorageTest extends TestBaseWithInventoryUtil {
 
     var headers = new HashMap<String, String>();
     headers.put(XOkapiHeaders.TENANT, tenantId);
-    headers.put(XOkapiHeaders.URL, mockServer.baseUrl());
     return settingsClient.attemptToUpdate(key, settingRequest, tenantId, headers);
   }
 }

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/SubjectSourceTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/SubjectSourceTest.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeoutException;
 import junitparams.JUnitParamsRunner;
 import lombok.SneakyThrows;
-import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.jaxrs.model.Subject;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.http.ResourceClient;
@@ -271,15 +270,15 @@ public class SubjectSourceTest extends TestBaseWithInventoryUtil {
   }
 
   private Response createSubjectSource(JsonObject object, String tenantId) {
-    return subjectSourceClient.attemptToCreate("", object, tenantId, Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+    return subjectSourceClient.attemptToCreate("", object, tenantId);
   }
 
   private Response updateSubjectSource(String id, JsonObject object) {
-    return subjectSourceClient.attemptToReplace(id, object, TENANT_ID, Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+    return subjectSourceClient.attemptToReplace(id, object);
   }
 
   private Response updateSubjectSource(String id, JsonObject object, String tenantId) {
-    return subjectSourceClient.attemptToReplace(id, object, tenantId, Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+    return subjectSourceClient.attemptToReplace(id, object, tenantId, Map.of());
   }
 
   private Response deleteSubjectSource(UUID id) {

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/SubjectTypeTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/SubjectTypeTest.java
@@ -22,7 +22,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import junitparams.JUnitParamsRunner;
 import lombok.SneakyThrows;
-import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.jaxrs.model.Subject;
 import org.folio.rest.support.Response;
 import org.folio.rest.support.ResponseHandler;
@@ -275,15 +274,15 @@ public class SubjectTypeTest extends TestBaseWithInventoryUtil {
   }
 
   private Response createSubjectType(JsonObject object, String tenantId) {
-    return subjectTypeClient.attemptToCreate("", object, tenantId, Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+    return subjectTypeClient.attemptToCreate("", object, tenantId);
   }
 
   private Response updateSubjectType(String id, JsonObject object) {
-    return subjectTypeClient.attemptToReplace(id, object, TENANT_ID, Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+    return subjectTypeClient.attemptToReplace(id, object);
   }
 
   private Response updateSubjectType(String id, JsonObject object, String tenantId) {
-    return subjectTypeClient.attemptToReplace(id, object, tenantId, Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+    return subjectTypeClient.attemptToReplace(id, object, tenantId, Map.of());
   }
 
   private Response deleteSubjectType(UUID id) {

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/TestBaseWithInventoryUtil.java
@@ -4,7 +4,9 @@ import static com.github.tomakehurst.wiremock.client.WireMock.equalToIgnoreCase;
 import static org.folio.rest.support.http.InterfaceUrls.instanceStatusesUrl;
 import static org.folio.rest.support.http.InterfaceUrls.itemsStorageUrl;
 import static org.folio.rest.support.http.InterfaceUrls.materialTypesStorageUrl;
+import static org.folio.utility.ModuleUtility.clearOkapiUrl;
 import static org.folio.utility.ModuleUtility.getClient;
+import static org.folio.utility.ModuleUtility.setOkapiUrl;
 import static org.folio.utility.RestUtility.CONSORTIUM_CENTRAL_TENANT;
 import static org.folio.utility.RestUtility.CONSORTIUM_MEMBER_TENANT;
 import static org.folio.utility.RestUtility.TENANT_ID;
@@ -20,7 +22,6 @@ import io.vertx.core.json.JsonObject;
 import java.net.HttpURLConnection;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -38,6 +39,7 @@ import org.folio.rest.support.builders.HoldingRequestBuilder;
 import org.folio.rest.support.builders.ItemRequestBuilder;
 import org.folio.rest.support.client.MaterialTypesClient;
 import org.folio.utility.LocationUtility;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 
@@ -104,10 +106,22 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
     setupLoanTypes();
     setupLocations();
 
+    // Route the default X-Okapi-Url header (and therefore the URL echoed into Kafka events)
+    // through WireMock, so it matches what the event message checks expect. The event checks
+    // in each subclass read this same value via ModuleUtility.okapiUrl().
+    setOkapiUrl(mockServer.baseUrl());
+
     KAFKA_CONSUMER.discardAllMessages();
     mockUserTenantsForNonConsortiumMember();
 
     logger.info("finishing @BeforeClass testBaseWithInvUtilBeforeClass()");
+  }
+
+  @AfterClass
+  public static void testBaseWithInvUtilAfterClass() {
+    // Reset so a later class that does not set it up (e.g. a plain TestBase subclass) does not
+    // inherit this class's now-stopped WireMock URL.
+    clearOkapiUrl();
   }
 
   public static void mockUserTenantsForNonConsortiumMember() {
@@ -280,7 +294,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
   }
 
   protected static IndividualResource createHoldingRecord(JsonObject holdingsJson, String tenantId) {
-    return holdingsClient.create(holdingsJson, tenantId, Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+    return holdingsClient.create(holdingsJson, tenantId);
   }
 
   protected static void updateHoldingRecord(UUID id, Builder builder) {
@@ -289,8 +303,7 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
 
   protected static void updateHoldingRecord(UUID id, JsonObject holdingJson) {
     var holdingId = id != null ? id.toString() : null;
-    var putResponse = holdingsClient.attemptToReplace(holdingId, holdingJson, TENANT_ID,
-      Map.of(XOkapiHeaders.URL, mockServer.baseUrl()));
+    var putResponse = holdingsClient.attemptToReplace(holdingId, holdingJson);
     assertThat(
       String.format("Failed to update holding record %s: %s", id, putResponse.getBody()),
       putResponse.getStatusCode(), is(HttpURLConnection.HTTP_NO_CONTENT));
@@ -399,7 +412,6 @@ public abstract class TestBaseWithInventoryUtil extends TestBase {
 
     var headers = new HashMap<String, String>();
     headers.put(XOkapiHeaders.TENANT, TENANT_ID);
-    headers.put(XOkapiHeaders.URL, mockServer.baseUrl());
     return settingsClient.attemptToUpdate(key, settingRequest, TENANT_ID, headers);
   }
 

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/support/HttpClient.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/support/HttpClient.java
@@ -23,6 +23,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.utility.ModuleUtility;
 
 public class HttpClient {
   private static final Logger LOG = LogManager.getLogger();
@@ -284,7 +285,13 @@ public class HttpClient {
     }
     if (url != null) {
       String baseUrl = format("%s://%s", url.getProtocol(), url.getAuthority());
-      request.putHeader(XOkapiHeaders.URL, baseUrl);
+      // Prefer the suite-wide okapi URL override (when set) so the X-Okapi-Url that the
+      // module echoes into Kafka events matches what the event assertions expect. Falls
+      // back to the request's own base URL when no override is configured.
+      String okapiUrl = ModuleUtility.okapiUrlOverride() != null
+        ? ModuleUtility.okapiUrlOverride()
+        : baseUrl;
+      request.putHeader(XOkapiHeaders.URL, okapiUrl);
       request.putHeader(XOkapiHeaders.URL_TO, baseUrl);
     }
     request.putHeader(ACCEPT, APPLICATION_JSON + ", " + TEXT_PLAIN);

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/BoundWithEventMessageChecks.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/BoundWithEventMessageChecks.java
@@ -1,7 +1,7 @@
 package org.folio.rest.support.messages;
 
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
-import static org.folio.utility.ModuleUtility.vertxUrl;
+import static org.folio.utility.ModuleUtility.okapiUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.allOf;
 
@@ -17,7 +17,7 @@ import org.jetbrains.annotations.NotNull;
 
 public class BoundWithEventMessageChecks {
   private final EventMessageMatchers eventMessageMatchers
-    = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
+    = new EventMessageMatchers(TENANT_ID, okapiUrl());
   private final FakeKafkaConsumer kafkaConsumer;
 
   public BoundWithEventMessageChecks(FakeKafkaConsumer kafkaConsumer) {

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
@@ -4,7 +4,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
 import static org.folio.rest.support.AwaitConfiguration.awaitDuring;
 import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_ID;
-import static org.folio.utility.ModuleUtility.vertxUrl;
+import static org.folio.utility.ModuleUtility.okapiUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
@@ -23,7 +23,7 @@ public class HoldingsEventMessageChecks {
 
   public HoldingsEventMessageChecks(FakeKafkaConsumer kafkaConsumer) {
     this.kafkaConsumer = kafkaConsumer;
-    this.eventMessageMatchers = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
+    this.eventMessageMatchers = new EventMessageMatchers(TENANT_ID, okapiUrl());
   }
 
   public HoldingsEventMessageChecks(FakeKafkaConsumer kafkaConsumer, String urlHeader) {

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/HoldingsEventMessageChecks.java
@@ -4,6 +4,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
 import static org.folio.rest.support.AwaitConfiguration.awaitDuring;
 import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_ID;
+import static org.folio.utility.ModuleUtility.vertxUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
@@ -19,6 +20,11 @@ public class HoldingsEventMessageChecks {
   private final EventMessageMatchers eventMessageMatchers;
 
   private final FakeKafkaConsumer kafkaConsumer;
+
+  public HoldingsEventMessageChecks(FakeKafkaConsumer kafkaConsumer) {
+    this.kafkaConsumer = kafkaConsumer;
+    this.eventMessageMatchers = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
+  }
 
   public HoldingsEventMessageChecks(FakeKafkaConsumer kafkaConsumer, String urlHeader) {
     this.kafkaConsumer = kafkaConsumer;

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/InstanceEventMessageChecks.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/InstanceEventMessageChecks.java
@@ -5,7 +5,7 @@ import static org.awaitility.Awaitility.await;
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
 import static org.folio.rest.support.AwaitConfiguration.awaitDuring;
 import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_ID;
-import static org.folio.utility.ModuleUtility.vertxUrl;
+import static org.folio.utility.ModuleUtility.okapiUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
@@ -26,12 +26,12 @@ public class InstanceEventMessageChecks {
 
   private static final Logger log = LogManager.getLogger();
 
-  private static final EventMessageMatchers EVENT_MESSAGE_MATCHERS
-    = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
+  private final EventMessageMatchers eventMessageMatchers;
   private final FakeKafkaConsumer kafkaConsumer;
 
   public InstanceEventMessageChecks(FakeKafkaConsumer kafkaConsumer) {
     this.kafkaConsumer = kafkaConsumer;
+    this.eventMessageMatchers = new EventMessageMatchers(TENANT_ID, okapiUrl());
   }
 
   private static String getId(JsonObject json) {
@@ -47,7 +47,7 @@ public class InstanceEventMessageChecks {
     final String instanceId = getId(instance);
 
     awaitAtMost().until(() -> kafkaConsumer.getMessagesForInstance(instanceId),
-      EVENT_MESSAGE_MATCHERS.hasCreateEventMessageFor(instance));
+      eventMessageMatchers.hasCreateEventMessageFor(instance));
   }
 
   public void createdMessagePublished(String instanceId) {
@@ -70,39 +70,39 @@ public class InstanceEventMessageChecks {
       }, hasSize(instances.size()));
 
     instances.forEach(instance -> assertThat(kafkaConsumer.getMessagesForInstances(instanceIds),
-      EVENT_MESSAGE_MATCHERS.hasCreateEventMessageFor(instance)));
+      eventMessageMatchers.hasCreateEventMessageFor(instance)));
   }
 
   public void updatedMessagePublished(JsonObject oldInstance, JsonObject newInstance) {
     final String instanceId = getId(oldInstance);
 
     awaitAtMost().until(() -> kafkaConsumer.getMessagesForInstance(instanceId),
-      EVENT_MESSAGE_MATCHERS.hasUpdateEventMessageFor(oldInstance, newInstance));
+      eventMessageMatchers.hasUpdateEventMessageFor(oldInstance, newInstance));
   }
 
   public void noUpdatedMessagePublished(String instanceId) {
     awaitDuring(1, SECONDS)
       .until(() -> kafkaConsumer.getMessagesForInstance(instanceId),
-        EVENT_MESSAGE_MATCHERS.hasNoUpdateEventMessage());
+        eventMessageMatchers.hasNoUpdateEventMessage());
   }
 
   public void deletedMessagePublished(JsonObject instance) {
     final String instanceId = getId(instance);
 
     awaitAtMost().until(() -> kafkaConsumer.getMessagesForInstance(instanceId),
-      EVENT_MESSAGE_MATCHERS.hasDeleteEventMessageFor(instance));
+      eventMessageMatchers.hasDeleteEventMessageFor(instance));
   }
 
   public void noDeletedMessagePublished(String instanceId) {
     awaitDuring(1, SECONDS)
       .until(() -> kafkaConsumer.getMessagesForInstance(instanceId),
-        EVENT_MESSAGE_MATCHERS.hasNoDeleteEventMessage());
+        eventMessageMatchers.hasNoDeleteEventMessage());
   }
 
   public void allInstancesDeletedMessagePublished() {
     awaitAtMost()
       .until(() -> kafkaConsumer.getMessagesForInstance(NULL_ID),
-        EVENT_MESSAGE_MATCHERS.hasDeleteAllEventMessage());
+        eventMessageMatchers.hasDeleteAllEventMessage());
   }
 
   public void countOfAllPublishedInstancesIs(Matcher<Integer> matcher) {

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/ItemEventMessageChecks.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/ItemEventMessageChecks.java
@@ -4,7 +4,7 @@ import static java.util.UUID.fromString;
 import static org.folio.rest.api.TestBase.holdingsClient;
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
 import static org.folio.services.domainevent.CommonDomainEventPublisher.NULL_ID;
-import static org.folio.utility.ModuleUtility.vertxUrl;
+import static org.folio.utility.ModuleUtility.okapiUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
@@ -24,7 +24,7 @@ public class ItemEventMessageChecks {
 
   public ItemEventMessageChecks(FakeKafkaConsumer kafkaConsumer) {
     this.kafkaConsumer = kafkaConsumer;
-    this.eventMessageMatchers = new EventMessageMatchers(TENANT_ID, vertxUrl(""));
+    this.eventMessageMatchers = new EventMessageMatchers(TENANT_ID, okapiUrl());
   }
 
   public ItemEventMessageChecks(FakeKafkaConsumer kafkaConsumer, String urlHeader) {

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/LoanTypeEventMessageChecks.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/LoanTypeEventMessageChecks.java
@@ -2,7 +2,7 @@ package org.folio.rest.support.messages;
 
 import static java.util.concurrent.TimeUnit.SECONDS;
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
-import static org.folio.utility.ModuleUtility.vertxUrl;
+import static org.folio.utility.ModuleUtility.okapiUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.Matchers.empty;
@@ -15,7 +15,7 @@ public class LoanTypeEventMessageChecks {
 
   private final FakeKafkaConsumer kafkaConsumer;
   private final EventMessageMatchers eventMessageMatchers = new EventMessageMatchers(
-    TENANT_ID, vertxUrl(""));
+    TENANT_ID, okapiUrl());
 
   public LoanTypeEventMessageChecks(FakeKafkaConsumer kafkaConsumer) {
     this.kafkaConsumer = kafkaConsumer;

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/MaterialTypeEventMessageChecks.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/MaterialTypeEventMessageChecks.java
@@ -1,7 +1,7 @@
 package org.folio.rest.support.messages;
 
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
-import static org.folio.utility.ModuleUtility.vertxUrl;
+import static org.folio.utility.ModuleUtility.okapiUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 
 import io.vertx.core.json.JsonObject;
@@ -12,7 +12,7 @@ public class MaterialTypeEventMessageChecks {
 
   private final FakeKafkaConsumer kafkaConsumer;
   private final EventMessageMatchers eventMessageMatchers = new EventMessageMatchers(
-    TENANT_ID, vertxUrl(""));
+    TENANT_ID, okapiUrl());
 
   public MaterialTypeEventMessageChecks(FakeKafkaConsumer kafkaConsumer) {
     this.kafkaConsumer = kafkaConsumer;

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/ServicePointEventMessageChecks.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/support/messages/ServicePointEventMessageChecks.java
@@ -1,7 +1,7 @@
 package org.folio.rest.support.messages;
 
 import static org.folio.rest.support.AwaitConfiguration.awaitAtMost;
-import static org.folio.utility.ModuleUtility.vertxUrl;
+import static org.folio.utility.ModuleUtility.okapiUrl;
 import static org.folio.utility.RestUtility.TENANT_ID;
 
 import io.vertx.core.json.JsonObject;
@@ -12,7 +12,7 @@ public class ServicePointEventMessageChecks {
 
   private final FakeKafkaConsumer kafkaConsumer;
   private final EventMessageMatchers eventMessageMatchers = new EventMessageMatchers(
-    TENANT_ID, vertxUrl(""));
+    TENANT_ID, okapiUrl());
 
   public ServicePointEventMessageChecks(FakeKafkaConsumer kafkaConsumer) {
     this.kafkaConsumer = kafkaConsumer;

--- a/mod-inventory-storage-server/src/test/java/org/folio/utility/ModuleUtility.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/utility/ModuleUtility.java
@@ -8,6 +8,7 @@ import io.vertx.core.DeploymentOptions;
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
+import java.net.URI;
 import java.net.URL;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -27,6 +28,10 @@ public final class ModuleUtility {
   private static Vertx vertx;
   private static HttpClient client;
   private static int port = 0;
+  // Suite-wide okapi URL used both for the default X-Okapi-Url request header and for
+  // Kafka event assertions, so the two never drift apart. Null means "not set": callers
+  // fall back to the module's own vertx URL, preserving the historical default.
+  private static String okapiUrlOverride;
 
   private ModuleUtility() {
     throw new UnsupportedOperationException("Cannot instantiate utility class.");
@@ -208,6 +213,39 @@ public final class ModuleUtility {
   public static URL vertxUrl(String path) {
     try {
       return new URL("http", "localhost", getPort(), path);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Set the okapi URL used as the default {@code X-Okapi-Url} header and as the expected
+   * URL in Kafka event assertions for the current test class. Should be cleared afterwards.
+   */
+  public static void setOkapiUrl(String url) {
+    okapiUrlOverride = url;
+  }
+
+  public static void clearOkapiUrl() {
+    okapiUrlOverride = null;
+  }
+
+  /** The configured okapi URL override,
+   * or {@code null} when none is set. */
+  public static String okapiUrlOverride() {
+    return okapiUrlOverride;
+  }
+
+  /**
+   * Resolved okapi URL for assertions: the override when set, otherwise the module's own
+   * vertx URL (the historical default).
+   */
+  public static URL okapiUrl() {
+    if (okapiUrlOverride == null) {
+      return vertxUrl("");
+    }
+    try {
+      return URI.create(okapiUrlOverride).toURL();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }


### PR DESCRIPTION
### Purpose
Fix unstable test with wrong assertions.
Test body suggests that item should be updated but assertion verifies that there was only 1 create event and it's unstable because there's no wait so sometimes it wrongly passes when update event is not captured for the time of the assertion.
x-okapi-url headers are inconsistent across integration tests, sometimes vertx url is used, sometimes - wiremock url.

### Approach
Rework assertion to wait for the update event.
Use wiremock url when appllicable for http client, kafka assertion, use vertx url otherwise

### Changes Checklist
- [ ] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [ ] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [ ] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [ ] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [ ] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

