### PR TITLE
MODINVSTOR-1600: Add instance custom link setting

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,7 @@
 
 ### Features
 * Create feature flag for enabling optimization to prevent redundant updates in Inventory (Instance,Holding,Item) ([MODINVSTOR-1577](https://folio-org.atlassian.net/browse/MODINVSTOR-1577))
+* Create instance custom link setting ([MODINVSTOR-1600](https://folio-org.atlassian.net/browse/MODINVSTOR-1600))
 
 ### Bug fixes
 * Populate item and holdings `hrId` in the items-and-holdings view ([MODINVSTOR-1587](https://folio-org.atlassian.net/browse/MODINVSTOR-1587))

--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -1456,6 +1456,37 @@
           "permissionsRequired": ["inventory-storage.settings.item.patch"]
         }
        ]
+    },
+    {
+      "id": "instance-custom-links",
+      "version": "1.0",
+      "handlers": [
+        {
+          "methods": ["GET"],
+          "pathPattern": "/instance-custom-links",
+          "perimssionsRequired": ["inventory-storage.instance-custom-links.collection.get"]
+        },
+        {
+          "methods": ["POST"],
+          "pathPattern": "/instance-custom-links",
+          "perimssionsRequired": ["inventory-storage.instance-custom-links.item.post"]
+        },
+        {
+          "methods": ["GET"],
+          "pathPattern": "/instance-custom-links/{id}",
+          "perimssionsRequired": ["inventory-storage.instance-custom-links.item.get"]
+        },
+        {
+          "methods": ["PUT"],
+          "pathPattern": "/instance-custom-links/{id}",
+          "perimssionsRequired": ["inventory-storage.instance-custom-links.item.put"]
+        },
+        {
+          "methods": ["DELETE"],
+          "pathPattern": "/instance-custom-links/{id}",
+          "perimssionsRequired": ["inventory-storage.instance-custom-links.item.delete"]
+        }
+      ]
     }
   ],
   "optional": [
@@ -2687,6 +2718,31 @@
       "description": "patch inventory setting"
     },
     {
+      "permissionName": "inventory-storage.instance-custom-links.collection.get",
+      "displayName": "inventory storage - get list of instance custom links",
+      "description": "get list of instance custom links"
+    },
+    {
+      "permissionName": "inventory-storage.instance-custom-links.item.get",
+      "displayName": "inventory storage - get instance custom link",
+      "description": "get instance custom link"
+    },
+    {
+      "permissionName": "inventory-storage.instance-custom-links.item.post",
+      "displayName": "inventory storage - create instance custom link",
+      "description": "create instance custom link"
+    },
+    {
+      "permissionName": "inventory-storage.instance-custom-links.item.put",
+      "displayName": "inventory storage - modify an instance custom link",
+      "description": "modify an instance custom link"
+    },
+    {
+      "permissionName": "inventory-storage.instance-custom-links.item.delete",
+      "displayName": "inventory storage - delete an instance custom link",
+      "description": "delete an instance custom link"
+    },
+    {
       "permissionName": "inventory-storage.all",
       "displayName": "inventory storage module - all permissions",
       "description": "Entire set of permissions needed to use the inventory storage module",
@@ -2935,7 +2991,12 @@
         "inventory-storage.instance-date-types.collection.get",
         "inventory-storage.instance-date-types.item.patch",
         "inventory-storage.settings.item.get",
-        "inventory-storage.settings.item.patch"
+        "inventory-storage.settings.item.patch",
+        "inventory-storage.instance-custom-links.collection.get",
+        "inventory-storage.instance-custom-links.item.get",
+        "inventory-storage.instance-custom-links.item.post",
+        "inventory-storage.instance-custom-links.item.put",
+        "inventory-storage.instance-custom-links.item.delete"
       ]
     }
   ],

--- a/mod-inventory-storage-server/src/main/java/org/folio/persist/InstanceCustomLinkRepository.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/persist/InstanceCustomLinkRepository.java
@@ -5,34 +5,104 @@ import static org.folio.services.instance.InstanceCustomLinkService.INSTANCE_CUS
 
 import io.vertx.core.Context;
 import io.vertx.core.Future;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.Tuple;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.folio.rest.exceptions.ValidationException;
 import org.folio.rest.jaxrs.model.Error;
 import org.folio.rest.jaxrs.model.Errors;
 import org.folio.rest.jaxrs.model.InstanceCustomLink;
