### PR TITLE
FOLIO-4553: Set "permissions: contents: read" in maven.yml

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,9 +1,14 @@
+# https://github.com/folio-org/.github/blob/master/README-maven.md
+
 name: Maven central workflow
 
 on:
   push:
   pull_request:
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   maven:

--- a/NEWS.md
+++ b/NEWS.md
@@ -21,6 +21,7 @@
 * Improve performance of /inventory-reindex-records/export api ([MSEARCH-1245](https://folio-org.atlassian.net/browse/MSEARCH-1245))
 
 ### Tech Dept
+* Set "permissions: contents: read" in maven.yml ([FOLIO-4553](https://folio-org.atlassian.net/browse/FOLIO-4553))
 * Description ([ISSUE](https://folio-org.atlassian.net/browse/ISSUE))
 
 ### Dependencies


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FOLIO-4553

### Purpose
Adding `permissions: contents: read` to the repository’s maven.yml file that calls the central maven github action workflow is best practice and significantly reduces supply chain attacks: https://docs.github.com/en/actions/reference/security/secure-use

Suggested maven.yml: https://github.com/folio-org/.github/blob/master/README-maven.md#usage

### Approach
Add `permissions: contents: read`

### Changes Checklist
- n/a **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- n/a **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- n/a **Interface Version Changes**: Indicate any changes to interface versions.
- n/a **Interface Dependencies**: Document added or removed dependencies.
- n/a **Permissions**: Document any changes to permissions.
- n/a **Logging**: Confirm that logging is appropriately handled.
- n/a **Unit Testing**: Confirm that changed classes were covered by unit tests.
- n/a **Integration Testing**: Confirm that changed logic was covered by integration tests.
- n/a **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [X] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues
https://folio-org.atlassian.net/browse/FOLIO-4553

### Learning and Resources (if applicable)
Follow documentation: https://github.com/folio-org/.github/blob/master/README-maven.md#usage