### PR TITLE
Create a instance summary endpoint. Trillium backport

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -182,7 +182,7 @@
     },
     {
       "id": "instance-storage",
-      "version": "11.3",
+      "version": "11.4",
       "handlers": [
         {
           "methods": ["GET"],
@@ -197,6 +197,10 @@
           "methods": ["GET"],
           "pathPattern": "/instance-storage/instances/{id}",
           "permissionsRequired": ["inventory-storage.instances.item.get"]
+        }, {
+          "methods": ["GET"],
+          "pathPattern": "/instance-storage/instances/{id}/summary",
+          "permissionsRequired": ["inventory-storage.instances.summary.get"]
         }, {
           "methods": ["POST"],
           "pathPattern": "/instance-storage/instances",
@@ -1617,6 +1621,11 @@
       "description": "get individual instance from storage"
     },
     {
+      "permissionName": "inventory-storage.instances.summary.get",
+      "displayName": "inventory storage - get individual instance summary",
+      "description": "get individual instance summary from storage"
+    },
+    {
       "permissionName": "inventory-storage.instances.item.post",
       "displayName": "inventory storage - create individual instance",
       "description": "create individual instance in storage"
@@ -2707,6 +2716,7 @@
         "inventory-storage.instances.collection.get",
         "inventory-storage.instances.retrieve.collection.post",
         "inventory-storage.instances.item.get",
+        "inventory-storage.instances.summary.get",
         "inventory-storage.instances.item.post",
         "inventory-storage.instances.item.put",
         "inventory-storage.instances.item.patch.execute",

--- a/mod-inventory-storage-server/src/main/java/org/folio/rest/impl/InstanceStorageApi.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/rest/impl/InstanceStorageApi.java
@@ -257,6 +257,20 @@ public class InstanceStorageApi implements InstanceStorage {
 
   @Validate
   @Override
+  public void getInstanceStorageInstancesSummaryByInstanceId(
+    String instanceId,
+    Map<String, String> okapiHeaders,
+    Handler<AsyncResult<Response>> asyncResultHandler,
+    Context vertxContext) {
+
+    new InstanceService(vertxContext, okapiHeaders)
+      .getInstanceSummary(instanceId)
+      .otherwise(EndpointFailureHandler::failureResponse)
+      .onComplete(asyncResultHandler);
+  }
+
+  @Validate
+  @Override
   public void deleteInstanceStorageInstancesByInstanceId(
     String instanceId,
 

--- a/mod-inventory-storage-server/src/main/java/org/folio/services/instance/InstanceService.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/services/instance/InstanceService.java
@@ -27,6 +27,7 @@ import io.vertx.core.Future;
 import io.vertx.core.Promise;
 import io.vertx.core.json.JsonObject;
 import io.vertx.pgclient.PgException;
+import io.vertx.sqlclient.Tuple;
 import java.lang.reflect.Method;
 import java.util.Collection;
 import java.util.Collections;
@@ -83,6 +84,8 @@ public class InstanceService {
   private static final String EXPECTED_A_MAXIMUM_RECORDS_TO_PREVENT_OUT_OF_MEMORY =
     "Expected a maximum of %s records to prevent out of memory but got %s";
   private static final String RESPOND_500_WITH_TEXT_PLAIN = "respond500WithTextPlain";
+  private static final String GET_INSTANCE_SUMMARY_SQL = "SELECT get_instance_summary($1::uuid) AS summary";
+  private static final String NOT_FOUND = "Not found";
   private final HridManager hridManager;
   private final Context vertxContext;
   private final Map<String, String> okapiHeaders;
@@ -118,6 +121,23 @@ public class InstanceService {
           return GetInstanceStorageInstancesByInstanceIdResponse.respond404WithTextPlain(null);
         }
         return GetInstanceStorageInstancesByInstanceIdResponse.respond200WithApplicationJson(instance);
+      });
+  }
+
+  public Future<Response> getInstanceSummary(String id) {
+    return postgresClient.execute(GET_INSTANCE_SUMMARY_SQL, Tuple.of(id))
+      .map(rows -> {
+        var iterator = rows.iterator();
+        if (!iterator.hasNext()) {
+          return Response.status(404).type("text/plain").entity(NOT_FOUND).build();
+        }
+
+        JsonObject summary = iterator.next().getJsonObject("summary");
+        if (summary == null) {
+          return Response.status(404).type("text/plain").entity(NOT_FOUND).build();
+        }
+
+        return Response.ok(summary.encode(), "application/json").build();
       });
   }
 

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceSummaryFunction.sql
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/instance/createInstanceSummaryFunction.sql
@@ -1,0 +1,314 @@
+DROP FUNCTION IF EXISTS ${myuniversity}_${mymodule}.get_instance_summary(uuid, boolean, boolean);
+DROP FUNCTION IF EXISTS ${myuniversity}_${mymodule}.get_instance_summary(uuid, boolean);
+
+CREATE OR REPLACE FUNCTION ${myuniversity}_${mymodule}.get_instance_summary(_instance_id uuid)
+  RETURNS jsonb
+  LANGUAGE sql
+AS $function$
+WITH
+  target_instance AS (
+    SELECT i.id, i.jsonb
+    FROM ${myuniversity}_${mymodule}.instance i
+    WHERE i.id = _instance_id
+  ),
+  holdings_all AS (
+    SELECT
+      hr.id,
+      hr.instanceid,
+      hr.jsonb,
+      COALESCE((hr.jsonb ->> 'discoverySuppress')::boolean, false) AS discovery_suppress
+    FROM ${myuniversity}_${mymodule}.holdings_record hr
+      JOIN target_instance ti ON hr.instanceid = ti.id
+  ),
+  holdings_not_suppressed AS (
+    SELECT *
+    FROM holdings_all
+    WHERE NOT discovery_suppress
+  ),
+  direct_items_all AS (
+    SELECT
+      item.id,
+      item.materialtypeid,
+      NULLIF(item.jsonb ->> 'effectiveShelvingOrder', '') AS effective_shelving_order,
+      CASE
+        WHEN jsonb_typeof(item.jsonb -> 'electronicAccess') = 'array'
+          AND item.jsonb -> 'electronicAccess' <> '[]'::jsonb
+          THEN item.jsonb -> 'electronicAccess'
+        ELSE NULL
+      END AS electronic_access,
+      COALESCE((hr.jsonb ->> 'discoverySuppress')::boolean, false) AS holdings_discovery_suppress,
+      COALESCE((item.jsonb ->> 'discoverySuppress')::boolean, false) AS item_discovery_suppress
+    FROM holdings_all hr
+      JOIN ${myuniversity}_${mymodule}.item item ON item.holdingsrecordid = hr.id
+  ),
+  bound_with_items_all AS (
+    SELECT
+      item.id,
+      item.materialtypeid,
+      NULLIF(item.jsonb ->> 'effectiveShelvingOrder', '') AS effective_shelving_order,
+      CASE
+        WHEN jsonb_typeof(item.jsonb -> 'electronicAccess') = 'array'
+          AND item.jsonb -> 'electronicAccess' <> '[]'::jsonb
+          THEN item.jsonb -> 'electronicAccess'
+        ELSE NULL
+      END AS electronic_access,
+      COALESCE((hr.jsonb ->> 'discoverySuppress')::boolean, false) AS holdings_discovery_suppress,
+      COALESCE((item.jsonb ->> 'discoverySuppress')::boolean, false) AS item_discovery_suppress
+    FROM holdings_all hr
+      JOIN ${myuniversity}_${mymodule}.bound_with_part bwp ON bwp.holdingsrecordid = hr.id
+      JOIN ${myuniversity}_${mymodule}.item item ON item.id = bwp.itemid
+  ),
+  items_all AS (
+    SELECT DISTINCT ON (all_items.id)
+      all_items.id,
+      all_items.materialtypeid,
+      all_items.effective_shelving_order,
+      all_items.electronic_access,
+      all_items.holdings_discovery_suppress,
+      all_items.item_discovery_suppress
+    FROM (
+      SELECT * FROM direct_items_all
+      UNION ALL
+      SELECT * FROM bound_with_items_all
+    ) all_items
+    ORDER BY all_items.id
+  ),
+  items_not_suppressed AS (
+    SELECT *
+    FROM items_all
+    WHERE NOT (holdings_discovery_suppress OR item_discovery_suppress)
+  ),
+  holdings_counts AS (
+    SELECT
+      COUNT(*) AS total,
+      COUNT(*) FILTER (WHERE discovery_suppress) AS suppressed_from_discovery,
+      COUNT(*) FILTER (WHERE NOT discovery_suppress) AS not_suppressed_from_discovery
+    FROM holdings_all
+  ),
+  items_counts AS (
+    SELECT
+      COUNT(*) AS total,
+      COUNT(*) FILTER (WHERE item_discovery_suppress) AS suppressed_from_discovery,
+      COUNT(*) FILTER (WHERE holdings_discovery_suppress) AS suppressed_by_holdings,
+      COUNT(*) FILTER (WHERE holdings_discovery_suppress OR item_discovery_suppress)
+        AS suppressed_from_discovery_or_by_holdings,
+      COUNT(*) FILTER (WHERE NOT (holdings_discovery_suppress OR item_discovery_suppress))
+        AS not_suppressed_from_discovery
+    FROM items_all
+  ),
+  electronic_access_data AS (
+    SELECT 'allRecords' AS scope, 1 AS source_order, electronic_access.ordinal, electronic_access.value
+    FROM target_instance ti
+      CROSS JOIN LATERAL jsonb_array_elements(COALESCE(ti.jsonb -> 'electronicAccess', '[]'::jsonb))
+        WITH ORDINALITY AS electronic_access(value, ordinal)
+    UNION ALL
+    SELECT 'notSuppressedFromDiscoveryRecords' AS scope, 1 AS source_order, electronic_access.ordinal, electronic_access.value
+    FROM target_instance ti
+      CROSS JOIN LATERAL jsonb_array_elements(COALESCE(ti.jsonb -> 'electronicAccess', '[]'::jsonb))
+        WITH ORDINALITY AS electronic_access(value, ordinal)
+    UNION ALL
+    SELECT 'allRecords' AS scope, 2 AS source_order, electronic_access.ordinal, electronic_access.value
+    FROM (
+        SELECT item.electronic_access
+        FROM items_all item
+        WHERE item.electronic_access IS NOT NULL
+      ) item
+      CROSS JOIN LATERAL jsonb_array_elements(item.electronic_access)
+        WITH ORDINALITY AS electronic_access(value, ordinal)
+    UNION ALL
+    SELECT 'notSuppressedFromDiscoveryRecords' AS scope, 2 AS source_order, electronic_access.ordinal, electronic_access.value
+    FROM (
+        SELECT item.electronic_access
+        FROM items_not_suppressed item
+        WHERE item.electronic_access IS NOT NULL
+      ) item
+      CROSS JOIN LATERAL jsonb_array_elements(item.electronic_access)
+        WITH ORDINALITY AS electronic_access(value, ordinal)
+    UNION ALL
+    SELECT 'allRecords' AS scope, 3 AS source_order, electronic_access.ordinal, electronic_access.value
+    FROM holdings_all hr
+      CROSS JOIN LATERAL jsonb_array_elements(COALESCE(hr.jsonb -> 'electronicAccess', '[]'::jsonb))
+        WITH ORDINALITY AS electronic_access(value, ordinal)
+    UNION ALL
+    SELECT 'notSuppressedFromDiscoveryRecords' AS scope, 3 AS source_order, electronic_access.ordinal, electronic_access.value
+    FROM holdings_not_suppressed hr
+      CROSS JOIN LATERAL jsonb_array_elements(COALESCE(hr.jsonb -> 'electronicAccess', '[]'::jsonb))
+        WITH ORDINALITY AS electronic_access(value, ordinal)
+  ),
+  electronic_access_distinct AS (
+    SELECT DISTINCT ON (scope, value ->> 'uri')
+      scope,
+      value,
+      source_order,
+      ordinal
+    FROM electronic_access_data
+    WHERE NULLIF(value ->> 'uri', '') IS NOT NULL
+    ORDER BY scope, value ->> 'uri', source_order, ordinal
+  ),
+  electronic_access_by_scope AS (
+    SELECT
+      COALESCE(
+        jsonb_agg(value ORDER BY source_order, ordinal) FILTER (WHERE scope = 'allRecords'),
+        '[]'::jsonb
+      ) AS all_records,
+      COALESCE(
+        jsonb_agg(value ORDER BY source_order, ordinal) FILTER (WHERE scope = 'notSuppressedFromDiscoveryRecords'),
+        '[]'::jsonb
+      ) AS not_suppressed_from_discovery_records
+    FROM electronic_access_distinct
+  ),
+  material_type_data AS (
+    SELECT 'allRecords' AS scope, mt.id::text AS id, mt.jsonb ->> 'name' AS name
+    FROM (
+        SELECT DISTINCT item.materialtypeid
+        FROM items_all item
+        WHERE item.materialtypeid IS NOT NULL
+      ) item
+      JOIN ${myuniversity}_${mymodule}.material_type mt ON item.materialtypeid = mt.id
+    UNION
+    SELECT 'notSuppressedFromDiscoveryRecords' AS scope, mt.id::text AS id, mt.jsonb ->> 'name' AS name
+    FROM (
+        SELECT DISTINCT item.materialtypeid
+        FROM items_not_suppressed item
+        WHERE item.materialtypeid IS NOT NULL
+      ) item
+      JOIN ${myuniversity}_${mymodule}.material_type mt ON item.materialtypeid = mt.id
+  ),
+  material_types_by_scope AS (
+    SELECT
+      COALESCE(
+        jsonb_agg(jsonb_build_object('id', id, 'name', name) ORDER BY name) FILTER (WHERE scope = 'allRecords'),
+        '[]'::jsonb
+      ) AS all_records,
+      COALESCE(
+        jsonb_agg(jsonb_build_object('id', id, 'name', name) ORDER BY name)
+          FILTER (WHERE scope = 'notSuppressedFromDiscoveryRecords'),
+        '[]'::jsonb
+      ) AS not_suppressed_from_discovery_records
+    FROM material_type_data
+  ),
+  shelving_order_by_scope AS (
+    SELECT
+      (
+        SELECT item.effective_shelving_order
+        FROM items_all item
+        WHERE item.effective_shelving_order IS NOT NULL
+        ORDER BY item.effective_shelving_order, item.id
+        LIMIT 1
+      ) AS all_records,
+      (
+        SELECT item.effective_shelving_order
+        FROM items_not_suppressed item
+        WHERE item.effective_shelving_order IS NOT NULL
+        ORDER BY item.effective_shelving_order, item.id
+        LIMIT 1
+      ) AS not_suppressed_from_discovery_records
+  ),
+  instance_format_candidates AS (
+    SELECT COALESCE(jsonb_agg(jsonb_build_object('id', id, 'name', name) ORDER BY name), '[]'::jsonb)
+      AS instance_formats
+    FROM (
+      SELECT DISTINCT instance_format.id::text AS id, instance_format.jsonb ->> 'name' AS name
+      FROM target_instance ti
+        CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(ti.jsonb -> 'instanceFormatIds', '[]'::jsonb))
+          AS instance_format_ids(format_id)
+        JOIN ${myuniversity}_${mymodule}.instance_format instance_format
+          ON instance_format.id = instance_format_ids.format_id::uuid
+    ) instance_formats
+  ),
+  nature_of_content_candidates AS (
+    SELECT COALESCE(jsonb_agg(jsonb_build_object('id', id, 'name', name) ORDER BY name), '[]'::jsonb)
+      AS nature_of_content_terms
+    FROM (
+      SELECT DISTINCT nature_of_content_term.id::text AS id, nature_of_content_term.jsonb ->> 'name' AS name
+      FROM target_instance ti
+        CROSS JOIN LATERAL jsonb_array_elements_text(COALESCE(ti.jsonb -> 'natureOfContentTermIds', '[]'::jsonb))
+          AS nature_of_content_term_ids(term_id)
+        JOIN ${myuniversity}_${mymodule}.nature_of_content_term nature_of_content_term
+          ON nature_of_content_term.id = nature_of_content_term_ids.term_id::uuid
+    ) nature_of_content_terms
+  ),
+  mode_of_issuance_candidate AS (
+    SELECT CASE
+      WHEN mode_of_issuance.id IS NULL THEN NULL
+      ELSE jsonb_build_object('id', mode_of_issuance.id::text, 'name', mode_of_issuance.jsonb ->> 'name')
+    END AS mode_of_issuance
+    FROM target_instance ti
+      LEFT JOIN ${myuniversity}_${mymodule}.mode_of_issuance mode_of_issuance
+        ON mode_of_issuance.id = NULLIF(ti.jsonb ->> 'modeOfIssuanceId', '')::uuid
+  ),
+  instance_type_candidate AS (
+    SELECT CASE
+      WHEN instance_type.id IS NULL THEN NULL
+      ELSE jsonb_build_object('id', instance_type.id::text, 'name', instance_type.jsonb ->> 'name')
+    END AS instance_type
+    FROM target_instance ti
+      LEFT JOIN ${myuniversity}_${mymodule}.instance_type instance_type
+        ON instance_type.id = NULLIF(ti.jsonb ->> 'instanceTypeId', '')::uuid
+  )
+SELECT jsonb_build_object(
+  'instance', ti.jsonb,
+  'isBoundWith', EXISTS (
+    SELECT 1
+    FROM holdings_all hr
+      JOIN ${myuniversity}_${mymodule}.bound_with_part bwp ON bwp.holdingsrecordid = hr.id
+      JOIN ${myuniversity}_${mymodule}.item item ON item.id = bwp.itemid
+  ),
+  'recordCounts', jsonb_build_object(
+    'holdings', jsonb_build_object(
+      'total', holdings_counts.total,
+      'suppressedFromDiscovery', holdings_counts.suppressed_from_discovery,
+      'notSuppressedFromDiscovery', holdings_counts.not_suppressed_from_discovery
+    ),
+    'items', jsonb_build_object(
+      'total', items_counts.total,
+      'suppressedFromDiscovery', items_counts.suppressed_from_discovery,
+      'suppressedByHoldings', items_counts.suppressed_by_holdings,
+      'suppressedFromDiscoveryOrByHoldings', items_counts.suppressed_from_discovery_or_by_holdings,
+      'notSuppressedFromDiscovery', items_counts.not_suppressed_from_discovery
+    )
+  ),
+  'aggregates', jsonb_build_object(
+    'allRecords', jsonb_build_object(
+      'itemDerivedFields', jsonb_build_object(
+        'effectiveShelvingOrder', shelving_order_by_scope.all_records
+      ),
+      'electronicAccess', electronic_access_by_scope.all_records,
+      'referenceValues', jsonb_build_object(
+        'itemMaterialTypes', material_types_by_scope.all_records
+      )
+    ),
+    'notSuppressedFromDiscoveryRecords', jsonb_build_object(
+      'itemDerivedFields', jsonb_build_object(
+        'effectiveShelvingOrder', shelving_order_by_scope.not_suppressed_from_discovery_records
+      ),
+      'electronicAccess', electronic_access_by_scope.not_suppressed_from_discovery_records,
+      'referenceValues', jsonb_build_object(
+        'itemMaterialTypes', material_types_by_scope.not_suppressed_from_discovery_records
+      )
+    )
+  ),
+  'referenceValues', (
+    jsonb_build_object(
+      'instanceFormats', instance_format_candidates.instance_formats,
+      'natureOfContentTerms', nature_of_content_candidates.nature_of_content_terms,
+      'instanceType', instance_type_candidate.instance_type
+    ) ||
+    CASE
+      WHEN mode_of_issuance_candidate.mode_of_issuance IS NULL THEN '{}'::jsonb
+      ELSE jsonb_build_object('modeOfIssuance', mode_of_issuance_candidate.mode_of_issuance)
+    END
+  )
+)
+FROM target_instance ti
+  CROSS JOIN holdings_counts
+  CROSS JOIN items_counts
+  CROSS JOIN electronic_access_by_scope
+  CROSS JOIN material_types_by_scope
+  CROSS JOIN shelving_order_by_scope
+  CROSS JOIN instance_format_candidates
+  CROSS JOIN nature_of_content_candidates
+  CROSS JOIN mode_of_issuance_candidate
+  CROSS JOIN instance_type_candidate;
+$function$
+;

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -1362,6 +1362,11 @@
       "run": "after",
       "snippetPath": "instance/createSettingsTable.sql",
       "fromModuleVersion": "30.0.5"
+    },
+    {
+      "run": "after",
+      "snippetPath": "instance/createInstanceSummaryFunction.sql",
+      "fromModuleVersion": "30.0.6"
     }
   ]
 }

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/InstanceSummaryStorageTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/InstanceSummaryStorageTest.java
@@ -1,0 +1,399 @@
+package org.folio.rest.api;
+
+import static java.net.HttpURLConnection.HTTP_CREATED;
+import static java.net.HttpURLConnection.HTTP_NOT_FOUND;
+import static java.net.HttpURLConnection.HTTP_OK;
+import static java.util.UUID.randomUUID;
+import static org.folio.rest.support.ResponseHandler.json;
+import static org.folio.rest.support.ResponseHandler.text;
+import static org.folio.rest.support.http.InterfaceUrls.instanceFormatsUrl;
+import static org.folio.rest.support.http.InterfaceUrls.instancesStorageUrl;
+import static org.folio.rest.support.http.InterfaceUrls.natureOfContentTermsUrl;
+import static org.folio.services.CallNumberConstants.LC_CN_TYPE_ID;
+import static org.folio.utility.ModuleUtility.getClient;
+import static org.folio.utility.RestUtility.TENANT_ID;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.is;
+
+import com.github.tomakehurst.wiremock.client.WireMock;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
+import org.folio.rest.jaxrs.model.ElectronicAccessItem;
+import org.folio.rest.jaxrs.model.InstanceFormat;
+import org.folio.rest.jaxrs.model.IssuanceMode;
+import org.folio.rest.jaxrs.model.NatureOfContentTerm;
+import org.folio.rest.support.Response;
+import org.folio.rest.support.builders.BoundWithPartBuilder;
+import org.folio.rest.support.builders.HoldingRequestBuilder;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+public class InstanceSummaryStorageTest extends TestBaseWithInventoryUtil {
+
+  @Before
+  public void beforeEach() {
+    deleteAllById(boundWithClient);
+    clearData();
+
+    setupMaterialTypes();
+    setupLoanTypes();
+    setupLocations();
+
+    removeAllEvents();
+    WireMock.reset();
+    mockUserTenantsForNonConsortiumMember();
+  }
+
+  @After
+  public void afterEach() {
+    deleteAllById(boundWithClient);
+  }
+
+  @Test
+  public void shouldReturnInstanceSummary() {
+    UUID instanceId = randomUUID();
+    createInstanceRecord(instance(instanceId));
+
+    UUID holdingId = createHolding(instanceId, MAIN_LIBRARY_LOCATION_ID, null);
+    createItem(buildItem(holdingId, MAIN_LIBRARY_LOCATION_ID, null));
+
+    JsonObject summary = getSummary(instanceId);
+
+    assertThat(summary.getJsonObject("instance").getString("id"), is(instanceId.toString()));
+    assertThat(summary.getBoolean("isBoundWith"), is(false));
+
+    JsonObject recordCounts = summary.getJsonObject("recordCounts");
+    assertCounts(recordCounts.getJsonObject("holdings"), 1, 0, 1);
+    assertCounts(recordCounts.getJsonObject("items"), 1, 0, 0, 0, 1);
+
+    JsonObject referenceValues = summary.getJsonObject("referenceValues");
+    assertThat(referenceValues.getJsonObject("instanceType").getString("id"), is(UUID_INSTANCE_TYPE.toString()));
+    assertThat(referenceValues.getJsonObject("instanceType").containsKey("name"), is(true));
+  }
+
+  @Test
+  public void shouldReturnVisibilityAwareRecordCountsAndAggregates() {
+    UUID instanceId = randomUUID();
+    createInstanceRecord(instance(instanceId));
+    createMixedVisibilityInventoryHoldingAndItem(instanceId);
+
+    JsonObject summary = getSummary(instanceId);
+    JsonObject recordCounts = summary.getJsonObject("recordCounts");
+
+    assertCounts(recordCounts.getJsonObject("holdings"), 2, 1, 1);
+    assertCounts(recordCounts.getJsonObject("items"), 4, 1, 1, 2, 2);
+
+    JsonObject aggregates = summary.getJsonObject("aggregates");
+    assertThat(aggregates
+      .getJsonObject("allRecords")
+      .getJsonObject("itemDerivedFields")
+      .getString("effectiveShelvingOrder"), is("PN 12 A6 41999"));
+    assertThat(aggregates
+      .getJsonObject("notSuppressedFromDiscoveryRecords")
+      .getJsonObject("itemDerivedFields")
+      .getString("effectiveShelvingOrder"), is("PN 12 A6 41999"));
+
+    assertMaterialTypeAggregates(aggregates);
+  }
+
+  @Test
+  public void shouldSummarizeBoundWithItems() {
+    UUID instanceId = randomUUID();
+    UUID boundItemInstanceId = randomUUID();
+    createInstanceRecord(instance(instanceId));
+    createInstanceRecord(instance(boundItemInstanceId));
+
+    UUID holdingId = createHolding(instanceId, MAIN_LIBRARY_LOCATION_ID, null);
+    UUID boundItemHoldingId = createHolding(boundItemInstanceId, SECOND_FLOOR_LOCATION_ID, null);
+    UUID boundItemId = randomUUID();
+    createItem(buildItem(boundItemHoldingId, SECOND_FLOOR_LOCATION_ID, null)
+      .withId(boundItemId.toString())
+      .withMaterialTypeId(bookMaterialTypeID));
+    createBoundWithPart(new BoundWithPartBuilder(holdingId, boundItemId).create());
+
+    JsonObject summary = getSummary(instanceId);
+
+    assertThat(summary.getBoolean("isBoundWith"), is(true));
+    assertCounts(summary.getJsonObject("recordCounts").getJsonObject("items"), 1, 0, 0, 0, 1);
+    assertThat(names(materialTypes(summary, "allRecords")), contains("book"));
+  }
+
+  @Test
+  public void shouldAggregateElectronicAccessByVisibilityScope() {
+    UUID instanceId = randomUUID();
+    createInstanceRecord(withElectronicAccess(instance(instanceId),
+      "https://example.org/instance", "https://example.org/duplicate"));
+    createElectronicAccessInventory(instanceId);
+
+    JsonObject aggregates = getSummary(instanceId).getJsonObject("aggregates");
+
+    assertThat(uris(electronicAccess(aggregates, "allRecords")), containsInAnyOrder(
+      "https://example.org/instance", "https://example.org/duplicate",
+      "https://example.org/item-visible", "https://example.org/item-suppressed",
+      "https://example.org/item-suppressed-by-holding", "https://example.org/holding-visible",
+      "https://example.org/holding-suppressed"));
+    assertThat(uris(electronicAccess(aggregates, "notSuppressedFromDiscoveryRecords")),
+      containsInAnyOrder("https://example.org/instance", "https://example.org/duplicate",
+        "https://example.org/item-visible", "https://example.org/holding-visible"));
+  }
+
+  @Test
+  public void shouldReturnInstanceReferenceValues() {
+    String suffix = randomUUID().toString();
+    UUID audioFormatId = createInstanceFormat("Audio carrier " + suffix);
+    UUID textFormatId = createInstanceFormat("Text carrier " + suffix);
+    UUID modeOfIssuanceId = createModeOfIssuance("Monographic unit " + suffix);
+    UUID bibliographyTermId = createNatureOfContentTerm("Bibliography " + suffix);
+    UUID thesisTermId = createNatureOfContentTerm("Thesis " + suffix);
+    UUID instanceId = randomUUID();
+
+    createInstanceRecord(instance(instanceId)
+      .put("instanceFormatIds", JsonArray.of(textFormatId.toString(), audioFormatId.toString()))
+      .put("modeOfIssuanceId", modeOfIssuanceId.toString())
+      .put("natureOfContentTermIds", JsonArray.of(thesisTermId.toString(), bibliographyTermId.toString())));
+
+    JsonObject referenceValues = getSummary(instanceId).getJsonObject("referenceValues");
+
+    assertNamedValue(referenceValues.getJsonObject("modeOfIssuance"), modeOfIssuanceId,
+      "Monographic unit " + suffix);
+    assertThat(names(referenceValues.getJsonArray("instanceFormats")),
+      contains("Audio carrier " + suffix, "Text carrier " + suffix));
+    assertThat(names(referenceValues.getJsonArray("natureOfContentTerms")),
+      contains("Bibliography " + suffix, "Thesis " + suffix));
+  }
+
+  @Test
+  public void shouldReturnSummaryForInstanceWithoutHoldingsOrItems() {
+    UUID instanceId = randomUUID();
+    createInstanceRecord(instance(instanceId));
+
+    JsonObject summary = getSummary(instanceId);
+    JsonObject recordCounts = summary.getJsonObject("recordCounts");
+
+    assertThat(summary.getBoolean("isBoundWith"), is(false));
+    assertCounts(recordCounts.getJsonObject("holdings"), 0, 0, 0);
+    assertCounts(recordCounts.getJsonObject("items"), 0, 0, 0, 0, 0);
+    assertEmptyAggregateScope(summary, "allRecords");
+    assertEmptyAggregateScope(summary, "notSuppressedFromDiscoveryRecords");
+    assertThat(summary.getJsonObject("referenceValues").containsKey("modeOfIssuance"), is(false));
+  }
+
+  @Test
+  public void shouldReturnNotFoundWhenInstanceDoesNotExist() {
+    Response response = getSummaryText(randomUUID());
+
+    assertThat(response.getStatusCode(), is(HTTP_NOT_FOUND));
+  }
+
+  private static void assertCounts(JsonObject counts, int total, int suppressed, int notSuppressed) {
+    assertThat(counts.getInteger("total"), is(total));
+    assertThat(counts.getInteger("suppressedFromDiscovery"), is(suppressed));
+    assertThat(counts.getInteger("notSuppressedFromDiscovery"), is(notSuppressed));
+  }
+
+  private static void assertCounts(JsonObject counts, int total, int suppressedFromDiscovery,
+                                   int suppressedByHoldings, int suppressedFromDiscoveryOrByHoldings,
+                                   int notSuppressedFromDiscovery) {
+    assertThat(counts.getInteger("total"), is(total));
+    assertThat(counts.getInteger("suppressedFromDiscovery"), is(suppressedFromDiscovery));
+    assertThat(counts.getInteger("suppressedByHoldings"), is(suppressedByHoldings));
+    assertThat(counts.getInteger("suppressedFromDiscoveryOrByHoldings"),
+      is(suppressedFromDiscoveryOrByHoldings));
+    assertThat(counts.getInteger("notSuppressedFromDiscovery"), is(notSuppressedFromDiscovery));
+  }
+
+  private void createMixedVisibilityInventoryHoldingAndItem(UUID instanceId) {
+    UUID visibleHoldingId = createHolding(instanceId, MAIN_LIBRARY_LOCATION_ID, null);
+
+    createItem(buildItem(visibleHoldingId, MAIN_LIBRARY_LOCATION_ID, null)
+      .withId("00000000-0000-4000-8000-000000000001")
+      .withMaterialTypeId(journalMaterialTypeID)
+      .withItemLevelCallNumber("PN2 .A69")
+      .withItemLevelCallNumberTypeId(LC_CN_TYPE_ID)
+      .withVolume("v.1")
+      .withEnumeration("no. 1"));
+    createItem(buildItem(visibleHoldingId, MAIN_LIBRARY_LOCATION_ID, null)
+      .withId("ffffffff-ffff-4fff-bfff-ffffffffffff")
+      .withMaterialTypeId(journalMaterialTypeID)
+      .withItemLevelCallNumber("PN2 .A6 1999")
+      .withItemLevelCallNumberTypeId(LC_CN_TYPE_ID));
+    createItem(buildItem(visibleHoldingId, MAIN_LIBRARY_LOCATION_ID, null)
+      .withMaterialTypeId(bookMaterialTypeID)
+      .withDiscoverySuppress(true));
+
+    UUID suppressedHoldingId = createSuppressedHolding(instanceId);
+    createItem(buildItem(suppressedHoldingId, SECOND_FLOOR_LOCATION_ID, null)
+      .withMaterialTypeId(bookMaterialTypeID));
+  }
+
+  private void createElectronicAccessInventory(UUID instanceId) {
+    UUID visibleHoldingId = createHolding(instanceId, MAIN_LIBRARY_LOCATION_ID, null,
+      List.of("https://example.org/holding-visible", "https://example.org/duplicate"));
+    UUID suppressedHoldingId = createSuppressedHolding(instanceId,
+      List.of("https://example.org/holding-suppressed"));
+
+    createItem(buildItem(visibleHoldingId, MAIN_LIBRARY_LOCATION_ID, null)
+      .withElectronicAccess(electronicAccessItems("https://example.org/item-visible",
+        "https://example.org/duplicate")));
+    createItem(buildItem(visibleHoldingId, MAIN_LIBRARY_LOCATION_ID, null)
+      .withDiscoverySuppress(true)
+      .withElectronicAccess(electronicAccessItems("https://example.org/item-suppressed")));
+    createItem(buildItem(suppressedHoldingId, SECOND_FLOOR_LOCATION_ID, null)
+      .withElectronicAccess(electronicAccessItems("https://example.org/item-suppressed-by-holding")));
+  }
+
+  private static UUID createSuppressedHolding(UUID instanceId) {
+    return createSuppressedHolding(instanceId, null);
+  }
+
+  private static UUID createSuppressedHolding(UUID instanceId, List<String> electronicAccessUrls) {
+    return createHoldingRecord(new HoldingRequestBuilder()
+      .withId(randomUUID())
+      .forInstance(instanceId)
+      .withSource(getPreparedHoldingSourceId())
+      .withPermanentLocation(SECOND_FLOOR_LOCATION_ID)
+      .withDiscoverySuppress(true)
+      .withElectronicAccess(electronicAccess(electronicAccessUrls))
+      .create()).getId();
+  }
+
+  private static UUID createInstanceFormat(String name) {
+    UUID id = randomUUID();
+    InstanceFormat instanceFormat = new InstanceFormat()
+      .withId(id.toString())
+      .withName(name)
+      .withCode("code-" + id)
+      .withSource("test");
+
+    assertCreated(get(getClient().post(instanceFormatsUrl(""), pojo2JsonObject(instanceFormat), TENANT_ID)));
+    return id;
+  }
+
+  private static UUID createModeOfIssuance(String name) {
+    UUID id = randomUUID();
+    modesOfIssuanceClient.create(pojo2JsonObject(new IssuanceMode()
+      .withId(id.toString())
+      .withName(name)
+      .withSource("test")));
+
+    return id;
+  }
+
+  private static UUID createNatureOfContentTerm(String name) {
+    UUID id = randomUUID();
+    NatureOfContentTerm natureOfContentTerm = new NatureOfContentTerm()
+      .withId(id.toString())
+      .withName(name)
+      .withSource("test");
+
+    assertCreated(get(getClient().post(natureOfContentTermsUrl(""),
+      pojo2JsonObject(natureOfContentTerm), TENANT_ID)));
+    return id;
+  }
+
+  private static void assertCreated(Response response) {
+    assertThat(response.getStatusCode(), is(HTTP_CREATED));
+  }
+
+  private static List<String> names(JsonArray referenceValues) {
+    return referenceValues.stream()
+      .map(JsonObject.class::cast)
+      .map(value -> value.getString("name"))
+      .toList();
+  }
+
+  private static List<String> uris(JsonArray electronicAccess) {
+    return electronicAccess.stream()
+      .map(JsonObject.class::cast)
+      .map(value -> value.getString("uri"))
+      .toList();
+  }
+
+  private static JsonObject withElectronicAccess(JsonObject inventoryRecord, String... uris) {
+    return inventoryRecord.put("electronicAccess", electronicAccess(Arrays.asList(uris)));
+  }
+
+  private static JsonArray electronicAccess(List<String> uris) {
+    return uris == null ? null : uris.stream()
+      .map(uri -> new JsonObject().put("uri", uri))
+      .collect(JsonArray::new, JsonArray::add, JsonArray::addAll);
+  }
+
+  private static JsonArray electronicAccess(JsonObject aggregates, String scope) {
+    return aggregates.getJsonObject(scope).getJsonArray("electronicAccess");
+  }
+
+  private static List<ElectronicAccessItem> electronicAccessItems(String... uris) {
+    return Arrays.stream(uris)
+      .map(uri -> new ElectronicAccessItem().withUri(uri))
+      .toList();
+  }
+
+  private static JsonArray materialTypes(JsonObject summary, String scope) {
+    return summary.getJsonObject("aggregates")
+      .getJsonObject(scope)
+      .getJsonObject("referenceValues")
+      .getJsonArray("itemMaterialTypes");
+  }
+
+  private static void assertNamedValue(JsonObject value, UUID id, String name) {
+    assertThat(value.getString("id"), is(id.toString()));
+    assertThat(value.getString("name"), is(name));
+  }
+
+  private static void assertEmptyAggregateScope(JsonObject summary, String scope) {
+    JsonObject aggregateScope = summary.getJsonObject("aggregates").getJsonObject(scope);
+
+    assertThat(aggregateScope.getJsonArray("electronicAccess").isEmpty(), is(true));
+    assertThat(aggregateScope
+      .getJsonObject("referenceValues")
+      .getJsonArray("itemMaterialTypes")
+      .isEmpty(), is(true));
+    assertThat(aggregateScope
+      .getJsonObject("itemDerivedFields")
+      .getString("effectiveShelvingOrder"), is((String) null));
+  }
+
+  private static void assertMaterialTypeAggregates(JsonObject aggregates) {
+    JsonArray allMaterialTypes = aggregates
+      .getJsonObject("allRecords")
+      .getJsonObject("referenceValues")
+      .getJsonArray("itemMaterialTypes");
+    JsonArray visibleMaterialTypes = aggregates
+      .getJsonObject("notSuppressedFromDiscoveryRecords")
+      .getJsonObject("referenceValues")
+      .getJsonArray("itemMaterialTypes");
+
+    assertThat(names(allMaterialTypes), containsInAnyOrder("book", "journal"));
+    assertThat(names(visibleMaterialTypes), contains("journal"));
+  }
+
+  private static JsonObject getSummary(UUID instanceId) {
+    Response response = getSummaryJson(instanceId);
+    assertThat(response.getStatusCode(), is(HTTP_OK));
+    return response.getJson();
+  }
+
+  private static Response getSummaryJson(UUID instanceId) {
+    CompletableFuture<Response> getCompleted = new CompletableFuture<>();
+    getClient().get(summaryUrl(instanceId), TENANT_ID, json(getCompleted));
+    return get(getCompleted);
+  }
+
+  private static Response getSummaryText(UUID instanceId) {
+    CompletableFuture<Response> getCompleted = new CompletableFuture<>();
+    getClient().get(summaryUrl(instanceId), TENANT_ID, text(getCompleted));
+    return get(getCompleted);
+  }
+
+  private static java.net.URL summaryUrl(UUID instanceId) {
+    return instancesStorageUrl("/" + instanceId + "/summary");
+  }
+}

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/api/StorageTestSuite.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/api/StorageTestSuite.java
@@ -51,6 +51,7 @@ import org.junit.runners.Suite;
   InstanceDomainEventTest.class,
   InstanceRelationshipsTest.class,
   InstanceSetTest.class,