+import org.folio.rest.jaxrs.model.Parameter;
 import org.folio.rest.persist.Conn;
 
 public class InstanceCustomLinkRepository extends AbstractRepository<InstanceCustomLink> {
   private static final int MAXIMUM_LINK_COUNT = 10;
+
+  private static final String ON_CREATE_QUERY = """
+    SELECT
+      COUNT(*) AS total_count,
+      COUNT(*) FILTER (WHERE lower(f_unaccent(jsonb ->> 'name')) = lower(f_unaccent($1))) AS name_count,
+      COUNT(*) FILTER (WHERE lower(f_unaccent(jsonb ->> 'linkText')) = lower(f_unaccent($2))) AS linktext_count,
+      COUNT(*) FILTER (WHERE lower(f_unaccent(jsonb ->> 'baseUrl')) = lower(f_unaccent($3))) AS baseurl_count
+    FROM
+      """ + INSTANCE_CUSTOM_LINK_TABLE;
+
+  private static final String ON_MODIFY_QUERY = """
+    SELECT
+      COUNT(*) FILTER (WHERE lower(f_unaccent(jsonb ->> 'name')) = lower(f_unaccent($1)) AND id != $4) AS name_count,
+      COUNT(*) FILTER (WHERE
+        lower(f_unaccent(jsonb ->> 'linkText')) = lower(f_unaccent($2))
+        AND id != $4
+      ) AS linktext_count,
+      COUNT(*) FILTER (WHERE
+        lower(f_unaccent(jsonb ->> 'baseUrl')) = lower(f_unaccent($3))
+        AND id != $4
+      ) AS baseurl_count
+    FROM
+      """ + INSTANCE_CUSTOM_LINK_TABLE;
 
   public InstanceCustomLinkRepository(Context context, Map<String, String> okapiHeaders) {
     super(postgresClient(context, okapiHeaders), INSTANCE_CUSTOM_LINK_TABLE, InstanceCustomLink.class);
   }
 
   public Future<String> create(Conn conn, InstanceCustomLink entity) {
+    return validateAndSave(conn, null, entity, true);
+  }
+
+  public Future<String> modify(Conn conn, String id, InstanceCustomLink entity) {
+    return validateAndSave(conn, id, entity, false);
+  }
+
+  private Future<String> validateAndSave(Conn conn, String id, InstanceCustomLink entity, boolean create) {
+    var queryTuple = Tuple.of(entity.getName(), entity.getLinkText(), entity.getBaseUrl());
+    if (!create) {
+      queryTuple.addString(id);
+    }
     return conn
       .execute(String.format("LOCK TABLE %s IN EXCLUSIVE MODE", INSTANCE_CUSTOM_LINK_TABLE))
-      .compose(x -> conn.execute(String.format("SELECT COUNT(*) AS linkcount FROM %s", INSTANCE_CUSTOM_LINK_TABLE)))
+      .compose(x -> conn.execute(create ? ON_CREATE_QUERY : ON_MODIFY_QUERY, queryTuple))
       .compose(rowSet -> {
-        int linkCount = rowSet.iterator().next().getInteger("linkcount");
-        if (linkCount >= MAXIMUM_LINK_COUNT) {
-          var ve = new ValidationException(new Errors().withErrors(List.of(
-            new Error().withCode("maximumCount")
-              .withMessage(String.format("Maximum limit of %d instance custom links reached", MAXIMUM_LINK_COUNT)))));
-          return Future.failedFuture(ve);
+        var row = rowSet.iterator().next();
+        var errors = checkUniqueness(row, entity);
+        if (create && row.getInteger("total_count") >= MAXIMUM_LINK_COUNT) {
+          errors.add(new Error().withCode("maximumCount")
+            .withMessage(String.format("Maximum limit of %d instance custom links reached", MAXIMUM_LINK_COUNT)));
         }
-        return conn.save(INSTANCE_CUSTOM_LINK_TABLE, entity);
+        if (!errors.isEmpty()) {
+          return Future.failedFuture(new ValidationException(new Errors().withErrors(errors)));
+        }
+        if (create) {
+          return conn.save(INSTANCE_CUSTOM_LINK_TABLE, entity);
+        } else {
+          return conn.update(INSTANCE_CUSTOM_LINK_TABLE, entity, id).map(y -> id);
+        }
       });
+  }
+
+  private ArrayList<Error> checkUniqueness(Row row, InstanceCustomLink entity) {
+    var errors = new ArrayList<Error>();
+    if (row.getInteger("name_count") > 0) {
+      errors.add(uniqueError("name", entity.getName()));
+    }
+    if (row.getInteger("linktext_count") > 0) {
+      errors.add(uniqueError("linkText", entity.getLinkText()));
+    }
+    if (row.getInteger("baseurl_count") > 0) {
+      errors.add(uniqueError("baseUrl", entity.getBaseUrl()));
+    }
+    return errors;
+  }
+
+  private Error uniqueError(String field, String value) {
+    return new Error()
+      .withCode("unique")
+      .withMessage(String.format("%s must be unique, but %s already exists", field, value))
+      .withParameters(List.of(
+        new Parameter()
+          .withKey(field)
+          .withValue(value)
+      ));
   }
 }

--- a/mod-inventory-storage-server/src/main/java/org/folio/persist/InstanceCustomLinkRepository.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/persist/InstanceCustomLinkRepository.java
@@ -25,7 +25,7 @@ public class InstanceCustomLinkRepository extends AbstractRepository<InstanceCus
       COUNT(*) AS total_count,
       COUNT(*) FILTER (WHERE lower(f_unaccent(jsonb ->> 'name')) = lower(f_unaccent($1))) AS name_count,
       COUNT(*) FILTER (WHERE lower(f_unaccent(jsonb ->> 'linkText')) = lower(f_unaccent($2))) AS linktext_count,
-      COUNT(*) FILTER (WHERE lower(f_unaccent(jsonb ->> 'baseUrl')) = lower(f_unaccent($3))) AS baseurl_count
+      COUNT(*) FILTER (WHERE lower(f_unaccent(jsonb ->> 'link')) = lower(f_unaccent($3))) AS link_count
     FROM
       """ + INSTANCE_CUSTOM_LINK_TABLE;
 
@@ -37,9 +37,9 @@ public class InstanceCustomLinkRepository extends AbstractRepository<InstanceCus
         AND id != $4
       ) AS linktext_count,
       COUNT(*) FILTER (WHERE
-        lower(f_unaccent(jsonb ->> 'baseUrl')) = lower(f_unaccent($3))
+        lower(f_unaccent(jsonb ->> 'link')) = lower(f_unaccent($3))
         AND id != $4
-      ) AS baseurl_count
+      ) AS link_count
     FROM
       """ + INSTANCE_CUSTOM_LINK_TABLE;
 
@@ -56,7 +56,7 @@ public class InstanceCustomLinkRepository extends AbstractRepository<InstanceCus
   }
 
   private Future<String> validateAndSave(Conn conn, String id, InstanceCustomLink entity, boolean create) {
-    var queryTuple = Tuple.of(entity.getName(), entity.getLinkText(), entity.getBaseUrl());
+    var queryTuple = Tuple.of(entity.getName(), entity.getLinkText(), entity.getLink());
     if (!create) {
       queryTuple.addString(id);
     }
@@ -89,8 +89,8 @@ public class InstanceCustomLinkRepository extends AbstractRepository<InstanceCus
     if (row.getInteger("linktext_count") > 0) {
       errors.add(uniqueError("linkText", entity.getLinkText()));
     }
-    if (row.getInteger("baseurl_count") > 0) {
-      errors.add(uniqueError("baseUrl", entity.getBaseUrl()));
+    if (row.getInteger("link_count") > 0) {
+      errors.add(uniqueError("link", entity.getLink()));
     }
     return errors;
   }

--- a/mod-inventory-storage-server/src/main/java/org/folio/persist/InstanceCustomLinkRepository.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/persist/InstanceCustomLinkRepository.java
@@ -1,0 +1,38 @@
+package org.folio.persist;
+
+import static org.folio.rest.persist.PgUtil.postgresClient;
+import static org.folio.services.instance.InstanceCustomLinkService.INSTANCE_CUSTOM_LINK_TABLE;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import java.util.List;
+import java.util.Map;
+import org.folio.rest.exceptions.ValidationException;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.jaxrs.model.InstanceCustomLink;
+import org.folio.rest.persist.Conn;
+
+public class InstanceCustomLinkRepository extends AbstractRepository<InstanceCustomLink> {
+  private static final int MAXIMUM_LINK_COUNT = 10;
+
+  public InstanceCustomLinkRepository(Context context, Map<String, String> okapiHeaders) {
+    super(postgresClient(context, okapiHeaders), INSTANCE_CUSTOM_LINK_TABLE, InstanceCustomLink.class);
+  }
+
+  public Future<String> create(Conn conn, InstanceCustomLink entity) {
+    return conn
+      .execute(String.format("LOCK TABLE %s IN EXCLUSIVE MODE", INSTANCE_CUSTOM_LINK_TABLE))
+      .compose(x -> conn.execute(String.format("SELECT COUNT(*) AS linkcount FROM %s", INSTANCE_CUSTOM_LINK_TABLE)))
+      .compose(rowSet -> {
+        int linkCount = rowSet.iterator().next().getInteger("linkcount");
+        if (linkCount >= MAXIMUM_LINK_COUNT) {
+          var ve = new ValidationException(new Errors().withErrors(List.of(
+            new Error().withCode("maximumCount")
+              .withMessage(String.format("Maximum limit of %d instance custom links reached", MAXIMUM_LINK_COUNT)))));
+          return Future.failedFuture(ve);
+        }
+        return conn.save(INSTANCE_CUSTOM_LINK_TABLE, entity);
+      });
+  }
+}

--- a/mod-inventory-storage-server/src/main/java/org/folio/rest/impl/InstanceCustomLinkApi.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/rest/impl/InstanceCustomLinkApi.java
@@ -4,9 +4,6 @@ import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
 import io.vertx.core.Future;
 import io.vertx.core.Handler;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.Pattern;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -34,9 +31,8 @@ public class InstanceCustomLinkApi extends BaseApi<InstanceCustomLink, InstanceC
 
   @Validate
   @Override
-  public void getInstanceCustomLinks(String query, @Pattern(regexp = "exact|estimated|none|auto") String totalRecords,
-      @Min(0) @Max(2147483647) int offset, @Min(0) @Max(2147483647) int limit, Map<String, String> okapiHeaders,
-      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+  public void getInstanceCustomLinks(String query, String totalRecords, int offset, int limit, Map<String,
+      String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     getEntities(query, totalRecords, offset, limit, okapiHeaders, asyncResultHandler, vertxContext,
       GetInstanceCustomLinksResponse.class);
   }

--- a/mod-inventory-storage-server/src/main/java/org/folio/rest/impl/InstanceCustomLinkApi.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/rest/impl/InstanceCustomLinkApi.java
@@ -28,7 +28,7 @@ public class InstanceCustomLinkApi extends BaseApi<InstanceCustomLink, InstanceC
 
   public static final String INSTANCE_CUSTOM_LINK_TYPE_TABLE = "instance_custom_link";
 
-  private static final String FIELD_BASE_URL = "baseUrl";
+  private static final String FIELD_LINK = "link";
   private static final List<String> QUERY_TOKENS = List.of("{{UUID}}", "{{HRID}}", "{{indexTitle}}");
 
   @Validate
@@ -131,40 +131,34 @@ public class InstanceCustomLinkApi extends BaseApi<InstanceCustomLink, InstanceC
   private List<Error> validate(InstanceCustomLink entity) {
     List<Error> errors = new ArrayList<>();
 
-    errors.addAll(validateQueryString(entity));
-    errors.addAll(validateBaseUrl(entity));
+    errors.addAll(validateLink(entity));
 
     return errors;
   }
 
-  private List<Error> validateQueryString(InstanceCustomLink entity) {
+  private List<Error> validateLink(InstanceCustomLink entity) {
     List<Error> errors = new ArrayList<>();
 
-    if (entity.getQueryString() != null) {
-      var queryString = entity.getQueryString();
-      if (QUERY_TOKENS.stream().noneMatch(queryString::contains)) {
-        errors.add(fieldError("missingToken", "queryString",
-          "must contain at least one of: " + QUERY_TOKENS, queryString));
+    if (entity.getLink() != null) {
+      var link = entity.getLink();
+
+      // Check if any matches to tokens and any unrecognized tokens
+      if (QUERY_TOKENS.stream().noneMatch(link::contains) && link.contains("{{") && link.contains("}}")) {
+        errors.add(fieldError("missingToken", FIELD_LINK,
+          "when tokens present, must be one of: " + QUERY_TOKENS, link));
       }
-    }
 
-    return errors;
-  }
-
-  private List<Error> validateBaseUrl(InstanceCustomLink entity) {
-    List<Error> errors = new ArrayList<>();
-
-    if (entity.getBaseUrl() != null) {
-      var baseUrl = entity.getBaseUrl();
+      // To check for URL validity, substitute known tokens with a valid URI character
+      var substituted = QUERY_TOKENS.stream().reduce(link, (intermediate, token) -> intermediate.replace(token, "a"));
       try {
-        var baseUri = new URI(baseUrl);
-        baseUri.toURL();
-        var baseScheme = baseUri.getScheme();
-        if (!"http".equalsIgnoreCase(baseScheme) && !"https".equalsIgnoreCase(baseScheme)) {
-          errors.add(fieldError("invalidScheme", FIELD_BASE_URL, "does not start with http or https", baseUrl));
+        var linkUri = new URI(substituted);
+        linkUri.toURL();
+        var linkScheme = linkUri.getScheme();
+        if (!"http".equalsIgnoreCase(linkScheme) && !"https".equalsIgnoreCase(linkScheme)) {
+          errors.add(fieldError("invalidScheme", FIELD_LINK, "does not start with http or https", link));
         }
       } catch (URISyntaxException | MalformedURLException | IllegalArgumentException e) {
-        errors.add(fieldError("invalidUrl", FIELD_BASE_URL, "not a valid URL", baseUrl));
+        errors.add(fieldError("invalidUrl", FIELD_LINK, "not a valid URL", link));
       }
     }
 

--- a/mod-inventory-storage-server/src/main/java/org/folio/rest/impl/InstanceCustomLinkApi.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/rest/impl/InstanceCustomLinkApi.java
@@ -1,0 +1,172 @@
+package org.folio.rest.impl;
+
+import io.vertx.core.AsyncResult;
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import io.vertx.core.Handler;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.ws.rs.core.Response;
+import org.folio.rest.annotations.Validate;
+import org.folio.rest.exceptions.ValidationException;
+import org.folio.rest.jaxrs.model.Error;
+import org.folio.rest.jaxrs.model.Errors;
+import org.folio.rest.jaxrs.model.InstanceCustomLink;
+import org.folio.rest.jaxrs.model.InstanceCustomLinks;
+import org.folio.rest.jaxrs.model.Parameter;
+import org.folio.rest.persist.PgUtil;
+import org.folio.services.instance.InstanceCustomLinkService;
+
+public class InstanceCustomLinkApi extends BaseApi<InstanceCustomLink, InstanceCustomLinks>
+  implements org.folio.rest.jaxrs.resource.InstanceCustomLinks {
+
+  public static final String INSTANCE_CUSTOM_LINK_TYPE_TABLE = "instance_custom_link";
+
+  private static final String FIELD_BASE_URL = "baseUrl";
+  private static final List<String> QUERY_TOKENS = List.of("{{UUID}}", "{{HRID}}", "{{indexTitle}}");
+
+  @Validate
+  @Override
+  public void getInstanceCustomLinks(String query, @Pattern(regexp = "exact|estimated|none|auto") String totalRecords,
+      @Min(0) @Max(2147483647) int offset, @Min(0) @Max(2147483647) int limit, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    getEntities(query, totalRecords, offset, limit, okapiHeaders, asyncResultHandler, vertxContext,
+      GetInstanceCustomLinksResponse.class);
+  }
+
+  @Validate
+  @Override
+  public void postInstanceCustomLinks(InstanceCustomLink entity, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    var errors = validate(entity);
+    if (!errors.isEmpty()) {
+      asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+        PostInstanceCustomLinksResponse.respond422WithApplicationJson(new Errors().withErrors(errors))));
+      return;
+    }
+
+    new InstanceCustomLinkService(vertxContext, okapiHeaders).create(entity)
+      .onSuccess(id -> asyncResultHandler.handle(Future.succeededFuture(PostInstanceCustomLinksResponse
+        .respond201WithApplicationJson(entity.withId(id), PostInstanceCustomLinksResponse.headersFor201()))))
+      .onFailure(cause -> {
+        if (cause instanceof ValidationException ve) {
+          asyncResultHandler.handle(Future.succeededFuture(PostInstanceCustomLinksResponse
+            .respond422WithApplicationJson(ve.getErrors())));
+        } else {
+          try {
+            var respond500 = PostInstanceCustomLinksResponse.class.getMethod("respond500WithTextPlain", Object.class);
+            PgUtil.response(INSTANCE_CUSTOM_LINK_TYPE_TABLE, entity.getId(), cause,
+              PostInstanceCustomLinksResponse.class, respond500, respond500).onComplete(asyncResultHandler);
+          } catch (NoSuchMethodException ex) {
+            Future.failedFuture(ex);
+          }
+        }
+      });
+  }
+
+  @Validate
+  @Override
+  public void getInstanceCustomLinksById(String id, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    getEntityById(id, okapiHeaders, asyncResultHandler, vertxContext, GetInstanceCustomLinksByIdResponse.class);
+  }
+
+  @Validate
+  @Override
+  public void deleteInstanceCustomLinksById(String id, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    deleteEntityById(id, okapiHeaders, asyncResultHandler, vertxContext, DeleteInstanceCustomLinksByIdResponse.class);
+  }
+
+  @Validate
+  @Override
+  public void putInstanceCustomLinksById(String id, InstanceCustomLink entity, Map<String, String> okapiHeaders,
+      Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
+    var errors = validate(entity);
+
+    if (!errors.isEmpty()) {
+      asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+        PutInstanceCustomLinksByIdResponse.respond422WithApplicationJson(
+          new Errors().withErrors(errors)
+        )));
+      return;
+    }
+
+    PgUtil.put(INSTANCE_CUSTOM_LINK_TYPE_TABLE, entity, id, okapiHeaders, vertxContext,
+      PutInstanceCustomLinksByIdResponse.class, asyncResultHandler);
+  }
+
+  @Override
+  protected String getReferenceTable() {
+    return INSTANCE_CUSTOM_LINK_TYPE_TABLE;
+  }
+
+  @Override
+  protected Class<InstanceCustomLink> getEntityClass() {
+    return InstanceCustomLink.class;
+  }
+
+  @Override
+  protected Class<InstanceCustomLinks> getEntityCollectionClass() {
+    return InstanceCustomLinks.class;
+  }
+
+  private List<Error> validate(InstanceCustomLink entity) {
+    List<Error> errors = new ArrayList<>();
+
+    errors.addAll(validateQueryString(entity));
+    errors.addAll(validateBaseUrl(entity));
+
+    return errors;
+  }
+
+  private List<Error> validateQueryString(InstanceCustomLink entity) {
+    List<Error> errors = new ArrayList<>();
+
+    if (entity.getQueryString() != null) {
+      var queryString = entity.getQueryString();
+      if (QUERY_TOKENS.stream().noneMatch(queryString::contains)) {
+        errors.add(fieldError("missingToken", "queryString",
+          "must contain at least one of: " + QUERY_TOKENS, queryString));
+      }
+    }
+
+    return errors;
+  }
+
+  private List<Error> validateBaseUrl(InstanceCustomLink entity) {
+    List<Error> errors = new ArrayList<>();
+
+    if (entity.getBaseUrl() != null) {
+      var baseUrl = entity.getBaseUrl();
+      try {
+        var baseUri = new URI(baseUrl);
+        baseUri.toURL();
+        var baseScheme = baseUri.getScheme();
+        if (!"http".equalsIgnoreCase(baseScheme) && !"https".equalsIgnoreCase(baseScheme)) {
+          errors.add(fieldError("invalidScheme", FIELD_BASE_URL, "does not start with http or https", baseUrl));
+        }
+      } catch (URISyntaxException | MalformedURLException | IllegalArgumentException e) {
+        errors.add(fieldError("invalidUrl", FIELD_BASE_URL, "not a valid URL", baseUrl));
+      }
+    }
+
+    return errors;
+  }
+
+  private Error fieldError(String code, String field, String message, String value) {
+    return new Error()
+      .withCode(code)
+      .withMessage(message)
+      .withParameters(List.of(
+        new Parameter().withKey(field).withValue(value)
+      ));
+  }
+}

--- a/mod-inventory-storage-server/src/main/java/org/folio/rest/impl/InstanceCustomLinkApi.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/rest/impl/InstanceCustomLinkApi.java
@@ -1,8 +1,10 @@
 package org.folio.rest.impl;
 
+import static io.vertx.core.Future.failedFuture;
+import static io.vertx.core.Future.succeededFuture;
+
 import io.vertx.core.AsyncResult;
 import io.vertx.core.Context;
-import io.vertx.core.Future;
 import io.vertx.core.Handler;
 import java.net.MalformedURLException;
 import java.net.URI;
@@ -43,17 +45,17 @@ public class InstanceCustomLinkApi extends BaseApi<InstanceCustomLink, InstanceC
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     var errors = validate(entity);
     if (!errors.isEmpty()) {
-      asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
+      asyncResultHandler.handle(succeededFuture(
         PostInstanceCustomLinksResponse.respond422WithApplicationJson(new Errors().withErrors(errors))));
       return;
     }
 
     new InstanceCustomLinkService(vertxContext, okapiHeaders).create(entity)
-      .onSuccess(id -> asyncResultHandler.handle(Future.succeededFuture(PostInstanceCustomLinksResponse
+      .onSuccess(id -> asyncResultHandler.handle(succeededFuture(PostInstanceCustomLinksResponse
         .respond201WithApplicationJson(entity.withId(id), PostInstanceCustomLinksResponse.headersFor201()))))
       .onFailure(cause -> {
         if (cause instanceof ValidationException ve) {
-          asyncResultHandler.handle(Future.succeededFuture(PostInstanceCustomLinksResponse
+          asyncResultHandler.handle(succeededFuture(PostInstanceCustomLinksResponse
             .respond422WithApplicationJson(ve.getErrors())));
         } else {
           try {
@@ -61,7 +63,7 @@ public class InstanceCustomLinkApi extends BaseApi<InstanceCustomLink, InstanceC
             PgUtil.response(INSTANCE_CUSTOM_LINK_TYPE_TABLE, entity.getId(), cause,
               PostInstanceCustomLinksResponse.class, respond500, respond500).onComplete(asyncResultHandler);
           } catch (NoSuchMethodException ex) {
-            Future.failedFuture(ex);
+            failedFuture(ex);
           }
         }
       });
@@ -86,17 +88,29 @@ public class InstanceCustomLinkApi extends BaseApi<InstanceCustomLink, InstanceC
   public void putInstanceCustomLinksById(String id, InstanceCustomLink entity, Map<String, String> okapiHeaders,
       Handler<AsyncResult<Response>> asyncResultHandler, Context vertxContext) {
     var errors = validate(entity);
-
     if (!errors.isEmpty()) {
-      asyncResultHandler.handle(io.vertx.core.Future.succeededFuture(
-        PutInstanceCustomLinksByIdResponse.respond422WithApplicationJson(
-          new Errors().withErrors(errors)
-        )));
+      asyncResultHandler.handle(succeededFuture(
+        PutInstanceCustomLinksByIdResponse.respond422WithApplicationJson(new Errors().withErrors(errors))));
       return;
     }
 
-    PgUtil.put(INSTANCE_CUSTOM_LINK_TYPE_TABLE, entity, id, okapiHeaders, vertxContext,
-      PutInstanceCustomLinksByIdResponse.class, asyncResultHandler);
+    new InstanceCustomLinkService(vertxContext, okapiHeaders).modify(id, entity)
+      .onSuccess(x -> asyncResultHandler.handle(succeededFuture(PutInstanceCustomLinksByIdResponse.respond204())))
+      .onFailure(cause -> {
+        if (cause instanceof ValidationException ve) {
+          asyncResultHandler.handle(succeededFuture(PutInstanceCustomLinksByIdResponse
+            .respond422WithApplicationJson(ve.getErrors())));
+        } else {
+          try {
+            var respond500 = PutInstanceCustomLinksByIdResponse.class.getMethod("respond500WithTextPlain",
+              Object.class);
+            PgUtil.response(INSTANCE_CUSTOM_LINK_TYPE_TABLE, entity.getId(), cause,
+              PutInstanceCustomLinksByIdResponse.class, respond500, respond500).onComplete(asyncResultHandler);
+          } catch (NoSuchMethodException ex) {
+            failedFuture(ex);
+          }
+        }
+      });
   }
 
   @Override

--- a/mod-inventory-storage-server/src/main/java/org/folio/services/instance/InstanceCustomLinkService.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/services/instance/InstanceCustomLinkService.java
@@ -22,4 +22,8 @@ public class InstanceCustomLinkService {
   public Future<String> create(InstanceCustomLink entity) {
     return postgresClient.withTrans(conn -> repository.create(conn, entity));
   }
+
+  public Future<String> modify(String id, InstanceCustomLink entity) {
+    return postgresClient.withTrans(conn -> repository.modify(conn, id, entity));
+  }
 }

--- a/mod-inventory-storage-server/src/main/java/org/folio/services/instance/InstanceCustomLinkService.java
+++ b/mod-inventory-storage-server/src/main/java/org/folio/services/instance/InstanceCustomLinkService.java
@@ -1,0 +1,25 @@
+package org.folio.services.instance;
+
+import io.vertx.core.Context;
+import io.vertx.core.Future;
+import java.util.Map;
+import org.folio.persist.InstanceCustomLinkRepository;
+import org.folio.rest.jaxrs.model.InstanceCustomLink;
+import org.folio.rest.persist.PgUtil;
+import org.folio.rest.persist.PostgresClient;
+
+public class InstanceCustomLinkService {
+  public static final String INSTANCE_CUSTOM_LINK_TABLE = "instance_custom_link";
+
+  private final InstanceCustomLinkRepository repository;
+  private final PostgresClient postgresClient;
+
+  public InstanceCustomLinkService(Context context, Map<String, String> okapiHeaders) {
+    this.repository = new InstanceCustomLinkRepository(context, okapiHeaders);
+    this.postgresClient = PgUtil.postgresClient(context, okapiHeaders);
+  }
+
+  public Future<String> create(InstanceCustomLink entity) {
+    return postgresClient.withTrans(conn -> repository.create(conn, entity));
+  }
+}

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -229,6 +229,25 @@
       ]
     },
     {
+      "tableName": "instance_custom_link",
+      "withMetadata": true,
+      "withAuditing": false,
+      "uniqueIndex": [
+        {
+          "fieldName": "name",
+          "tOps": "ADD"
+        },
+        {
+          "fieldName": "linkText",
+          "tOps": "ADD"
+        },
+        {
+          "fieldName": "baseUrl",
+          "tOps": "ADD"
+        }
+      ]
+    },
+    {
       "tableName": "nature_of_content_term",
       "withMetadata": true,
       "withAuditing": false,

--- a/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
+++ b/mod-inventory-storage-server/src/main/resources/templates/db_scripts/schema.json
@@ -242,7 +242,7 @@
           "tOps": "ADD"
         },
         {
-          "fieldName": "baseUrl",
+          "fieldName": "link",
           "tOps": "ADD"
         }
       ]

--- a/mod-inventory-storage-server/src/test/java/org/folio/persist/InstanceCustomLinkRepositoryTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/persist/InstanceCustomLinkRepositoryTest.java
@@ -1,0 +1,86 @@
+package org.folio.persist;
+
+import static org.folio.services.instance.InstanceCustomLinkService.INSTANCE_CUSTOM_LINK_TABLE;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.sqlclient.Row;
+import io.vertx.sqlclient.RowIterator;
+import io.vertx.sqlclient.RowSet;
+import java.util.List;
+import java.util.Map;
+import org.folio.rest.exceptions.ValidationException;
+import org.folio.rest.jaxrs.model.InstanceCustomLink;
+import org.folio.rest.persist.Conn;
+import org.junit.jupiter.api.Test;
+
+class InstanceCustomLinkRepositoryTest {
+  @Test
+  void createEntityWhenRowCountBelowLimit() {
+    var row = mock(Row.class);
+    when(row.getInteger("linkcount")).thenReturn(9);
+
+    var rowIter = mock(RowIterator.class);
+    var listIter = List.of(row).iterator();
+    when(rowIter.hasNext()).thenAnswer(invocation -> listIter.hasNext());
+    when(rowIter.next()).thenAnswer(invocation -> listIter.next());
+    var rowSet = mock(RowSet.class);
+    when(rowSet.iterator()).thenReturn(rowIter);
+
+    var conn = mock(Conn.class);
+    when(conn.execute(String.format("LOCK TABLE %s IN EXCLUSIVE MODE", INSTANCE_CUSTOM_LINK_TABLE)))
+      .thenReturn(Future.succeededFuture(mock(RowSet.class)));
+    when(conn.execute(String.format("SELECT COUNT(*) AS linkcount FROM %s", INSTANCE_CUSTOM_LINK_TABLE)))
+      .thenReturn(Future.succeededFuture(rowSet));
+    when(conn.save(eq(INSTANCE_CUSTOM_LINK_TABLE), any()))
+      .thenReturn(Future.succeededFuture("aaaa-bbbb"));
+
+    var context = Vertx.vertx().getOrCreateContext();
+    var headers = Map.of("X-Okapi-Tenant", "diku");
+    var repository = new InstanceCustomLinkRepository(context, headers);
+    var entity = mock(InstanceCustomLink.class);
+    Future<String> result = repository.create(conn, entity);
+
+    assertTrue(result.succeeded());
+    verify(conn).save(eq(INSTANCE_CUSTOM_LINK_TABLE), any());
+  }
+
+  @Test
+  void exceptionWhenRowCountAtLimit() {
+    var row = mock(Row.class);
+    when(row.getInteger("linkcount")).thenReturn(10);
+
+    var rowIter = mock(RowIterator.class);
+    var listIter = List.of(row).iterator();
+    when(rowIter.hasNext()).thenAnswer(invocation -> listIter.hasNext());
+    when(rowIter.next()).thenAnswer(invocation -> listIter.next());
+    var rowSet = mock(RowSet.class);
+    when(rowSet.iterator()).thenReturn(rowIter);
+
+    var conn = mock(Conn.class);
+    when(conn.execute(String.format("LOCK TABLE %s IN EXCLUSIVE MODE", INSTANCE_CUSTOM_LINK_TABLE)))
+      .thenReturn(Future.succeededFuture(mock(RowSet.class)));
+    when(conn.execute(String.format("SELECT COUNT(*) AS linkcount FROM %s", INSTANCE_CUSTOM_LINK_TABLE)))
+      .thenReturn(Future.succeededFuture(rowSet));
+    when(conn.save(eq(INSTANCE_CUSTOM_LINK_TABLE), any()))
+      .thenReturn(Future.succeededFuture("aaaa-bbbb"));
+
+    var context = Vertx.vertx().getOrCreateContext();
+    var headers = Map.of("X-Okapi-Tenant", "diku");
+    var repository = new InstanceCustomLinkRepository(context, headers);
+    var entity = mock(InstanceCustomLink.class);
+    Future<String> result = repository.create(conn, entity);
+
+    assertTrue(result.failed());
+    assertInstanceOf(ValidationException.class, result.cause());
+    verify(conn, never()).save(any(), any());
+  }
+}

--- a/mod-inventory-storage-server/src/test/java/org/folio/persist/InstanceCustomLinkRepositoryTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/persist/InstanceCustomLinkRepositoryTest.java
@@ -4,7 +4,9 @@ import static org.folio.services.instance.InstanceCustomLinkService.INSTANCE_CUS
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -15,38 +17,43 @@ import io.vertx.core.Vertx;
 import io.vertx.sqlclient.Row;
 import io.vertx.sqlclient.RowIterator;
 import io.vertx.sqlclient.RowSet;
+import io.vertx.sqlclient.Tuple;
 import java.util.List;
 import java.util.Map;
 import org.folio.rest.exceptions.ValidationException;
 import org.folio.rest.jaxrs.model.InstanceCustomLink;
 import org.folio.rest.persist.Conn;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 class InstanceCustomLinkRepositoryTest {
-  @Test
-  void createEntityWhenRowCountBelowLimit() {
-    var row = mock(Row.class);
-    when(row.getInteger("linkcount")).thenReturn(9);
+  private static String MOCK_ID = "aaaa-bbbb";
 
-    var rowIter = mock(RowIterator.class);
-    var listIter = List.of(row).iterator();
-    when(rowIter.hasNext()).thenAnswer(invocation -> listIter.hasNext());
-    when(rowIter.next()).thenAnswer(invocation -> listIter.next());
-    var rowSet = mock(RowSet.class);
-    when(rowSet.iterator()).thenReturn(rowIter);
+  Conn conn;
 
-    var conn = mock(Conn.class);
-    when(conn.execute(String.format("LOCK TABLE %s IN EXCLUSIVE MODE", INSTANCE_CUSTOM_LINK_TABLE)))
-      .thenReturn(Future.succeededFuture(mock(RowSet.class)));
-    when(conn.execute(String.format("SELECT COUNT(*) AS linkcount FROM %s", INSTANCE_CUSTOM_LINK_TABLE)))
-      .thenReturn(Future.succeededFuture(rowSet));
-    when(conn.save(eq(INSTANCE_CUSTOM_LINK_TABLE), any()))
-      .thenReturn(Future.succeededFuture("aaaa-bbbb"));
+  InstanceCustomLink entity;
 
+  InstanceCustomLinkRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    conn = mock(Conn.class);
+    entity = mock(InstanceCustomLink.class);
     var context = Vertx.vertx().getOrCreateContext();
     var headers = Map.of("X-Okapi-Tenant", "diku");
-    var repository = new InstanceCustomLinkRepository(context, headers);
-    var entity = mock(InstanceCustomLink.class);
+    repository = new InstanceCustomLinkRepository(context, headers);
+    lenient().when(conn.execute(argThat(sql -> sql.startsWith("LOCK TABLE"))))
+      .thenReturn(Future.succeededFuture(mock(RowSet.class)));
+    lenient().when(conn.save(eq(INSTANCE_CUSTOM_LINK_TABLE), any()))
+      .thenReturn(Future.succeededFuture(MOCK_ID));
+    lenient().when(conn.update(eq(INSTANCE_CUSTOM_LINK_TABLE), any(), eq(MOCK_ID)))
+      .thenReturn(Future.succeededFuture(mock(RowSet.class)));
+  }
+
+  @Test
+  void createEntityWhenRowCountBelowLimit() {
+    setupQueryReturn(9, 0, 0, 0);
+
     Future<String> result = repository.create(conn, entity);
 
     assertTrue(result.succeeded());
@@ -55,8 +62,41 @@ class InstanceCustomLinkRepositoryTest {
 
   @Test
   void exceptionWhenRowCountAtLimit() {
+    setupQueryReturn(10, 0, 0, 0);
+
+    Future<String> result = repository.create(conn, entity);
+
+    assertTrue(result.failed());
+    assertInstanceOf(ValidationException.class, result.cause());
+    verify(conn, never()).save(any(), any());
+  }
+
+  @Test
+  void updateEntityWhenRowCountBelowLimit() {
+    setupQueryReturn(9, 0, 0, 0);
+
+    Future<String> result = repository.modify(conn, MOCK_ID, entity);
+
+    assertTrue(result.succeeded());
+    verify(conn).update(eq(INSTANCE_CUSTOM_LINK_TABLE), any(), any());
+  }
+
+  @Test
+  void updateEntityWhenRowCountAtLimit() {
+    setupQueryReturn(10, 0, 0, 0);
+
+    Future<String> result = repository.modify(conn, MOCK_ID, entity);
+
+    assertTrue(result.succeeded());
+    verify(conn).update(eq(INSTANCE_CUSTOM_LINK_TABLE), any(), any());
+  }
+
+  private void setupQueryReturn(int totalCount, int nameCount, int linkTextCount, int baseUrlCount) {
     var row = mock(Row.class);
-    when(row.getInteger("linkcount")).thenReturn(10);
+    when(row.getInteger("total_count")).thenReturn(totalCount);
+    when(row.getInteger("name_count")).thenReturn(nameCount);
+    when(row.getInteger("linktext_count")).thenReturn(linkTextCount);
+    when(row.getInteger("baseurl_count")).thenReturn(baseUrlCount);
 
     var rowIter = mock(RowIterator.class);
     var listIter = List.of(row).iterator();
@@ -65,22 +105,7 @@ class InstanceCustomLinkRepositoryTest {
     var rowSet = mock(RowSet.class);
     when(rowSet.iterator()).thenReturn(rowIter);
 
-    var conn = mock(Conn.class);
-    when(conn.execute(String.format("LOCK TABLE %s IN EXCLUSIVE MODE", INSTANCE_CUSTOM_LINK_TABLE)))
-      .thenReturn(Future.succeededFuture(mock(RowSet.class)));
-    when(conn.execute(String.format("SELECT COUNT(*) AS linkcount FROM %s", INSTANCE_CUSTOM_LINK_TABLE)))
+    when(conn.execute(argThat(sql -> sql.contains("COUNT(*)")), any(Tuple.class)))
       .thenReturn(Future.succeededFuture(rowSet));
-    when(conn.save(eq(INSTANCE_CUSTOM_LINK_TABLE), any()))
-      .thenReturn(Future.succeededFuture("aaaa-bbbb"));
-
-    var context = Vertx.vertx().getOrCreateContext();
-    var headers = Map.of("X-Okapi-Tenant", "diku");
-    var repository = new InstanceCustomLinkRepository(context, headers);
-    var entity = mock(InstanceCustomLink.class);
-    Future<String> result = repository.create(conn, entity);
-
-    assertTrue(result.failed());
-    assertInstanceOf(ValidationException.class, result.cause());
-    verify(conn, never()).save(any(), any());
   }
 }

--- a/mod-inventory-storage-server/src/test/java/org/folio/persist/InstanceCustomLinkRepositoryTest.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/persist/InstanceCustomLinkRepositoryTest.java
@@ -36,6 +36,7 @@ class InstanceCustomLinkRepositoryTest {
   InstanceCustomLinkRepository repository;
 
   @BeforeEach
+  @SuppressWarnings("unchecked")
   void setUp() {
     conn = mock(Conn.class);
     entity = mock(InstanceCustomLink.class);
@@ -91,12 +92,13 @@ class InstanceCustomLinkRepositoryTest {
     verify(conn).update(eq(INSTANCE_CUSTOM_LINK_TABLE), any(), any());
   }
 
-  private void setupQueryReturn(int totalCount, int nameCount, int linkTextCount, int baseUrlCount) {
+  @SuppressWarnings("unchecked")
+  private void setupQueryReturn(int totalCount, int nameCount, int linkTextCount, int linkCount) {
     var row = mock(Row.class);
     when(row.getInteger("total_count")).thenReturn(totalCount);
     when(row.getInteger("name_count")).thenReturn(nameCount);
     when(row.getInteger("linktext_count")).thenReturn(linkTextCount);
-    when(row.getInteger("baseurl_count")).thenReturn(baseUrlCount);
+    when(row.getInteger("link_count")).thenReturn(linkCount);
 
     var rowIter = mock(RowIterator.class);
     var listIter = List.of(row).iterator();

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/impl/InstanceCustomLinkIT.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/impl/InstanceCustomLinkIT.java
@@ -4,10 +4,14 @@ import static org.folio.HttpStatus.HTTP_CREATED;
 import static org.folio.HttpStatus.HTTP_NO_CONTENT;
 import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
 import static org.folio.services.instance.InstanceCustomLinkService.INSTANCE_CUSTOM_LINK_TABLE;
+import static org.folio.utility.RestUtility.TENANT_ID;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxExtension;
 import io.vertx.junit5.VertxTestContext;
 import java.util.List;
 import java.util.function.Function;
@@ -16,11 +20,16 @@ import java.util.stream.Stream;
 import org.folio.rest.jaxrs.model.InstanceCustomLink;
 import org.folio.rest.jaxrs.model.InstanceCustomLinks;
 import org.folio.rest.jaxrs.model.Metadata;
+import org.folio.rest.persist.PostgresClient;
+import org.folio.rest.persist.cql.CQLWrapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+@ExtendWith(VertxExtension.class)
 class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCustomLink, InstanceCustomLinks> {
 
   @Override
@@ -92,6 +101,11 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
     );
   }
   
+  @BeforeEach
+  void beforeEach(Vertx vertx, VertxTestContext ctx) {
+    deleteAllInstanceCustomLinkData(vertx, ctx);
+  }
+
   @Test
   void createWithValidQueryString(Vertx vertx, VertxTestContext ctx) {
     var client = vertx.createHttpClient();
@@ -157,13 +171,17 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
 
   @ParameterizedTest
   @MethodSource("duplicateFieldValueCreates")
-  void cannotReuseDuplicateFieldValueOnCreate(JsonObject first, JsonObject second, Vertx vertx, VertxTestContext ctx) {
+  void cannotReuseDuplicateFieldValueOnCreate(JsonObject first, JsonObject second, String duplicatedField,
+      Vertx vertx, VertxTestContext ctx) {
     var client = vertx.createHttpClient();
     doPost(client, resourceUrl(), first)
       .onComplete(ctx.succeeding(response1 ->
         doPost(client, resourceUrl(), second)
           .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
-          .onComplete(ctx.succeeding(response2 -> ctx.completeNow()))
+          .onComplete(event -> ctx.verify(() -> {
+            assertDuplicateError(event.result(), duplicatedField);
+            ctx.completeNow();
+          }))
       ));
   }
 
@@ -243,7 +261,7 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
   @ParameterizedTest
   @MethodSource("duplicateFieldValueUpdates")
   void cannotReuseDuplicateFieldValueOnUpdate(JsonObject first, JsonObject second, JsonObject update,
-      Vertx vertx, VertxTestContext ctx) {
+      String duplicatedField, Vertx vertx, VertxTestContext ctx) {
     var client = vertx.createHttpClient();
     doPost(client, resourceUrl(), first)
       .onComplete(ctx.succeeding(response1 ->
@@ -253,9 +271,32 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
             update.put("id", id2);
             doPut(client, resourceUrlById(id2), update)
               .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
-              .onComplete(ctx.succeeding(response3 -> ctx.completeNow()));
+              .onComplete(event -> ctx.verify(() -> {
+                assertDuplicateError(event.result(), duplicatedField);
+                ctx.completeNow();
+              }));
           }))
       ));
+  }
+
+  private void assertDuplicateError(TestResponse response, String fieldName) {
+    var errors = response.jsonBody().getJsonArray("errors");
+    assertThat(errors.size(), is(1));
+
+    var error = errors.getJsonObject(0);
+    var errorParameters = error.getJsonArray("parameters");
+    assertThat(errorParameters.size(), is(1));
+
+    var parameter = errorParameters.getJsonObject(0);
+    assertThat(parameter.getString("key"), is(fieldName));
+  }
+
+  private static void deleteAllInstanceCustomLinkData(Vertx vertx, VertxTestContext ctx) {
+    var postgresClient = PostgresClient.getInstance(vertx, TENANT_ID);
+
+    postgresClient.delete(INSTANCE_CUSTOM_LINK_TABLE, (CQLWrapper) null)
+      .onFailure(ctx::failNow)
+      .onComplete(event -> ctx.completeNow());
   }
 
   @SuppressWarnings("checkstyle:MethodLength")
@@ -271,7 +312,8 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
           .put("name", "duplicate name")
           .put("baseUrl", "https://base2.host")
           .put("linkText", "link text 2")
-          .put("source", "local")
+          .put("source", "local"),
+        "name"
       ),
       arguments(
         new JsonObject()
@@ -283,7 +325,8 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
           .put("name", "name 2")
           .put("baseUrl", "https://base2.host")
           .put("linkText", "duplicate text")
-          .put("source", "local")
+          .put("source", "local"),
+        "linkText"
       ),
       arguments(
         new JsonObject()
@@ -295,7 +338,8 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
           .put("name", "name 2")
           .put("baseUrl", "https://duplicate")
           .put("linkText", "link text 2")
-          .put("source", "local")
+          .put("source", "local"),
+        "baseUrl"
       )
     );
   }
@@ -318,7 +362,8 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
           .put("name", "duplicate name")
           .put("baseUrl", "https://base2.host")
           .put("linkText", "link text 2")
-          .put("source", "local")
+          .put("source", "local"),
+        "name"
       ),
       arguments(
         new JsonObject()
@@ -335,7 +380,8 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
           .put("name", "name 2")
           .put("baseUrl", "https://base2.host")
           .put("linkText", "duplicate text")
-          .put("source", "local")
+          .put("source", "local"),
+        "linkText"
       ),
       arguments(
         new JsonObject()
@@ -352,7 +398,8 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
           .put("name", "name 2")
           .put("baseUrl", "https://duplicate")
           .put("linkText", "link text 2")
-          .put("source", "local")
+          .put("source", "local"),
+        "baseUrl"
       )
     );
   }

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/impl/InstanceCustomLinkIT.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/impl/InstanceCustomLinkIT.java
@@ -1,0 +1,384 @@
+package org.folio.rest.impl;
+
+import static org.folio.HttpStatus.HTTP_CREATED;
+import static org.folio.HttpStatus.HTTP_NO_CONTENT;
+import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
+import static org.folio.services.instance.InstanceCustomLinkService.INSTANCE_CUSTOM_LINK_TABLE;
+
+import io.vertx.core.Vertx;
+import io.vertx.core.json.JsonObject;
+import io.vertx.junit5.VertxTestContext;
+import java.util.List;
+import java.util.function.Function;
+import java.util.function.UnaryOperator;
+import org.folio.rest.jaxrs.model.InstanceCustomLink;
+import org.folio.rest.jaxrs.model.InstanceCustomLinks;
+import org.folio.rest.jaxrs.model.Metadata;
+import org.junit.jupiter.api.Test;
+
+class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCustomLink, InstanceCustomLinks> {
+
+  @Override
+  protected String referenceTable() {
+    return INSTANCE_CUSTOM_LINK_TABLE;
+  }
+
+  @Override
+  protected String resourceUrl() {
+    return "/instance-custom-links";
+  }
+
+  @Override
+  protected Class<InstanceCustomLink> targetClass() {
+    return InstanceCustomLink.class;
+  }
+
+  @Override
+  protected Class<InstanceCustomLinks> collectionClass() {
+    return InstanceCustomLinks.class;
+  }
+
+  @Override
+  protected InstanceCustomLink sampleRecord() {
+    return new InstanceCustomLink()
+      .withName("sample")
+      .withSource(InstanceCustomLink.Source.LOCAL)
+      .withBaseUrl("http://localhost")
+      .withLinkText("Sample OPAC");
+  }
+
+  @Override
+  protected Function<InstanceCustomLinks, List<InstanceCustomLink>> collectionRecordsExtractor() {
+    return InstanceCustomLinks::getInstanceCustomLinks;
+  }
+
+  @Override
+  protected List<Function<InstanceCustomLink, Object>> recordFieldExtractors() {
+    return List.of(
+      InstanceCustomLink::getBaseUrl,
+      InstanceCustomLink::getLinkText,
+      InstanceCustomLink::getName,
+      InstanceCustomLink::getQueryString,
+      InstanceCustomLink::getShow,
+      InstanceCustomLink::getSource
+    );
+  }
+
+  @Override
+  protected Function<InstanceCustomLink, String> idExtractor() {
+    return InstanceCustomLink::getId;
+  }
+
+  @Override
+  protected Function<InstanceCustomLink, Metadata> metadataExtractor() {
+    return InstanceCustomLink::getMetadata;
+  }
+
+  @Override
+  protected UnaryOperator<InstanceCustomLink> recordModifyingFunction() {
+    return instanceCustomLink -> instanceCustomLink.withName(instanceCustomLink.getName() + "-modified");
+  }
+
+  @Override
+  protected List<String> queries() {
+    return List.of(
+      "name==sample",
+      "source==LOCAL"
+    );
+  }
+  
+  @Test
+  void createWithValidQueryString(Vertx vertx, VertxTestContext ctx) {
+    var client = vertx.createHttpClient();
+    var req = new JsonObject()
+      .put("name", "name")
+      .put("baseUrl", "https://base.host")
+      .put("linkText", "link text")
+      .put("source", "local")
+      .put("queryString", "{{UUID}}/{{HRID}}/{{indexTitle}}");
+    doPost(client, resourceUrl(), req)
+      .onComplete(verifyStatus(ctx, HTTP_CREATED))
+      .onComplete(ctx.succeeding(response -> ctx.completeNow()));
+  }
+  
+  @Test
+  void cannotCreateWithMissingTokensInQueryString(Vertx vertx, VertxTestContext ctx) {
+    var client = vertx.createHttpClient();
+    var req = new JsonObject()
+      .put("name", "name")
+      .put("baseUrl", "https://base.host")
+      .put("linkText", "link text")
+      .put("source", "local")
+      .put("queryString", "no-valid-tokens");
+    doPost(client, resourceUrl(), req)
+      .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
+      .onComplete(ctx.succeeding(response -> ctx.completeNow()));
+  }
+
+  @Test
+  void cannotCreateWithInvalidBaseUrl(Vertx vertx, VertxTestContext ctx) {
+    var client = vertx.createHttpClient();
+    var req = new JsonObject()
+      .put("name", "name")
+      .put("baseUrl", "ftp://base.host")
+      .put("linkText", "link text")
+      .put("source", "local");
+    doPost(client, resourceUrl(), req)
+      .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
+      .onComplete(ctx.succeeding(response -> ctx.completeNow()));
+  }
+
+  @Test
+  void cannotCreateBeyondLinkCountLimit(Vertx vertx, VertxTestContext ctx) {
+    var client = vertx.createHttpClient();
+    for (var i = 1; i <= 10; i++) {
+      var req = new JsonObject()
+        .put("name", "name " + i)
+        .put("baseUrl", "https://base.host/" + i)
+        .put("linkText", "link text " + i)
+        .put("source", "local");
+      doPost(client, resourceUrl(), req)
+        .onComplete(verifyStatus(ctx, HTTP_CREATED));
+    }
+    var overLimit = new JsonObject()
+      .put("name", "name 11")
+      .put("baseUrl", "https://base.host/11")
+      .put("linkText", "link text 11")
+      .put("source", "local");
+    doPost(client, resourceUrl(), overLimit)
+      .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
+      .onComplete(ctx.succeeding(response2 -> ctx.completeNow()));
+  }
+
+  @Test
+  void cannotReuseCustomLinkNameOnCreate(Vertx vertx, VertxTestContext ctx) {
+    var client = vertx.createHttpClient();
+    var req1 = new JsonObject()
+      .put("name", "repeated name")
+      .put("baseUrl", "https://base1.host")
+      .put("linkText", "link text 1")
+      .put("source", "local");
+    var req2 = new JsonObject()
+      .put("name", "repeated name")
+      .put("baseUrl", "https://base2.host")
+      .put("linkText", "link text 2")
+      .put("source", "local");
+    doPost(client, resourceUrl(), req1)
+      .onComplete(ctx.succeeding(response1 -> {
+        doPost(client, resourceUrl(), req2)
+          .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
+          .onComplete(ctx.succeeding(response2 -> ctx.completeNow()));
+      }));
+  }
+
+  @Test
+  void cannotReuseCustomLinkLinkTextOnCreate(Vertx vertx, VertxTestContext ctx) {
+    var client = vertx.createHttpClient();
+    var req1 = new JsonObject()
+      .put("name", "name 1")
+      .put("baseUrl", "https://base1.host")
+      .put("linkText", "repeated link text")
+      .put("source", "local");
+    var req2 = new JsonObject()
+      .put("name", "name 2")
+      .put("baseUrl", "https://base2.host")
+      .put("linkText", "repeated link text")
+      .put("source", "local");
+    doPost(client, resourceUrl(), req1)
+      .onComplete(ctx.succeeding(response1 -> {
+        doPost(client, resourceUrl(), req2)
+          .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
+          .onComplete(ctx.succeeding(response2 -> ctx.completeNow()));
+      }));
+  }
+
+  @Test
+  void cannotReuseCustomLinkBaseUrlOnCreate(Vertx vertx, VertxTestContext ctx) {
+    var client = vertx.createHttpClient();
+    var req1 = new JsonObject()
+      .put("name", "name 1")
+      .put("baseUrl", "https://repeated.host")
+      .put("linkText", "link text 1")
+      .put("source", "local");
+    var req2 = new JsonObject()
+      .put("name", "name 2")
+      .put("baseUrl", "https://repeated.host")
+      .put("linkText", "link text 2")
+      .put("source", "local");
+    doPost(client, resourceUrl(), req1)
+      .onComplete(ctx.succeeding(response1 -> {
+        doPost(client, resourceUrl(), req2)
+          .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
+          .onComplete(ctx.succeeding(response2 -> ctx.completeNow()));
+      }));
+  }
+
+  @Test
+  void updateWithValidQueryString(Vertx vertx, VertxTestContext ctx) {
+    var client = vertx.createHttpClient();
+    var req1 = new JsonObject()
+      .put("name", "name 1")
+      .put("baseUrl", "https://base1.host")
+      .put("linkText", "link text 1")
+      .put("source", "local")
+      .put("queryString", "/{{UUID}}");
+    var req2 = new JsonObject()
+      .put("name", "name 1")
+      .put("baseUrl", "https://base1.host")
+      .put("linkText", "link text 1")
+      .put("source", "local")
+      .put("queryString", "/{{HRID}}");
+    doPost(client, resourceUrl(), req1)
+      .onComplete(ctx.succeeding(response1 -> {
+        var id = response1.jsonBody().getString("id");
+        req2.put("id", id);
+        doPut(client, resourceUrlById(id), req2)
+          .onComplete(verifyStatus(ctx, HTTP_NO_CONTENT))
+          .onComplete(ctx.succeeding(response -> ctx.completeNow()));
+      }));
+  }
+
+  @Test
+  void cannotUpdateWithMissingTokensInQueryString(Vertx vertx, VertxTestContext ctx) {
+    var client = vertx.createHttpClient();
+    var req1 = new JsonObject()
+      .put("name", "name 1")
+      .put("baseUrl", "https://base1.host")
+      .put("linkText", "link text 1")
+      .put("source", "local")
+      .put("queryString", "/{{UUID}}");
+    var req2 = new JsonObject()
+      .put("name", "name 1")
+      .put("baseUrl", "https://base1.host")
+      .put("linkText", "link text 1")
+      .put("source", "local")
+      .put("queryString", "/{{not-a-token}}");
+    doPost(client, resourceUrl(), req1)
+      .onComplete(ctx.succeeding(response1 -> {
+        var id = response1.jsonBody().getString("id");
+        req2.put("id", id);
+        doPut(client, resourceUrlById(id), req2)
+          .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
+          .onComplete(ctx.succeeding(response3 -> ctx.completeNow()));
+      }));
+  }
+
+  @Test
+  void cannotUpdateWithInvalidBaseUrl(Vertx vertx, VertxTestContext ctx) {
+    var client = vertx.createHttpClient();
+    var req1 = new JsonObject()
+      .put("name", "name 1")
+      .put("baseUrl", "https://base1.host")
+      .put("linkText", "link text 1")
+      .put("source", "local");
+    var req2 = new JsonObject()
+      .put("name", "name 1")
+      .put("baseUrl", "uri:urn:base")
+      .put("linkText", "link text 1")
+      .put("source", "local");
+    doPost(client, resourceUrl(), req1)
+      .onComplete(ctx.succeeding(response1 -> {
+        var id = response1.jsonBody().getString("id");
+        req2.put("id", id);
+        doPut(client, resourceUrlById(id), req2)
+          .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
+          .onComplete(ctx.succeeding(response3 -> ctx.completeNow()));
+      }));
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:MethodLength")
+  void cannotReuseCustomLinkNameOnUpdate(Vertx vertx, VertxTestContext ctx) {
+    var client = vertx.createHttpClient();
+    var req1 = new JsonObject()
+      .put("name", "name 1")
+      .put("baseUrl", "https://base1.host")
+      .put("linkText", "link text 1")
+      .put("source", "local");
+    var req2 = new JsonObject()
+      .put("name", "name 2")
+      .put("baseUrl", "https://base2.host")
+      .put("linkText", "link text 2")
+      .put("source", "local");
+    var req3 = new JsonObject()
+      .put("name", "name 1")
+      .put("baseUrl", "https://base2.host")
+      .put("linkText", "link text 2")
+      .put("source", "local");
+    doPost(client, resourceUrl(), req1)
+      .onComplete(ctx.succeeding(response1 -> {
+        doPost(client, resourceUrl(), req2)
+          .onComplete(ctx.succeeding(response2 -> {
+            var id2 = response2.jsonBody().getString("id");
+            req3.put("id", id2);
+            doPut(client, resourceUrlById(id2), req3)
+              .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
+              .onComplete(ctx.succeeding(response3 -> ctx.completeNow()));
+          }));
+      }));
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:MethodLength")
+  void cannotReuseCustomLinkLinkTextOnUpdate(Vertx vertx, VertxTestContext ctx) {
+    var client = vertx.createHttpClient();
+    var req1 = new JsonObject()
+      .put("name", "name 1")
+      .put("baseUrl", "https://base1.host")
+      .put("linkText", "link text 1")
+      .put("source", "local");
+    var req2 = new JsonObject()
+      .put("name", "name 2")
+      .put("baseUrl", "https://base2.host")
+      .put("linkText", "link text 2")
+      .put("source", "local");
+    var req3 = new JsonObject()
+      .put("name", "name 2")
+      .put("baseUrl", "https://base2.host")
+      .put("linkText", "link text 1")
+      .put("source", "local");
+    doPost(client, resourceUrl(), req1)
+      .onComplete(ctx.succeeding(response1 -> {
+        doPost(client, resourceUrl(), req2)
+          .onComplete(ctx.succeeding(response2 -> {
+            var id2 = response2.jsonBody().getString("id");
+            req3.put("id", id2);
+            doPut(client, resourceUrlById(id2), req3)
+              .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
+              .onComplete(ctx.succeeding(response3 -> ctx.completeNow()));
+          }));
+      }));
+  }
+
+  @Test
+  @SuppressWarnings("checkstyle:MethodLength")
+  void cannotReuseCustomLinkBaseUrlOnUpdate(Vertx vertx, VertxTestContext ctx) {
+    var client = vertx.createHttpClient();
+    var req1 = new JsonObject()
+      .put("name", "name 1")
+      .put("baseUrl", "https://base1.host")
+      .put("linkText", "link text 1")
+      .put("source", "local");
+    var req2 = new JsonObject()
+      .put("name", "name 2")
+      .put("baseUrl", "https://base2.host")
+      .put("linkText", "link text 2")
+      .put("source", "local");
+    var req3 = new JsonObject()
+      .put("name", "name 2")
+      .put("baseUrl", "https://base1.host")
+      .put("linkText", "link text 2")
+      .put("source", "local");
+    doPost(client, resourceUrl(), req1)
+      .onComplete(ctx.succeeding(response1 -> {
+        doPost(client, resourceUrl(), req2)
+          .onComplete(ctx.succeeding(response2 -> {
+            var id2 = response2.jsonBody().getString("id");
+            req3.put("id", id2);
+            doPut(client, resourceUrlById(id2), req3)
+              .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
+              .onComplete(ctx.succeeding(response3 -> ctx.completeNow()));
+          }));
+      }));
+  }
+}

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/impl/InstanceCustomLinkIT.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/impl/InstanceCustomLinkIT.java
@@ -57,8 +57,8 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
     return new InstanceCustomLink()
       .withName("sample")
       .withSource(InstanceCustomLink.Source.LOCAL)
-      .withBaseUrl("http://localhost")
-      .withLinkText("Sample OPAC");
+      .withLinkText("Sample OPAC")
+      .withLink("http://localhost");
   }
 
   @Override
@@ -69,10 +69,9 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
   @Override
   protected List<Function<InstanceCustomLink, Object>> recordFieldExtractors() {
     return List.of(
-      InstanceCustomLink::getBaseUrl,
+      InstanceCustomLink::getLink,
       InstanceCustomLink::getLinkText,
       InstanceCustomLink::getName,
-      InstanceCustomLink::getQueryString,
       InstanceCustomLink::getShow,
       InstanceCustomLink::getSource
     );
@@ -107,40 +106,51 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
   }
 
   @Test
-  void createWithValidQueryString(Vertx vertx, VertxTestContext ctx) {
+  void createWithValidLinkWithTokens(Vertx vertx, VertxTestContext ctx) {
     var client = vertx.createHttpClient();
     var req = new JsonObject()
       .put("name", "name")
-      .put("baseUrl", "https://base.host")
       .put("linkText", "link text")
-      .put("source", "local")
-      .put("queryString", "{{UUID}}/{{HRID}}/{{indexTitle}}");
+      .put("link", "https://base.host/{{UUID}}/{{HRID}}/{{indexTitle}}")
+      .put("source", "local");
     doPost(client, resourceUrl(), req)
       .onComplete(verifyStatus(ctx, HTTP_CREATED))
       .onComplete(ctx.succeeding(response -> ctx.completeNow()));
   }
-  
+
   @Test
-  void cannotCreateWithMissingTokensInQueryString(Vertx vertx, VertxTestContext ctx) {
+  void createWithValidLinkWithoutTokens(Vertx vertx, VertxTestContext ctx) {
     var client = vertx.createHttpClient();
     var req = new JsonObject()
       .put("name", "name")
-      .put("baseUrl", "https://base.host")
       .put("linkText", "link text")
-      .put("source", "local")
-      .put("queryString", "no-valid-tokens");
+      .put("link", "https://base.host/just-a-link")
+      .put("source", "local");
+    doPost(client, resourceUrl(), req)
+      .onComplete(verifyStatus(ctx, HTTP_CREATED))
+      .onComplete(ctx.succeeding(response -> ctx.completeNow()));
+  }
+
+  @Test
+  void cannotCreateWithInvalidTokensInLink(Vertx vertx, VertxTestContext ctx) {
+    var client = vertx.createHttpClient();
+    var req = new JsonObject()
+      .put("name", "name")
+      .put("linkText", "link text")
+      .put("link", "https://base.host/{{token-but-invalid}}")
+      .put("source", "local");
     doPost(client, resourceUrl(), req)
       .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
       .onComplete(ctx.succeeding(response -> ctx.completeNow()));
   }
 
   @Test
-  void cannotCreateWithInvalidBaseUrl(Vertx vertx, VertxTestContext ctx) {
+  void cannotCreateWithInvalidLinkProtocol(Vertx vertx, VertxTestContext ctx) {
     var client = vertx.createHttpClient();
     var req = new JsonObject()
       .put("name", "name")
-      .put("baseUrl", "ftp://base.host")
       .put("linkText", "link text")
+      .put("link", "ftp://base.host")
       .put("source", "local");
     doPost(client, resourceUrl(), req)
       .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
@@ -153,16 +163,16 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
     for (var i = 1; i <= 10; i++) {
       var req = new JsonObject()
         .put("name", "name " + i)
-        .put("baseUrl", "https://base.host/" + i)
         .put("linkText", "link text " + i)
+        .put("link", "https://base.host/" + i)
         .put("source", "local");
       doPost(client, resourceUrl(), req)
         .onComplete(verifyStatus(ctx, HTTP_CREATED));
     }
     var overLimit = new JsonObject()
       .put("name", "name 11")
-      .put("baseUrl", "https://base.host/11")
       .put("linkText", "link text 11")
+      .put("link", "https://base.host/11")
       .put("source", "local");
     doPost(client, resourceUrl(), overLimit)
       .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
@@ -186,20 +196,18 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
   }
 
   @Test
-  void updateWithValidQueryString(Vertx vertx, VertxTestContext ctx) {
+  void updateWithValidLink(Vertx vertx, VertxTestContext ctx) {
     var client = vertx.createHttpClient();
     var req1 = new JsonObject()
       .put("name", "name 1")
-      .put("baseUrl", "https://base1.host")
       .put("linkText", "link text 1")
-      .put("source", "local")
-      .put("queryString", "/{{UUID}}");
+      .put("link", "https://base1.host/{{UUID}}")
+      .put("source", "local");
     var req2 = new JsonObject()
       .put("name", "name 1")
-      .put("baseUrl", "https://base1.host")
       .put("linkText", "link text 1")
-      .put("source", "local")
-      .put("queryString", "/{{HRID}}");
+      .put("link", "https://base1.host/{{HRID}}")
+      .put("source", "local");
     doPost(client, resourceUrl(), req1)
       .onComplete(ctx.succeeding(response1 -> {
         var id = response1.jsonBody().getString("id");
@@ -211,20 +219,18 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
   }
 
   @Test
-  void cannotUpdateWithMissingTokensInQueryString(Vertx vertx, VertxTestContext ctx) {
+  void cannotUpdateWithMissingTokensInLink(Vertx vertx, VertxTestContext ctx) {
     var client = vertx.createHttpClient();
     var req1 = new JsonObject()
       .put("name", "name 1")
-      .put("baseUrl", "https://base1.host")
       .put("linkText", "link text 1")
-      .put("source", "local")
-      .put("queryString", "/{{UUID}}");
+      .put("link", "https://base1.host/{{UUID}}")
+      .put("source", "local");
     var req2 = new JsonObject()
       .put("name", "name 1")
-      .put("baseUrl", "https://base1.host")
       .put("linkText", "link text 1")
-      .put("source", "local")
-      .put("queryString", "/{{not-a-token}}");
+      .put("link", "https://base1.host/{{not-a-token}}")
+      .put("source", "local");
     doPost(client, resourceUrl(), req1)
       .onComplete(ctx.succeeding(response1 -> {
         var id = response1.jsonBody().getString("id");
@@ -236,17 +242,17 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
   }
 
   @Test
-  void cannotUpdateWithInvalidBaseUrl(Vertx vertx, VertxTestContext ctx) {
+  void cannotUpdateWithInvalidLink(Vertx vertx, VertxTestContext ctx) {
     var client = vertx.createHttpClient();
     var req1 = new JsonObject()
       .put("name", "name 1")
-      .put("baseUrl", "https://base1.host")
       .put("linkText", "link text 1")
+      .put("link", "https://base1.host")
       .put("source", "local");
     var req2 = new JsonObject()
       .put("name", "name 1")
-      .put("baseUrl", "uri:urn:base")
       .put("linkText", "link text 1")
+      .put("link", "uri:urn:base")
       .put("source", "local");
     doPost(client, resourceUrl(), req1)
       .onComplete(ctx.succeeding(response1 -> {
@@ -305,41 +311,41 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
       arguments(
         new JsonObject()
           .put("name", "duplicate name")
-          .put("baseUrl", "https://base1.host")
           .put("linkText", "link text 1")
+          .put("link", "https://base1.host")
           .put("source", "local"),
         new JsonObject()
           .put("name", "duplicate name")
-          .put("baseUrl", "https://base2.host")
           .put("linkText", "link text 2")
+          .put("link", "https://base2.host")
           .put("source", "local"),
         "name"
       ),
       arguments(
         new JsonObject()
           .put("name", "name 1")
-          .put("baseUrl", "https://base1.host")
           .put("linkText", "duplicate text")
+          .put("link", "https://base1.host")
           .put("source", "local"),
         new JsonObject()
           .put("name", "name 2")
-          .put("baseUrl", "https://base2.host")
           .put("linkText", "duplicate text")
+          .put("link", "https://base2.host")
           .put("source", "local"),
         "linkText"
       ),
       arguments(
         new JsonObject()
           .put("name", "name 1")
-          .put("baseUrl", "https://duplicate")
           .put("linkText", "link text 1")
+          .put("link", "https://duplicate")
           .put("source", "local"),
         new JsonObject()
           .put("name", "name 2")
-          .put("baseUrl", "https://duplicate")
           .put("linkText", "link text 2")
+          .put("link", "https://duplicate")
           .put("source", "local"),
-        "baseUrl"
+        "link"
       )
     );
   }
@@ -350,56 +356,56 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
       arguments(
         new JsonObject()
           .put("name", "duplicate name")
-          .put("baseUrl", "https://base1.host")
           .put("linkText", "link text 1")
+          .put("link", "https://base1.host")
           .put("source", "local"),
         new JsonObject()
           .put("name", "name 2")
-          .put("baseUrl", "https://base2.host")
           .put("linkText", "link text 2")
+          .put("link", "https://base2.host")
           .put("source", "local"),
         new JsonObject()
           .put("name", "duplicate name")
-          .put("baseUrl", "https://base2.host")
           .put("linkText", "link text 2")
+          .put("link", "https://base2.host")
           .put("source", "local"),
         "name"
       ),
       arguments(
         new JsonObject()
           .put("name", "name 1")
-          .put("baseUrl", "https://base1.host")
           .put("linkText", "duplicate text")
+          .put("link", "https://base1.host")
           .put("source", "local"),
         new JsonObject()
           .put("name", "name 2")
-          .put("baseUrl", "https://base2.host")
           .put("linkText", "link text 2")
+          .put("link", "https://base2.host")
           .put("source", "local"),
         new JsonObject()
           .put("name", "name 2")
-          .put("baseUrl", "https://base2.host")
           .put("linkText", "duplicate text")
+          .put("link", "https://base2.host")
           .put("source", "local"),
         "linkText"
       ),
       arguments(
         new JsonObject()
           .put("name", "name 1")
-          .put("baseUrl", "https://duplicate")
           .put("linkText", "link text 1")
+          .put("link", "https://duplicate")
           .put("source", "local"),
         new JsonObject()
           .put("name", "name 2")
-          .put("baseUrl", "https://base2.host")
           .put("linkText", "link text 2")
+          .put("link", "https://base2.host")
           .put("source", "local"),
         new JsonObject()
           .put("name", "name 2")
-          .put("baseUrl", "https://duplicate")
           .put("linkText", "link text 2")
+          .put("link", "https://duplicate")
           .put("source", "local"),
-        "baseUrl"
+        "link"
       )
     );
   }

--- a/mod-inventory-storage-server/src/test/java/org/folio/rest/impl/InstanceCustomLinkIT.java
+++ b/mod-inventory-storage-server/src/test/java/org/folio/rest/impl/InstanceCustomLinkIT.java
@@ -4,6 +4,7 @@ import static org.folio.HttpStatus.HTTP_CREATED;
 import static org.folio.HttpStatus.HTTP_NO_CONTENT;
 import static org.folio.HttpStatus.HTTP_UNPROCESSABLE_ENTITY;
 import static org.folio.services.instance.InstanceCustomLinkService.INSTANCE_CUSTOM_LINK_TABLE;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
 import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonObject;
@@ -11,10 +12,14 @@ import io.vertx.junit5.VertxTestContext;
 import java.util.List;
 import java.util.function.Function;
 import java.util.function.UnaryOperator;
+import java.util.stream.Stream;
 import org.folio.rest.jaxrs.model.InstanceCustomLink;
 import org.folio.rest.jaxrs.model.InstanceCustomLinks;
 import org.folio.rest.jaxrs.model.Metadata;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCustomLink, InstanceCustomLinks> {
 
@@ -150,67 +155,16 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
       .onComplete(ctx.succeeding(response2 -> ctx.completeNow()));
   }
 
-  @Test
-  void cannotReuseCustomLinkNameOnCreate(Vertx vertx, VertxTestContext ctx) {
+  @ParameterizedTest
+  @MethodSource("duplicateFieldValueCreates")
+  void cannotReuseDuplicateFieldValueOnCreate(JsonObject first, JsonObject second, Vertx vertx, VertxTestContext ctx) {
     var client = vertx.createHttpClient();
-    var req1 = new JsonObject()
-      .put("name", "repeated name")
-      .put("baseUrl", "https://base1.host")
-      .put("linkText", "link text 1")
-      .put("source", "local");
-    var req2 = new JsonObject()
-      .put("name", "repeated name")
-      .put("baseUrl", "https://base2.host")
-      .put("linkText", "link text 2")
-      .put("source", "local");
-    doPost(client, resourceUrl(), req1)
-      .onComplete(ctx.succeeding(response1 -> {
-        doPost(client, resourceUrl(), req2)
+    doPost(client, resourceUrl(), first)
+      .onComplete(ctx.succeeding(response1 ->
+        doPost(client, resourceUrl(), second)
           .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
-          .onComplete(ctx.succeeding(response2 -> ctx.completeNow()));
-      }));
-  }
-
-  @Test
-  void cannotReuseCustomLinkLinkTextOnCreate(Vertx vertx, VertxTestContext ctx) {
-    var client = vertx.createHttpClient();
-    var req1 = new JsonObject()
-      .put("name", "name 1")
-      .put("baseUrl", "https://base1.host")
-      .put("linkText", "repeated link text")
-      .put("source", "local");
-    var req2 = new JsonObject()
-      .put("name", "name 2")
-      .put("baseUrl", "https://base2.host")
-      .put("linkText", "repeated link text")
-      .put("source", "local");
-    doPost(client, resourceUrl(), req1)
-      .onComplete(ctx.succeeding(response1 -> {
-        doPost(client, resourceUrl(), req2)
-          .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
-          .onComplete(ctx.succeeding(response2 -> ctx.completeNow()));
-      }));
-  }
-
-  @Test
-  void cannotReuseCustomLinkBaseUrlOnCreate(Vertx vertx, VertxTestContext ctx) {
-    var client = vertx.createHttpClient();
-    var req1 = new JsonObject()
-      .put("name", "name 1")
-      .put("baseUrl", "https://repeated.host")
-      .put("linkText", "link text 1")
-      .put("source", "local");
-    var req2 = new JsonObject()
-      .put("name", "name 2")
-      .put("baseUrl", "https://repeated.host")
-      .put("linkText", "link text 2")
-      .put("source", "local");
-    doPost(client, resourceUrl(), req1)
-      .onComplete(ctx.succeeding(response1 -> {
-        doPost(client, resourceUrl(), req2)
-          .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
-          .onComplete(ctx.succeeding(response2 -> ctx.completeNow()));
-      }));
+          .onComplete(ctx.succeeding(response2 -> ctx.completeNow()))
+      ));
   }
 
   @Test
@@ -286,99 +240,120 @@ class InstanceCustomLinkIT extends BaseReferenceDataIntegrationTest<InstanceCust
       }));
   }
 
-  @Test
-  @SuppressWarnings("checkstyle:MethodLength")
-  void cannotReuseCustomLinkNameOnUpdate(Vertx vertx, VertxTestContext ctx) {
+  @ParameterizedTest
+  @MethodSource("duplicateFieldValueUpdates")
+  void cannotReuseDuplicateFieldValueOnUpdate(JsonObject first, JsonObject second, JsonObject update,
+      Vertx vertx, VertxTestContext ctx) {
     var client = vertx.createHttpClient();
-    var req1 = new JsonObject()
-      .put("name", "name 1")
-      .put("baseUrl", "https://base1.host")
-      .put("linkText", "link text 1")
-      .put("source", "local");
-    var req2 = new JsonObject()
-      .put("name", "name 2")
-      .put("baseUrl", "https://base2.host")
-      .put("linkText", "link text 2")
-      .put("source", "local");
-    var req3 = new JsonObject()
-      .put("name", "name 1")
-      .put("baseUrl", "https://base2.host")
-      .put("linkText", "link text 2")
-      .put("source", "local");
-    doPost(client, resourceUrl(), req1)
-      .onComplete(ctx.succeeding(response1 -> {
-        doPost(client, resourceUrl(), req2)
+    doPost(client, resourceUrl(), first)
+      .onComplete(ctx.succeeding(response1 ->
+        doPost(client, resourceUrl(), second)
           .onComplete(ctx.succeeding(response2 -> {
             var id2 = response2.jsonBody().getString("id");
-            req3.put("id", id2);
-            doPut(client, resourceUrlById(id2), req3)
+            update.put("id", id2);
+            doPut(client, resourceUrlById(id2), update)
               .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
               .onComplete(ctx.succeeding(response3 -> ctx.completeNow()));
-          }));
-      }));
+          }))
+      ));
   }
 
-  @Test
   @SuppressWarnings("checkstyle:MethodLength")
-  void cannotReuseCustomLinkLinkTextOnUpdate(Vertx vertx, VertxTestContext ctx) {
-    var client = vertx.createHttpClient();
-    var req1 = new JsonObject()
-      .put("name", "name 1")
-      .put("baseUrl", "https://base1.host")
-      .put("linkText", "link text 1")
-      .put("source", "local");
-    var req2 = new JsonObject()
-      .put("name", "name 2")
-      .put("baseUrl", "https://base2.host")
-      .put("linkText", "link text 2")
-      .put("source", "local");
-    var req3 = new JsonObject()
-      .put("name", "name 2")
-      .put("baseUrl", "https://base2.host")
-      .put("linkText", "link text 1")
-      .put("source", "local");
-    doPost(client, resourceUrl(), req1)
-      .onComplete(ctx.succeeding(response1 -> {
-        doPost(client, resourceUrl(), req2)
-          .onComplete(ctx.succeeding(response2 -> {
-            var id2 = response2.jsonBody().getString("id");
-            req3.put("id", id2);
-            doPut(client, resourceUrlById(id2), req3)
-              .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
-              .onComplete(ctx.succeeding(response3 -> ctx.completeNow()));
-          }));
-      }));
+  private static Stream<Arguments> duplicateFieldValueCreates() {
+    return Stream.of(
+      arguments(
+        new JsonObject()
+          .put("name", "duplicate name")
+          .put("baseUrl", "https://base1.host")
+          .put("linkText", "link text 1")
+          .put("source", "local"),
+        new JsonObject()
+          .put("name", "duplicate name")
+          .put("baseUrl", "https://base2.host")
+          .put("linkText", "link text 2")
+          .put("source", "local")
+      ),
+      arguments(
+        new JsonObject()
+          .put("name", "name 1")
+          .put("baseUrl", "https://base1.host")
+          .put("linkText", "duplicate text")
+          .put("source", "local"),
+        new JsonObject()
+          .put("name", "name 2")
+          .put("baseUrl", "https://base2.host")
+          .put("linkText", "duplicate text")
+          .put("source", "local")
+      ),
+      arguments(
+        new JsonObject()
+          .put("name", "name 1")
+          .put("baseUrl", "https://duplicate")
+          .put("linkText", "link text 1")
+          .put("source", "local"),
+        new JsonObject()
+          .put("name", "name 2")
+          .put("baseUrl", "https://duplicate")
+          .put("linkText", "link text 2")
+          .put("source", "local")
+      )
+    );
   }
 
-  @Test
   @SuppressWarnings("checkstyle:MethodLength")
-  void cannotReuseCustomLinkBaseUrlOnUpdate(Vertx vertx, VertxTestContext ctx) {
-    var client = vertx.createHttpClient();
-    var req1 = new JsonObject()
-      .put("name", "name 1")
-      .put("baseUrl", "https://base1.host")
-      .put("linkText", "link text 1")
-      .put("source", "local");
-    var req2 = new JsonObject()
-      .put("name", "name 2")
-      .put("baseUrl", "https://base2.host")
-      .put("linkText", "link text 2")
-      .put("source", "local");
-    var req3 = new JsonObject()
-      .put("name", "name 2")
-      .put("baseUrl", "https://base1.host")
-      .put("linkText", "link text 2")
-      .put("source", "local");
-    doPost(client, resourceUrl(), req1)
-      .onComplete(ctx.succeeding(response1 -> {
-        doPost(client, resourceUrl(), req2)
-          .onComplete(ctx.succeeding(response2 -> {
-            var id2 = response2.jsonBody().getString("id");
-            req3.put("id", id2);
-            doPut(client, resourceUrlById(id2), req3)
-              .onComplete(verifyStatus(ctx, HTTP_UNPROCESSABLE_ENTITY))
-              .onComplete(ctx.succeeding(response3 -> ctx.completeNow()));
-          }));
-      }));
+  private static Stream<Arguments> duplicateFieldValueUpdates() {
+    return Stream.of(
+      arguments(
+        new JsonObject()
+          .put("name", "duplicate name")
+          .put("baseUrl", "https://base1.host")
+          .put("linkText", "link text 1")
+          .put("source", "local"),
+        new JsonObject()
+          .put("name", "name 2")
+          .put("baseUrl", "https://base2.host")
+          .put("linkText", "link text 2")
+          .put("source", "local"),
+        new JsonObject()
+          .put("name", "duplicate name")
+          .put("baseUrl", "https://base2.host")
+          .put("linkText", "link text 2")
+          .put("source", "local")
+      ),
+      arguments(
+        new JsonObject()
+          .put("name", "name 1")
+          .put("baseUrl", "https://base1.host")
+          .put("linkText", "duplicate text")
+          .put("source", "local"),
+        new JsonObject()
+          .put("name", "name 2")
+          .put("baseUrl", "https://base2.host")
+          .put("linkText", "link text 2")
+          .put("source", "local"),
+        new JsonObject()
+          .put("name", "name 2")
+          .put("baseUrl", "https://base2.host")
+          .put("linkText", "duplicate text")
+          .put("source", "local")
+      ),
+      arguments(
+        new JsonObject()
+          .put("name", "name 1")
+          .put("baseUrl", "https://duplicate")
+          .put("linkText", "link text 1")
+          .put("source", "local"),
+        new JsonObject()
+          .put("name", "name 2")
+          .put("baseUrl", "https://base2.host")
+          .put("linkText", "link text 2")
+          .put("source", "local"),
+        new JsonObject()
+          .put("name", "name 2")
+          .put("baseUrl", "https://duplicate")
+          .put("linkText", "link text 2")
+          .put("source", "local")
+      )
+    );
   }
 }

--- a/ramls/examples/instance-custom-links/instanceCustomLink.json
+++ b/ramls/examples/instance-custom-links/instanceCustomLink.json
@@ -1,0 +1,8 @@
+    {
+      "id": "a3300f00-1d30-440d-a475-a5c8fad7ba7e",
+      "name": "OPAC",
+      "linkText": "Locate",
+      "baseUrl": "https://www.locate.library.com",
+      "queryString": "/items/{UUID}.html",
+      "show": true
+    }

--- a/ramls/examples/instance-custom-links/instanceCustomLink.json
+++ b/ramls/examples/instance-custom-links/instanceCustomLink.json
@@ -2,7 +2,6 @@
       "id": "a3300f00-1d30-440d-a475-a5c8fad7ba7e",
       "name": "OPAC",
       "linkText": "Locate",
-      "baseUrl": "https://www.locate.library.com",
-      "queryString": "/items/{UUID}.html",
+      "link": "https://www.locate.library.com/items/{UUID}.html",
       "show": true
     }

--- a/ramls/examples/instance-custom-links/instanceCustomLinks.json
+++ b/ramls/examples/instance-custom-links/instanceCustomLinks.json
@@ -4,15 +4,14 @@
       "id": "a3300f00-1d30-440d-a475-a5c8fad7ba7e",
       "name": "OPAC",
       "linkText": "Locate",
-      "baseUrl": "https://www.locate.library.com",
-      "queryString": "/items/{UUID}.html",
+      "link": "https://www.locate.library.com/items/{UUID}.html",
       "show": true
     },
     {
       "id": "a63a2d8c-22a4-4bfc-9d8d-5ade3b5154fa",
       "name": "archival",
       "linkText": "Old OPAC",
-      "baseUrl": "https://old-opac.library.com",
+      "link": "https://old-opac.library.com",
       "show": false
     }
   ],

--- a/ramls/examples/instance-custom-links/instanceCustomLinks.json
+++ b/ramls/examples/instance-custom-links/instanceCustomLinks.json
@@ -1,0 +1,20 @@
+{
+  "instanceCustomLinks": [
+    {
+      "id": "a3300f00-1d30-440d-a475-a5c8fad7ba7e",
+      "name": "OPAC",
+      "linkText": "Locate",
+      "baseUrl": "https://www.locate.library.com",
+      "queryString": "/items/{UUID}.html",
+      "show": true
+    },
+    {
+      "id": "a63a2d8c-22a4-4bfc-9d8d-5ade3b5154fa",
+      "name": "archival",
+      "linkText": "Old OPAC",
+      "baseUrl": "https://old-opac.library.com",
+      "show": false
+    }
+  ],
+  "totalRecords": 2
+}

--- a/ramls/instance-custom-link.raml
+++ b/ramls/instance-custom-link.raml
@@ -1,0 +1,55 @@
+#%RAML 1.0
+title: Instance Custom Links API
+version: v1.0
+protocols: [ HTTP, HTTPS ]
+baseUri: http://localhost
+
+documentation:
+  - title: Instances Custom Links API
+    content: This documents the API calls that can be made to query and manage instance custom links
+
+types:
+  instanceCustomLink: !include schemas/instance-custom-links/instanceCustomLink.json
+  instanceCustomLinks: !include schemas/instance-custom-links/instanceCustomLinks.json
+  errors: !include raml-util/schemas/errors.schema
+
+traits:
+  pageable: !include raml-util/traits/pageable.raml
+  searchable: !include raml-util/traits/searchable.raml
+  validate: !include raml-util/traits/validation.raml
+
+resourceTypes:
+  collection: !include raml-util/rtypes/collection.raml
+  collection-item: !include raml-util/rtypes/item-collection.raml
+
+/instance-custom-links:
+  type:
+    collection:
+      exampleCollection: !include examples/instance-custom-links/instanceCustomLinks.json
+      exampleItem: !include examples/instance-custom-links/instanceCustomLink.json
+      schemaCollection: instanceCustomLinks
+      schemaItem: instanceCustomLink
+  get:
+    is: [
+      searchable: {description: "with valid searchable fields", example: "name=aaa"},
+      pageable
+    ]
+    description: Return a list of instance custom links
+  post:
+    description: Create a new instance custom link
+    is: [validate]
+  /{id}:
+    description: Pass in the instance custom link id
+    type:
+      collection-item:
+        exampleItem: !include examples/instance-custom-links/instanceCustomLink.json
+        schema: instanceCustomLink
+    put:
+        description: Update a instance custom link
+        is: [validate]
+        responses:
+          422:
+            description: "Validation error"
+            body:
+              application/json:
+                type: errors

--- a/ramls/schemas/instance-custom-links/instanceCustomLink.json
+++ b/ramls/schemas/instance-custom-links/instanceCustomLink.json
@@ -12,7 +12,7 @@
     "name": {
       "type": "string",
       "description": "Name of the instance custom link",
-      "maxLength": 1000
+      "maxLength": 150
     },
     "linkText": {
       "type": "string",
@@ -27,7 +27,7 @@
     "queryString": {
       "type": "string",
       "description": "The templated path or query string to append to the base URL when rendering the instance custom link",
-      "maxLength": 1000
+      "maxLength": 150
     },
     "show": {
       "type": "boolean",

--- a/ramls/schemas/instance-custom-links/instanceCustomLink.json
+++ b/ramls/schemas/instance-custom-links/instanceCustomLink.json
@@ -11,8 +11,7 @@
     },
     "name": {
       "type": "string",
-      "description": "Name of the instance custom link",
-      "maxLength": 99
+      "description": "Name of the instance custom link"
     },
     "linkText": {
       "type": "string",
@@ -21,13 +20,11 @@
     },
     "baseUrl": {
       "type": "string",
-      "description": "The base URL including scheme and host for rendering the instance custom link",
-      "maxLength": 99
+      "description": "The base URL including scheme and host for rendering the instance custom link"
     },
     "queryString": {
       "type": "string",
-      "description": "The templated path or query string to append to the base URL when rendering the instance custom link",
-      "maxLength": 99
+      "description": "The templated path or query string to append to the base URL when rendering the instance custom link"
     },
     "show": {
       "type": "boolean",

--- a/ramls/schemas/instance-custom-links/instanceCustomLink.json
+++ b/ramls/schemas/instance-custom-links/instanceCustomLink.json
@@ -19,15 +19,10 @@
       "description": "Text to display when rendering the instance custom link",
       "maxLength": 40
     },
-    "baseUrl": {
+    "link": {
       "type": "string",
       "description": "The base URL including scheme and host for rendering the instance custom link",
       "maxLength": 1000
-    },
-    "queryString": {
-      "type": "string",
-      "description": "The templated path or query string to append to the base URL when rendering the instance custom link",
-      "maxLength": 150
     },
     "show": {
       "type": "boolean",
@@ -50,7 +45,7 @@
   "required": [
     "name",
     "linkText",
-    "baseUrl",
+    "link",
     "source"
   ]
 }

--- a/ramls/schemas/instance-custom-links/instanceCustomLink.json
+++ b/ramls/schemas/instance-custom-links/instanceCustomLink.json
@@ -11,7 +11,8 @@
     },
     "name": {
       "type": "string",
-      "description": "Name of the instance custom link"
+      "description": "Name of the instance custom link",
+      "maxLength": 1000
     },
     "linkText": {
       "type": "string",
@@ -20,11 +21,13 @@
     },
     "baseUrl": {
       "type": "string",
-      "description": "The base URL including scheme and host for rendering the instance custom link"
+      "description": "The base URL including scheme and host for rendering the instance custom link",
+      "maxLength": 1000
     },
     "queryString": {
       "type": "string",
-      "description": "The templated path or query string to append to the base URL when rendering the instance custom link"
+      "description": "The templated path or query string to append to the base URL when rendering the instance custom link",
+      "maxLength": 1000
     },
     "show": {
       "type": "boolean",

--- a/ramls/schemas/instance-custom-links/instanceCustomLink.json
+++ b/ramls/schemas/instance-custom-links/instanceCustomLink.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "An instance custom link",
+  "javaType": "org.folio.rest.jaxrs.model.InstanceCustomLink",
+  "type": "object",
+  "properties": {
+    "id": {
+      "type": "string",
+      "description": "The unique ID of the instance custom link; UUID",
+      "$ref": "../common/uuid.json"
+    },
+    "name": {
+      "type": "string",
+      "description": "Name of the instance custom link",
+      "maxLength": 99
+    },
+    "linkText": {
+      "type": "string",
+      "description": "Text to display when rendering the instance custom link",
+      "maxLength": 40
+    },
+    "baseUrl": {
+      "type": "string",
+      "description": "The base URL including scheme and host for rendering the instance custom link",
+      "maxLength": 99
+    },
+    "queryString": {
+      "type": "string",
+      "description": "The templated path or query string to append to the base URL when rendering the instance custom link",
+      "maxLength": 99
+    },
+    "show": {
+      "type": "boolean",
+      "description": "Whether to show this instance custom link"
+    },
+    "source": {
+      "type": "string",
+      "enum": [
+        "local",
+        "consortium"
+      ],
+      "description": "The instance custom link source"
+    },
+    "metadata": {
+      "type": "object",
+      "$ref": "../../raml-util/schemas/metadata.schema",
+      "readonly": true
+    }
+  },
+  "required": [
+    "name",
+    "linkText",
+    "baseUrl",
+    "source"
+  ]
+}

--- a/ramls/schemas/instance-custom-links/instanceCustomLinks.json
+++ b/ramls/schemas/instance-custom-links/instanceCustomLinks.json
@@ -1,0 +1,25 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "description": "A collection of instance custom links",
+  "javaType": "org.folio.rest.jaxrs.model.InstanceCustomLinks",
+  "type": "object",
+  "properties": {
+    "instanceCustomLinks": {
+      "description": "List of instance custom links",
+      "id": "instanceCustomLinks",
+      "type": "array",
+      "items": {
+        "type": "object",
+        "$ref": "instanceCustomLink.json"
+      }
+    },
+    "totalRecords": {
+      "description": "Estimated or exact total number of records",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "instanceCustomLinks",
+    "totalRecords"
+  ]
+}


### PR DESCRIPTION
### Purpose

Add a custom link setting intended for use and display with instance actions.

### Approach

- Add RAML and supporting schemas for `/instance-custom-links`
- Update database schema.json
- Implement API with additional field validation beyond required and maximum field size
- Add repository with ability to limit the number of custom links per tenant to 10

### Changes Checklist
- [x] **API Changes**: Document any API paths, methods, request or response bodies changed, added, or removed.
- [x] **Database Schema Changes**: Indicate any database schema changes and their impact. Confirm that migration scripts were created.
- [ ] **Interface Version Changes**: Indicate any changes to interface versions.
- [ ] **Interface Dependencies**: Document added or removed dependencies.
- [ ] **Permissions**: Document any changes to permissions.
- [ ] **Logging**: Confirm that logging is appropriately handled.
- [x] **Unit Testing**: Confirm that changed classes were covered by unit tests.
- [x] **Integration Testing**: Confirm that changed logic was covered by integration tests.
- [x] **Manual Testing**: Confirm that changes were tested on local or dev environment.
- [x] **NEWS**: Confirm that the NEWS file is updated with relevant information about the changes made in this pull request.

### Related Issues

https://folio-org.atlassian.net/browse/MODINVSTOR-1600