+  InstanceSummaryStorageTest.class,
   InstanceStorageInstancesBulkApiTest.class,
   InstanceStorageTest.class,
   InventoryHierarchyViewTest.class,

--- a/ramls/examples/instance-summary.json
+++ b/ramls/examples/instance-summary.json
@@ -1,0 +1,147 @@
+{
+  "instance": {
+    "id": "601a8dc4-dee7-48eb-b03f-d02fdf0debd0",
+    "_version": 1,
+    "hrid": "in00000000001",
+    "source": "MARC",
+    "title": "Long Way to a Small Angry Planet",
+    "contributors": [
+      {
+        "name": "Chambers, Becky",
+        "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a",
+        "primary": true
+      }
+    ],
+    "identifiers": [
+      {
+        "identifierTypeId": "8261054f-be78-422d-bd51-4ed9f33c3422",
+        "value": "9781473619777"
+      }
+    ],
+    "electronicAccess": [
+      {
+        "uri": "https://example.org/ebooks/long-way",
+        "linkText": "Available online"
+      }
+    ],
+    "instanceTypeId": "535e3160-763a-42f9-b0c0-d8ed7df6e2a2",
+    "instanceFormatIds": [
+      "8e4d5d19-97f3-4abc-a252-f2b4b23a6d49"
+    ],
+    "modeOfIssuanceId": "9bce7691-9c81-4b19-902a-1a4f89a26609",
+    "natureOfContentTermIds": [
+      "0d74a603-7a26-46f1-8ba8-ec6ffac3480c"
+    ],
+    "discoverySuppress": false,
+    "tags": {
+      "tagList": [
+        "science-fiction"
+      ]
+    }
+  },
+  "isBoundWith": true,
+  "recordCounts": {
+    "holdings": {
+      "total": 2,
+      "suppressedFromDiscovery": 1,
+      "notSuppressedFromDiscovery": 1
+    },
+    "items": {
+      "total": 4,
+      "suppressedFromDiscovery": 1,
+      "suppressedByHoldings": 1,
+      "suppressedFromDiscoveryOrByHoldings": 2,
+      "notSuppressedFromDiscovery": 2
+    }
+  },
+  "aggregates": {
+    "allRecords": {
+      "itemDerivedFields": {
+        "effectiveShelvingOrder": "PN 12 A6 41999"
+      },
+      "electronicAccess": [
+        {
+          "uri": "https://example.org/ebooks/long-way",
+          "linkText": "Available online"
+        },
+        {
+          "uri": "https://example.org/item-visible",
+          "linkText": "Visible item link"
+        },
+        {
+          "uri": "https://example.org/item-suppressed",
+          "linkText": "Suppressed item link"
+        },
+        {
+          "uri": "https://example.org/holding-visible",
+          "linkText": "Visible holdings link"
+        },
+        {
+          "uri": "https://example.org/holding-suppressed",
+          "linkText": "Suppressed holdings link"
+        }
+      ],
+      "referenceValues": {
+        "itemMaterialTypes": [
+          {
+            "id": "1d89f03a-e963-4a61-b02a-200377ab0919",
+            "name": "book"
+          },
+          {
+            "id": "615b8413-82d5-4203-aa6e-e37984cb5ac3",
+            "name": "journal"
+          }
+        ]
+      }
+    },
+    "notSuppressedFromDiscoveryRecords": {
+      "itemDerivedFields": {
+        "effectiveShelvingOrder": "PN 12 A6 41999"
+      },
+      "electronicAccess": [
+        {
+          "uri": "https://example.org/ebooks/long-way",
+          "linkText": "Available online"
+        },
+        {
+          "uri": "https://example.org/item-visible",
+          "linkText": "Visible item link"
+        },
+        {
+          "uri": "https://example.org/holding-visible",
+          "linkText": "Visible holdings link"
+        }
+      ],
+      "referenceValues": {
+        "itemMaterialTypes": [
+          {
+            "id": "1d89f03a-e963-4a61-b02a-200377ab0919",
+            "name": "book"
+          }
+        ]
+      }
+    }
+  },
+  "referenceValues": {
+    "instanceFormats": [
+      {
+        "id": "8e4d5d19-97f3-4abc-a252-f2b4b23a6d49",
+        "name": "computer"
+      }
+    ],
+    "modeOfIssuance": {
+      "id": "9bce7691-9c81-4b19-902a-1a4f89a26609",
+      "name": "monographic unit"
+    },
+    "natureOfContentTerms": [
+      {
+        "id": "0d74a603-7a26-46f1-8ba8-ec6ffac3480c",
+        "name": "bibliography"
+      }
+    ],
+    "instanceType": {
+      "id": "535e3160-763a-42f9-b0c0-d8ed7df6e2a2",
+      "name": "text"
+    }
+  }
+}

--- a/ramls/instance-storage.raml
+++ b/ramls/instance-storage.raml
@@ -1,6 +1,6 @@
 #%RAML 1.0
 title: Instance Storage
-version: v11.3
+version: v11.4
 protocols: [ HTTP, HTTPS ]
 baseUri: http://localhost
 
@@ -10,6 +10,7 @@ documentation:
 
 types:
   instance: !include schemas/instance-storage/instance.json
+  instanceSummary: !include schemas/instance-storage/instance-summary.json
   instances: !include schemas/instance-storage/instances.json
   marcJson: !include schemas/instance-storage/marc.json
   instanceRelationship: !include schemas/instance-storage/instancerelationship.json
@@ -133,6 +134,27 @@ resourceTypes:
             body:
               text/plain:
                 example: "internal server error, contact administrator"
+
+      /summary:
+        get:
+          description: |
+            Get a compact summary for an instance, including record counts and aggregate inventory facts.
+          responses:
+            200:
+              body:
+                application/json:
+                  type: instanceSummary
+                  example: !include examples/instance-summary.json
+            404:
+              description: "Instance with a given ID not found"
+              body:
+                text/plain:
+                  example: Not found
+            500:
+              description: "Internal server error, e.g. due to misconfiguration"
+              body:
+                text/plain:
+                  example: "internal server error, contact administrator"
 
       /source-record:
         delete:

--- a/ramls/schemas/instance-storage/instance-summary.json
+++ b/ramls/schemas/instance-storage/instance-summary.json
@@ -1,0 +1,219 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A compact summary of an instance and derived inventory facts",
+  "javaType": "org.folio.rest.jaxrs.model.InstanceSummary",
+  "type": "object",
+  "properties": {
+    "instance": {
+      "description": "Instance record being summarized",
+      "$ref": "instance.json"
+    },
+    "isBoundWith": {
+      "description": "Whether any holdings for the instance are part of a bound-with relationship",
+      "type": "boolean"
+    },
+    "recordCounts": {
+      "type": "object",
+      "description": "Counts that allow consumers to apply their own suppression policy",
+      "additionalProperties": false,
+      "properties": {
+        "holdings": {
+          "description": "Counts for holdings records associated with the instance",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "total": {
+              "description": "Total number of holdings records associated with the instance",
+              "type": "integer"
+            },
+            "suppressedFromDiscovery": {
+              "description": "Number of holdings records suppressed from discovery",
+              "type": "integer"
+            },
+            "notSuppressedFromDiscovery": {
+              "description": "Number of holdings records not suppressed from discovery",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "total",
+            "suppressedFromDiscovery",
+            "notSuppressedFromDiscovery"
+          ]
+        },
+        "items": {
+          "description": "Counts for item records associated with the instance",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "total": {
+              "description": "Total number of item records associated with the instance",
+              "type": "integer"
+            },
+            "suppressedFromDiscovery": {
+              "description": "Number of item records directly suppressed from discovery",
+              "type": "integer"
+            },
+            "suppressedByHoldings": {
+              "description": "Number of item records associated with holdings suppressed from discovery",
+              "type": "integer"
+            },
+            "suppressedFromDiscoveryOrByHoldings": {
+              "description": "Number of item records directly suppressed from discovery or associated with suppressed holdings",
+              "type": "integer"
+            },
+            "notSuppressedFromDiscovery": {
+              "description": "Number of item records not directly suppressed from discovery and not associated with suppressed holdings",
+              "type": "integer"
+            }
+          },
+          "required": [
+            "total",
+            "suppressedFromDiscovery",
+            "suppressedByHoldings",
+            "suppressedFromDiscoveryOrByHoldings",
+            "notSuppressedFromDiscovery"
+          ]
+        }
+      },
+      "required": [
+        "holdings",
+        "items"
+      ]
+    },
+    "aggregates": {
+      "type": "object",
+      "description": "Aggregate facts for all records and for records not suppressed from discovery",
+      "additionalProperties": false,
+      "properties": {
+        "allRecords": {
+          "description": "Aggregate facts calculated from all holdings and item records",
+          "$ref": "#/definitions/aggregateScope"
+        },
+        "notSuppressedFromDiscoveryRecords": {
+          "description": "Aggregate facts calculated from holdings and item records not suppressed from discovery",
+          "$ref": "#/definitions/aggregateScope"
+        }
+      },
+      "required": [
+        "allRecords",
+        "notSuppressedFromDiscoveryRecords"
+      ]
+    },
+    "referenceValues": {
+      "type": "object",
+      "description": "Instance-level reference values useful to consumers",
+      "additionalProperties": false,
+      "properties": {
+        "instanceFormats": {
+          "description": "Instance format reference values for the instance",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/namedValue"
+          }
+        },
+        "modeOfIssuance": {
+          "description": "Mode of issuance reference value for the instance",
+          "$ref": "#/definitions/namedValue"
+        },
+        "natureOfContentTerms": {
+          "description": "Nature of content term reference values for the instance",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/namedValue"
+          }
+        },
+        "instanceType": {
+          "description": "Instance type reference value for the instance",
+          "$ref": "#/definitions/namedValue"
+        }
+      },
+      "required": [
+        "instanceFormats",
+        "natureOfContentTerms",
+        "instanceType"
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "instance",
+    "isBoundWith",
+    "recordCounts",
+    "aggregates",
+    "referenceValues"
+  ],
+  "definitions": {
+    "aggregateScope": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "itemDerivedFields": {
+          "description": "Fields derived from item records without returning item rows",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "effectiveShelvingOrder": {
+              "description": "First item effective shelving order in this aggregate scope, if available",
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "effectiveShelvingOrder"
+          ]
+        },
+        "electronicAccess": {
+          "type": "array",
+          "description": "Deduplicated electronic access entries from the instance, holdings, and items",
+          "items": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "referenceValues": {
+          "description": "Reference values derived from records in this aggregate scope",
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "itemMaterialTypes": {
+              "description": "Material type reference values represented by items in this aggregate scope",
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/namedValue"
+              }
+            }
+          },
+          "required": [
+            "itemMaterialTypes"
+          ]
+        }
+      },
+      "required": [
+        "itemDerivedFields",
+        "electronicAccess",
+        "referenceValues"
+      ]
+    },
+    "namedValue": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "description": "Reference value identifier",
+          "type": "string"
+        },
+        "name": {
+          "description": "Reference value display name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Backport of [MODINVSTOR-1564](https://folio-org.atlassian.net/browse/MODINVSTOR-1564) (#1383) to the Trillium (R1 2026) release line, for release v30.0.6.

Tracked by [MODINVSTOR-1602](https://folio-org.atlassian.net/browse/MODINVSTOR-1602); the release itself is [MODINVSTOR-1601](https://folio-org.atlassian.net/browse/MODINVSTOR-1601). Targets `tmp-release-v30.0.6` rather than `release/v30.0`, following #1391.

## What carried over unchanged

Cherry-picked verbatim from `30f2f223`: `InstanceStorageApi`, `InstanceService`, `ramls/instance-storage.raml`, the `instance-summary` schema and example, `ModuleDescriptor-template.json`, and `InstanceSummaryStorageTest`. Provides `instance-storage 11.4`, identical to master (this branch was on 11.3, as master was pre-#1383).

## What had to be rewritten, and why

`release/v30.0` predates the Liquibase migration (#1369 is master-only and ships in 30.1.0), so the migration half of the original commit could not be cherry-picked:

| master (30.1.0) | here (30.0.6) |
| --- | --- |
| `changeSet` in `liquibase/tenant/scripts/v30.1.0/01-functions.xml` | `scripts[]` entry in `templates/db_scripts/schema.json` with `fromModuleVersion: 30.0.6` |
| `liquibase/.../sql/instance/create_instance_summary_function.sql` | `templates/db_scripts/instance/createInstanceSummaryFunction.sql` |
| unqualified SQL identifiers | all 16 table/function references qualified with `${myuniversity}_${mymodule}` |

The qualification is required: Liquibase supplies `defaultSchemaName`, RMB script snippets do not, and a `LANGUAGE sql` function body resolves its references at `CREATE` time. This matches every other snippet on this branch (`createToTimestampFunction.sql`, `createItemFormerIdsIndex.sql`, ...). `diff` against the original SQL shows only those 16 qualifications; the remaining 298 lines and all 17 CTE references are untouched.

## Verification

Run locally against `release/v30.0` + this commit:

- `InstanceSummaryStorageTest` — **7/7 pass**, both standalone and inside `StorageTestSuite`
- Full suite — **1331 tests**, 0 errors, 2 pre-existing skips
- `clean verify` — checkstyle **0 violations**, `folio-module-descriptor-validator` passes
- Logs confirm RMB expanded `${myuniversity}_${mymodule}` to the tenant schema and executed the new snippet during tenant init, so `get_instance_summary` is created where the endpoint's query resolves it

One unrelated pre-existing flake shows up on this branch: `InstanceStorageTest.shouldNotChangeStatusUpdatedDateWhenStatusHasNotChanged` asserts `withinSecondsBeforeNow(2)` against a Postgres-generated timestamp and intermittently fails when the container clock is a few ms ahead of the JVM. Reproduced on pristine `release/v30.0` (1324 tests, same single failure), so it is not introduced here. Master already fixed neighbouring assertions in this class via #1395, which has not been backported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
